### PR TITLE
retry x times if fetchTimeSeries fails.

### DIFF
--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -49,7 +49,7 @@ function getErrorMessage(e: CombinedError) {
 }
 
 type State = {
-  // The number of times FetchMqlTimeSeriesQuery will retry if the initial query fails.
+  // The number of times FetchMqlTimeSeriesQuery will retry if the initial query fails. Defaults to 0.
   retries: number;
 
   // We endeavor to keep this ID up to date with the chart we are currently displaying or wish to render next

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -91,7 +91,7 @@ type Action =
   | { type: "postQuerySuccess"; queryId: string }
   | { type: "fetchResultsFail"; errorMessage: string }
   | { type: "fetchResultsRunning" }
-  | { type: "retryFetch" }
+  | { type: "retryFetchResults" }
   | {
       type: "fetchResultsSuccess";
       data: FetchMqlTimeSeriesQuery;
@@ -166,7 +166,7 @@ function mqlQueryReducer(state: State, action: Action): State {
       };
     }
 
-    case "retryFetch": {
+    case "retryFetchResults": {
       const now = Date.now();
       const diff = now - (state.fetchStartTime || 0);
 
@@ -295,7 +295,7 @@ export default function useMqlQuery({
   useEffect(() => {
     if (error) {
       if (retries > 0 && state.retries !== retries) {
-        dispatch({ type: "retryFetch" });
+        dispatch({ type: "retryFetchResults" });
         refetchMqlQuery();
       } else {
         dispatch({
@@ -335,7 +335,7 @@ export default function useMqlQuery({
 
     if (status === MqlQueryStatus.Failed) {
       if (retries > 0 && state.retries !== retries) {
-        dispatch({ type: "retryFetch" });
+        dispatch({ type: "retryFetchResults" });
         refetchMqlQuery();
       } else {
         const errorMessage = `This query failed for an unknown reason.\n\nQueryId: ${

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -49,6 +49,9 @@ function getErrorMessage(e: CombinedError) {
 }
 
 type State = {
+  // The number of times FetchMqlTimeSeriesQuery will retry if the initial query fails.
+  retries: number;
+
   // We endeavor to keep this ID up to date with the chart we are currently displaying or wish to render next
   queryId: string | null;
 
@@ -73,6 +76,7 @@ type State = {
 };
 
 const initialState: State = {
+  retries: 0,
   queryId: null,
   queryStatus: MqlQueryStatus.Pending,
   data: null,
@@ -87,6 +91,7 @@ type Action =
   | { type: "postQuerySuccess"; queryId: string }
   | { type: "fetchResultsFail"; errorMessage: string }
   | { type: "fetchResultsRunning" }
+  | { type: "retryFetch" }
   | {
       type: "fetchResultsSuccess";
       data: FetchMqlTimeSeriesQuery;
@@ -161,6 +166,18 @@ function mqlQueryReducer(state: State, action: Action): State {
       };
     }
 
+    case "retryFetch": {
+      const now = Date.now();
+      const diff = now - (state.fetchStartTime || 0);
+
+      return {
+        ...state,
+        isTakingForever: diff >= LONG_FETCH_QUERY_ATTEMPT_MAX,
+        errorMessage: undefined,
+        retries: state.retries + 1,
+      };
+    }
+
     case "fetchResultsFail": {
       return {
         ...state,
@@ -205,6 +222,7 @@ type UseMqlQueryParams = {
   limit?: number;
   queryInput?: CreateMqlQueryMutationVariables;
   skip?: boolean;
+  retries?: number;
 };
 
 // This custom hook consists of one useCallback and two useHooks that should asynchronously handle all scenarios for this chained
@@ -215,6 +233,7 @@ export default function useMqlQuery({
   metricName,
   limit,
   skip,
+  retries = 0,
 }: UseMqlQueryParams) {
   const {
     useQuery,
@@ -275,11 +294,17 @@ export default function useMqlQuery({
 
   useEffect(() => {
     if (error) {
-      dispatch({
-        type: "fetchResultsFail",
-        errorMessage: getErrorMessage(error),
-      });
-      handleCombinedError(error);
+      if (retries > 0 && state.retries !== retries) {
+        dispatch({ type: "retryFetch" });
+        refetchMqlQuery();
+      } else {
+        dispatch({
+          type: "fetchResultsFail",
+          errorMessage: getErrorMessage(error),
+        });
+        handleCombinedError(error);
+      }
+
       return;
     }
 
@@ -306,6 +331,30 @@ export default function useMqlQuery({
         dispatch({ type: "fetchResultsRunning" });
         refetchMqlQuery();
       }, QUERY_POLLING_MS);
+    }
+
+    if (status === MqlQueryStatus.Failed) {
+      if (retries > 0 && state.retries !== retries) {
+        dispatch({ type: "retryFetch" });
+        refetchMqlQuery();
+      } else {
+        const errorMessage = `This query failed for an unknown reason.\n\nQueryId: ${
+          data?.mqlQuery?.id
+        }\nStatus: ${data?.mqlQuery?.status}\nResult: ${JSON.stringify(
+          data?.mqlQuery?.result
+        )}`;
+
+        dispatch({
+          type: "fetchResultsFail",
+          errorMessage,
+        });
+
+        handleCombinedError({
+          name: "Unknown Error",
+          message: errorMessage,
+          graphQLErrors: [],
+        });
+      }
     }
   }, [data, error, state.cancelledQueries, limit, handleCombinedError]);
 

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -17,12 +17,3834 @@ export type Scalars = {
   DateTime: any;
   bigint: any;
   date: any;
-  entity: any;
   json: any;
   jsonb: any;
-  questionorreply: any;
   timestamptz: any;
   uuid: any;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** fetch data from the table: "annotations" using primary key columns */
+  annotation?: Maybe<Annotations>;
+  /** fetch data from the table: "annotations" */
+  annotations: Array<Annotations>;
+  /** fetch aggregated fields from the table: "annotations" */
+  annotationsAggregate: Annotations_Aggregate;
+  /** fetch data from the table: "api_keys" using primary key columns */
+  apiKey?: Maybe<Api_Keys>;
+  /** fetch data from the table: "api_keys" */
+  apiKeys: Array<Api_Keys>;
+  /** fetch aggregated fields from the table: "api_keys" */
+  apiKeysAggregate: Api_Keys_Aggregate;
+  auth0Profile?: Maybe<Auth0Profile>;
+  /** fetch data from the table: "dashboards" using primary key columns */
+  dashboard?: Maybe<Dashboards>;
+  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
+  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
+  /** fetch data from the table: "dashboard_item_configs" */
+  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
+  /** fetch aggregated fields from the table: "dashboard_item_configs" */
+  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
+  /** fetch data from the table: "dashboard_sections" using primary key columns */
+  dashboardSection?: Maybe<Dashboard_Sections>;
+  /** fetch data from the table: "dashboard_sections" */
+  dashboardSections: Array<Dashboard_Sections>;
+  /** fetch aggregated fields from the table: "dashboard_sections" */
+  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
+  /** fetch data from the table: "dashboards" */
+  dashboards: Array<Dashboards>;
+  /** fetch aggregated fields from the table: "dashboards" */
+  dashboardsAggregate: Dashboards_Aggregate;
+  /** fetch data from the table: "org_data_sources" using primary key columns */
+  dataSource?: Maybe<Org_Data_Sources>;
+  /** fetch data from the table: "data_source_versions" using primary key columns */
+  dataSourceVersion?: Maybe<Data_Source_Versions>;
+  /** fetch data from the table: "data_source_versions" */
+  dataSourceVersions: Array<Data_Source_Versions>;
+  /** fetch aggregated fields from the table: "data_source_versions" */
+  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
+  /** fetch data from the table: "org_data_sources" */
+  dataSources: Array<Org_Data_Sources>;
+  /** fetch aggregated fields from the table: "org_data_sources" */
+  dataSourcesAggregate: Org_Data_Sources_Aggregate;
+  /** fetch data from the table: "features" using primary key columns */
+  feature?: Maybe<Features>;
+  /** fetch data from the table: "features" */
+  features: Array<Features>;
+  /** fetch aggregated fields from the table: "features" */
+  featuresAggregate: Features_Aggregate;
+  latestMqlServer?: Maybe<MqlServerVersion>;
+  /** execute function "me" which returns "users" */
+  me: Array<Users>;
+  /** execute function "me" and query aggregates on result of table type "users" */
+  me_aggregate: Users_Aggregate;
+  /** fetch data from the table: "metric_annotations" using primary key columns */
+  metricAnnotation?: Maybe<Metric_Annotations>;
+  /** fetch data from the table: "metric_annotations" */
+  metricAnnotations: Array<Metric_Annotations>;
+  /** fetch aggregated fields from the table: "metric_annotations" */
+  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
+  /** fetch data from the table: "metric_approvals" using primary key columns */
+  metricApproval?: Maybe<Metric_Approvals>;
+  /** fetch data from the table: "metric_approvals" */
+  metricApprovals: Array<Metric_Approvals>;
+  /** fetch aggregated fields from the table: "metric_approvals" */
+  metricApprovalsAggregate: Metric_Approvals_Aggregate;
+  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
+  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
+  /** fetch data from the table: "metric_collections" using primary key columns */
+  metricCollection?: Maybe<Metric_Collections>;
+  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
+  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** fetch data from the table: "metric_collection_metrics" */
+  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
+  /** fetch aggregated fields from the table: "metric_collection_metrics" */
+  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
+  /** fetch data from the table: "metric_collection_view" using primary key columns */
+  metricCollectionView?: Maybe<Metric_Collection_View>;
+  /** fetch aggregated fields from the table: "metric_collection_view" */
+  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
+  /** fetch data from the table: "metric_collection_view" */
+  metricCollectionViews: Array<Metric_Collection_View>;
+  /** fetch data from the table: "metric_collections" */
+  metricCollections: Array<Metric_Collections>;
+  /** fetch aggregated fields from the table: "metric_collections" */
+  metricCollectionsAggregate: Metric_Collections_Aggregate;
+  /** fetch data from the table: "metric_current_description" */
+  metricCurrentDescriptions: Array<Metric_Current_Description>;
+  /** fetch data from the table: "metric_descriptions" using primary key columns */
+  metricDescription?: Maybe<Metric_Descriptions>;
+  /** fetch data from the table: "metric_descriptions" */
+  metricDescriptions: Array<Metric_Descriptions>;
+  /** fetch aggregated fields from the table: "metric_descriptions" */
+  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
+  /** fetch data from the table: "metric_team_owners" using primary key columns */
+  metricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** fetch data from the table: "metric_team_owners" */
+  metricTeamOwners: Array<Metric_Team_Owners>;
+  /** fetch aggregated fields from the table: "metric_team_owners" */
+  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
+  /** fetch data from the table: "metric_user_owners" using primary key columns */
+  metricUserOwner?: Maybe<Metric_User_Owners>;
+  /** fetch data from the table: "metric_user_owners" */
+  metricUserOwners: Array<Metric_User_Owners>;
+  /** fetch aggregated fields from the table: "metric_user_owners" */
+  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
+  /** fetch data from the table: "metric_versions" using primary key columns */
+  metricVersion?: Maybe<Metric_Versions>;
+  /** fetch data from the table: "metric_versions" */
+  metricVersions: Array<Metric_Versions>;
+  /** fetch aggregated fields from the table: "metric_versions" */
+  metricVersionsAggregate: Metric_Versions_Aggregate;
+  /** fetch data from the table: "metric_view" */
+  metricViews: Array<Metric_View>;
+  /** fetch aggregated fields from the table: "metric_view" */
+  metricViewsAggregate: Metric_View_Aggregate;
+  /** fetch aggregated fields from the table: "metric_current_description" */
+  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
+  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
+  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
+  /** fetch data from the table: "org_metrics_current_view" */
+  metrics: Array<Org_Metrics_Current_View>;
+  /** fetch aggregated fields from the table: "org_metrics_current_view" */
+  metricsAggregate: Org_Metrics_Current_View_Aggregate;
+  /** fetch data from the table: "models" using primary key columns */
+  model?: Maybe<Models>;
+  /** fetch data from the table: "model_data_sources" using primary key columns */
+  modelDataSource?: Maybe<Model_Data_Sources>;
+  /** fetch data from the table: "model_data_sources" */
+  modelDataSources: Array<Model_Data_Sources>;
+  /** fetch aggregated fields from the table: "model_data_sources" */
+  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
+  /** fetch data from the table: "model_metrics" using primary key columns */
+  modelMetric?: Maybe<Model_Metrics>;
+  /** fetch data from the table: "model_metrics" */
+  modelMetrics: Array<Model_Metrics>;
+  /** fetch aggregated fields from the table: "model_metrics" */
+  modelMetricsAggregate: Model_Metrics_Aggregate;
+  /** fetch data from the table: "model_current" */
+  model_current: Array<Model_Current>;
+  /** fetch data from the table: "models" */
+  models: Array<Models>;
+  /** fetch aggregated fields from the table: "models" */
+  modelsAggregate: Models_Aggregate;
+  /** fetch data from the table: "mql_heartbeats" using primary key columns */
+  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
+  /** fetch data from the table: "mql_heartbeats" */
+  mqlHeartbeats: Array<Mql_Heartbeats>;
+  mqlServerUrl?: Maybe<Scalars['String']>;
+  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
+  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
+  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
+  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
+  /** execute function "my_org" which returns "organizations" */
+  my_org: Array<Organizations>;
+  /** fetch data from the table: "org_mql_servers" using primary key columns */
+  orgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** fetch data from the table: "org_mql_servers" */
+  orgMqlServers: Array<Org_Mql_Servers>;
+  /** fetch aggregated fields from the table: "org_mql_servers" */
+  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
+  /** fetch data from the table: "organizations" using primary key columns */
+  organization?: Maybe<Organizations>;
+  /** fetch data from the table: "organization_features" using primary key columns */
+  organizationFeature?: Maybe<Organization_Features>;
+  /** fetch data from the table: "organization_features" */
+  organizationFeatures: Array<Organization_Features>;
+  /** fetch aggregated fields from the table: "organization_features" */
+  organizationFeaturesAggregate: Organization_Features_Aggregate;
+  /** fetch data from the table: "organizations" */
+  organizations: Array<Organizations>;
+  /** fetch data from the table: "priorities" */
+  priorities: Array<Priorities>;
+  /** fetch data from the table: "priorities" using primary key columns */
+  priorities_by_pk?: Maybe<Priorities>;
+  /** fetch data from the table: "questions" using primary key columns */
+  question?: Maybe<Questions>;
+  /** fetch data from the table: "question_directed_to" */
+  questionDirectedTo: Array<Question_Directed_To>;
+  /** fetch aggregated fields from the table: "question_directed_to" */
+  questionDirectedToAggregate: Question_Directed_To_Aggregate;
+  /** fetch data from the table: "question_directed_to" using primary key columns */
+  questionDirectedToByPK?: Maybe<Question_Directed_To>;
+  /** fetch data from the table: "question_likes" using primary key columns */
+  questionLike?: Maybe<Question_Likes>;
+  /** fetch data from the table: "question_likes" */
+  questionLikes: Array<Question_Likes>;
+  /** fetch aggregated fields from the table: "question_likes" */
+  questionLikesAggregate: Question_Likes_Aggregate;
+  /** fetch data from the table: "question_replies" */
+  questionReplies: Array<Question_Replies>;
+  /** fetch aggregated fields from the table: "question_replies" */
+  questionRepliesAggregate: Question_Replies_Aggregate;
+  /** fetch data from the table: "question_replies" using primary key columns */
+  questionReply?: Maybe<Question_Replies>;
+  /** fetch data from the table: "questions" */
+  questions: Array<Questions>;
+  /** fetch aggregated fields from the table: "questions" */
+  questionsAggregate: Questions_Aggregate;
+  /** fetch data from the table: "saved_queries" */
+  savedQueries: Array<Saved_Queries>;
+  /** fetch aggregated fields from the table: "saved_queries" */
+  savedQueriesAggregate: Saved_Queries_Aggregate;
+  /** fetch data from the table: "saved_queries" using primary key columns */
+  savedQuery?: Maybe<Saved_Queries>;
+  /** fetch data from the table: "saved_query_metrics" using primary key columns */
+  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** fetch data from the table: "saved_query_metrics" */
+  savedQueryMetrics: Array<Saved_Query_Metrics>;
+  /** fetch aggregated fields from the table: "saved_query_metrics" */
+  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
+  /** fetch data from the table: "teams" using primary key columns */
+  team?: Maybe<Teams>;
+  /** fetch data from the table: "team_dashboards" using primary key columns */
+  teamDashboard?: Maybe<Team_Dashboards>;
+  /** fetch data from the table: "team_dashboards" */
+  teamDashboards: Array<Team_Dashboards>;
+  /** fetch aggregated fields from the table: "team_dashboards" */
+  teamDashboardsAggregate: Team_Dashboards_Aggregate;
+  /** fetch data from the table: "team_members" using primary key columns */
+  teamMember?: Maybe<Team_Members>;
+  /** fetch data from the table: "team_members" */
+  teamMembers: Array<Team_Members>;
+  /** fetch aggregated fields from the table: "team_members" */
+  teamMembersAggregate: Team_Members_Aggregate;
+  /** fetch data from the table: "team_views" */
+  team_views: Array<Team_Views>;
+  /** fetch data from the table: "team_views" using primary key columns */
+  team_views_by_pk?: Maybe<Team_Views>;
+  /** fetch data from the table: "teams" */
+  teams: Array<Teams>;
+  /** fetch aggregated fields from the table: "teams" */
+  teamsAggregate: Teams_Aggregate;
+  /** fetch data from the table: "users" using primary key columns */
+  user?: Maybe<Users>;
+  /** fetch data from the table: "user_features" using primary key columns */
+  userFeature?: Maybe<User_Features>;
+  /** fetch data from the table: "user_features" */
+  userFeatures: Array<User_Features>;
+  /** fetch aggregated fields from the table: "user_features" */
+  userFeaturesAggregate: User_Features_Aggregate;
+  /** fetch data from the table: "user_prefs" using primary key columns */
+  userPreference?: Maybe<User_Prefs>;
+  /** fetch data from the table: "user_prefs" */
+  userPreferences: Array<User_Prefs>;
+  /** fetch aggregated fields from the table: "user_prefs" */
+  userPreferencesAggregate: User_Prefs_Aggregate;
+  /** fetch data from the table: "user_roles" using primary key columns */
+  userRole?: Maybe<User_Roles>;
+  /** fetch data from the table: "user_roles" */
+  userRoles: Array<User_Roles>;
+  /** fetch aggregated fields from the table: "user_roles" */
+  userRolesAggregate: User_Roles_Aggregate;
+  /** fetch data from the table: "users" */
+  users: Array<Users>;
+  /** fetch aggregated fields from the table: "users" */
+  usersAggregate: Users_Aggregate;
+  heartbeat: Scalars['String'];
+};
+
+
+export type QueryAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+export type QueryAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+export type QueryApiKeyArgs = {
+  prefix: Scalars['String'];
+};
+
+
+export type QueryApiKeysArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+export type QueryApiKeysAggregateArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+export type QueryAuth0ProfileArgs = {
+  auth0Id: Scalars['String'];
+};
+
+
+export type QueryDashboardArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDashboardItemConfigArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDashboardItemConfigsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+export type QueryDashboardItemConfigsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+export type QueryDashboardSectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDashboardSectionsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+export type QueryDashboardSectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+export type QueryDashboardsArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+export type QueryDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+export type QueryDataSourceArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDataSourceVersionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDataSourceVersionsArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+export type QueryDataSourceVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+export type QueryDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryFeatureArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryFeaturesArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+export type QueryFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+export type QueryMeArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+export type QueryMe_AggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+export type QueryMetricAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+export type QueryMetricAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+export type QueryMetricApprovalArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricApprovalsArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+export type QueryMetricApprovalsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+export type QueryMetricByIdTempArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionMetricsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionViewArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionViewAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+export type QueryMetricCurrentDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+export type QueryMetricDescriptionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+export type QueryMetricDescriptionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+export type QueryMetricTeamOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricTeamOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricTeamOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricUserOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricUserOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricUserOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricVersionArgs = {
+  id: Scalars['bigint'];
+};
+
+
+export type QueryMetricVersionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+export type QueryMetricVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+export type QueryMetricViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+export type QueryMetricViewsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+export type QueryMetric_Current_Description_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+export type QueryMetric_Lineage_Data_SourcesArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryMetric_Lineage_Data_Sources_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryMetric_Lineage_Data_Sources_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryModelArgs = {
+  id: Scalars['bigint'];
+};
+
+
+export type QueryModelDataSourceArgs = {
+  dataSourceVersionId: Scalars['Int'];
+  modelId: Scalars['Int'];
+};
+
+
+export type QueryModelDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryModelDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryModelMetricArgs = {
+  metricId: Scalars['bigint'];
+  metricVersionId: Scalars['bigint'];
+  modelId: Scalars['bigint'];
+};
+
+
+export type QueryModelMetricsArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+export type QueryModelMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+export type QueryModel_CurrentArgs = {
+  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Current_Order_By>>;
+  where?: Maybe<Model_Current_Bool_Exp>;
+};
+
+
+export type QueryModelsArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+export type QueryModelsAggregateArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+export type QueryMqlHeartbeatArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMqlHeartbeatsArgs = {
+  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
+  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
+};
+
+
+export type QueryMy_Most_Viewed_MetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryMy_Most_Viewed_Metrics_AggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryMy_OrgArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+export type QueryOrgMqlServerArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryOrgMqlServersArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+export type QueryOrgMqlServersAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+export type QueryOrganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryOrganizationFeatureArgs = {
+  featureId: Scalars['Int'];
+  organizationId: Scalars['Int'];
+};
+
+
+export type QueryOrganizationFeaturesArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+export type QueryOrganizationFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+export type QueryOrganizationsArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+export type QueryPrioritiesArgs = {
+  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Priorities_Order_By>>;
+  where?: Maybe<Priorities_Bool_Exp>;
+};
+
+
+export type QueryPriorities_By_PkArgs = {
+  value: Scalars['String'];
+};
+
+
+export type QueryQuestionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionDirectedToArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+export type QueryQuestionDirectedToAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+export type QueryQuestionDirectedToByPkArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionLikeArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionLikesArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+export type QueryQuestionLikesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+export type QueryQuestionRepliesArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+export type QueryQuestionRepliesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+export type QueryQuestionReplyArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionsArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+export type QueryQuestionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+export type QuerySavedQueriesArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+export type QuerySavedQueriesAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+export type QuerySavedQueryArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QuerySavedQueryMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QuerySavedQueryMetricsArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+export type QuerySavedQueryMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+export type QueryTeamArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryTeamDashboardArgs = {
+  dashboardId: Scalars['Int'];
+  team_id: Scalars['Int'];
+};
+
+
+export type QueryTeamDashboardsArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+export type QueryTeamDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+export type QueryTeamMemberArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryTeamMembersArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+export type QueryTeamMembersAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+export type QueryTeam_ViewsArgs = {
+  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Views_Order_By>>;
+  where?: Maybe<Team_Views_Bool_Exp>;
+};
+
+
+export type QueryTeam_Views_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryTeamsArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+export type QueryTeamsAggregateArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+export type QueryUserArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryUserFeatureArgs = {
+  featureId: Scalars['Int'];
+  userId: Scalars['Int'];
+};
+
+
+export type QueryUserFeaturesArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+export type QueryUserFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+export type QueryUserPreferenceArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryUserPreferencesArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+export type QueryUserPreferencesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+export type QueryUserRoleArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryUserRolesArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+export type QueryUserRolesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+export type QueryUsersArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+export type QueryUsersAggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+/** Base mutation object exposed by GraphQL. */
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** insert a single row into the table: "metric_collection_metrics" */
+  addMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** insert data into the table: "metric_collection_metrics" */
+  addMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
+  /** insert a single row into the table: "team_members" */
+  addTeamMember?: Maybe<Team_Members>;
+  /** insert data into the table: "team_members" */
+  addTeamMembers?: Maybe<Team_Members_Mutation_Response>;
+  /** perform the action: "addUserRole" */
+  addUserRole?: Maybe<AddUserRoleOutput>;
+  /** insert a single row into the table: "metric_approvals" */
+  approveMetric?: Maybe<Metric_Approvals>;
+  /** insert data into the table: "metric_approvals" */
+  approveMetrics?: Maybe<Metric_Approvals_Mutation_Response>;
+  /** insert a single row into the table: "user_roles" */
+  assignUserRole?: Maybe<User_Roles>;
+  /** insert data into the table: "user_roles" */
+  assignUserRoles?: Maybe<User_Roles_Mutation_Response>;
+  /** insert a single row into the table: "annotations" */
+  createAnnotation?: Maybe<Annotations>;
+  /** insert data into the table: "annotations" */
+  createAnnotations?: Maybe<Annotations_Mutation_Response>;
+  /** perform the action: "createApiKey" */
+  createApiKey?: Maybe<CreateApiKeyOutput>;
+  /** insert a single row into the table: "dashboards" */
+  createDashboard?: Maybe<Dashboards>;
+  /** insert a single row into the table: "dashboard_item_configs" */
+  createDashboardItem?: Maybe<Dashboard_Item_Configs>;
+  /** insert data into the table: "dashboard_item_configs" */
+  createDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
+  /** insert a single row into the table: "dashboard_sections" */
+  createDashboardSection?: Maybe<Dashboard_Sections>;
+  /** insert data into the table: "dashboard_sections" */
+  createDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
+  /** insert data into the table: "dashboards" */
+  createDashboards?: Maybe<Dashboards_Mutation_Response>;
+  /** insert a single row into the table: "metric_annotations" */
+  createMetricAnnotation?: Maybe<Metric_Annotations>;
+  /** insert data into the table: "metric_annotations" */
+  createMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
+  /** insert a single row into the table: "metric_collections" */
+  createMetricCollection?: Maybe<Metric_Collections>;
+  /** insert a single row into the table: "metric_collection_view" */
+  createMetricCollectionView?: Maybe<Metric_Collection_View>;
+  /** insert data into the table: "metric_collection_view" */
+  createMetricCollectionViews?: Maybe<Metric_Collection_View_Mutation_Response>;
+  /** insert data into the table: "metric_collections" */
+  createMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
+  /** insert a single row into the table: "metric_descriptions" */
+  createMetricDescription?: Maybe<Metric_Descriptions>;
+  /** insert data into the table: "metric_descriptions" */
+  createMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
+  /** insert a single row into the table: "metric_team_owners" */
+  createMetricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** insert data into the table: "metric_team_owners" */
+  createMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
+  /** insert a single row into the table: "metric_user_owners" */
+  createMetricUserOwner?: Maybe<Metric_User_Owners>;
+  /** insert data into the table: "metric_user_owners" */
+  createMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
+  /** insert a single row into the table: "metric_view" */
+  createMetricView?: Maybe<Metric_View>;
+  /** insert data into the table: "metric_view" */
+  createMetricViews?: Maybe<Metric_View_Mutation_Response>;
+  /** insert a single row into the table: "mql_heartbeats" */
+  createMqlHeartbeat?: Maybe<Mql_Heartbeats>;
+  /** insert data into the table: "mql_heartbeats" */
+  createMqlHeartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
+  /** insert a single row into the table: "org_mql_servers" */
+  createOrgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** insert data into the table: "org_mql_servers" */
+  createOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
+  /** insert a single row into the table: "questions" */
+  createQuestion?: Maybe<Questions>;
+  /** insert data into the table: "question_replies" */
+  createQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
+  /** insert a single row into the table: "question_replies" */
+  createQuestionReply?: Maybe<Question_Replies>;
+  /** insert data into the table: "questions" */
+  createQuestions?: Maybe<Questions_Mutation_Response>;
+  /** insert data into the table: "saved_queries" */
+  createSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
+  /** insert a single row into the table: "saved_queries" */
+  createSavedQuery?: Maybe<Saved_Queries>;
+  /** insert a single row into the table: "teams" */
+  createTeam?: Maybe<Teams>;
+  /** insert a single row into the table: "team_dashboards" */
+  createTeamDashboard?: Maybe<Team_Dashboards>;
+  /** insert data into the table: "team_dashboards" */
+  createTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
+  /** insert a single row into the table: "team_views" */
+  createTeamView?: Maybe<Team_Views>;
+  /** insert data into the table: "team_views" */
+  createTeamViews?: Maybe<Team_Views_Mutation_Response>;
+  /** insert data into the table: "teams" */
+  createTeams?: Maybe<Teams_Mutation_Response>;
+  /** perform the action: "createUser" */
+  createUser?: Maybe<CreateUserOutput>;
+  /** insert a single row into the table: "user_prefs" */
+  createUserPreference?: Maybe<User_Prefs>;
+  /** insert data into the table: "user_prefs" */
+  createUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
+  /** insert a single row into the table: "saved_query_metrics" */
+  createdSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** insert data into the table: "saved_query_metrics" */
+  createdSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
+  /** perform the action: "deactivateUser" */
+  deactivateUser?: Maybe<DeactivateUserOutput>;
+  /** delete single row from the table: "dashboard_item_configs" */
+  deleteDashboardItem?: Maybe<Dashboard_Item_Configs>;
+  /** delete data from the table: "dashboard_item_configs" */
+  deleteDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
+  /** delete single row from the table: "dashboard_sections" */
+  deleteDashboardSection?: Maybe<Dashboard_Sections>;
+  /** delete data from the table: "dashboard_sections" */
+  deleteDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
+  /** delete single row from the table: "metric_annotations" */
+  deleteMetricAnnotation?: Maybe<Metric_Annotations>;
+  /** delete data from the table: "metric_annotations" */
+  deleteMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
+  /** delete single row from the table: "metric_collections" */
+  deleteMetricCollection?: Maybe<Metric_Collections>;
+  /** delete data from the table: "metric_collections" */
+  deleteMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
+  /** delete single row from the table: "metric_descriptions" */
+  deleteMetricDescription?: Maybe<Metric_Descriptions>;
+  /** delete data from the table: "metric_descriptions" */
+  deleteMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
+  /** delete single row from the table: "metric_team_owners" */
+  deleteMetricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** delete data from the table: "metric_team_owners" */
+  deleteMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
+  /** delete single row from the table: "metric_user_owners" */
+  deleteMetricUserOwner?: Maybe<Metric_User_Owners>;
+  /** delete data from the table: "metric_user_owners" */
+  deleteMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
+  /** delete single row from the table: "org_mql_servers" */
+  deleteOrgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** delete data from the table: "org_mql_servers" */
+  deleteOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
+  /** delete data from the table: "question_replies" */
+  deleteQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
+  /** delete single row from the table: "question_replies" */
+  deleteQuestionReply?: Maybe<Question_Replies>;
+  /** delete single row from the table: "saved_query_metrics" */
+  deleteSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** delete data from the table: "saved_query_metrics" */
+  deleteSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
+  /** delete single row from the table: "team_dashboards" */
+  deleteTeamDashboard?: Maybe<Team_Dashboards>;
+  /** delete data from the table: "team_dashboards" */
+  deleteTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
+  /** delete single row from the table: "user_prefs" */
+  deleteUserPreference?: Maybe<User_Prefs>;
+  /** delete data from the table: "user_prefs" */
+  deleteUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
+  /** insert a single row into the table: "question_directed_to" */
+  directQuestionTo?: Maybe<Question_Directed_To>;
+  /** insert data into the table: "question_directed_to" */
+  directQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
+  /** insert data into the table: "users" */
+  insert_users?: Maybe<Users_Mutation_Response>;
+  /** insert a single row into the table: "users" */
+  insert_users_one?: Maybe<Users>;
+  /** insert a single row into the table: "question_likes" */
+  likeQuestion?: Maybe<Question_Likes>;
+  /** insert data into the table: "question_likes" */
+  likeQuestions?: Maybe<Question_Likes_Mutation_Response>;
+  logMqlLog?: Maybe<LogMqlLogs>;
+  /** perform the action: "reactivateUser" */
+  reactivateUser?: Maybe<ReactivateUserOutput>;
+  /** delete single row from the table: "question_directed_to" */
+  removeDirectQuestionTo?: Maybe<Question_Directed_To>;
+  /** delete data from the table: "question_directed_to" */
+  removeDirectQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
+  /** delete single row from the table: "metric_approvals" */
+  removeMetricApproval?: Maybe<Metric_Approvals>;
+  /** delete data from the table: "metric_approvals" */
+  removeMetricApprovals?: Maybe<Metric_Approvals_Mutation_Response>;
+  /** delete single row from the table: "metric_collection_metrics" */
+  removeMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** delete data from the table: "metric_collection_metrics" */
+  removeMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
+  /** delete single row from the table: "team_members" */
+  removeTeamMember?: Maybe<Team_Members>;
+  /** delete data from the table: "team_members" */
+  removeTeamMembers?: Maybe<Team_Members_Mutation_Response>;
+  /** perform the action: "removeUserRole" */
+  removeUserRole?: Maybe<RemoveUserRoleOutput>;
+  /** delete single row from the table: "question_likes" */
+  unlikeQuestion?: Maybe<Question_Likes>;
+  /** delete data from the table: "question_likes" */
+  unlikeQuestions?: Maybe<Question_Likes_Mutation_Response>;
+  /** update single row of the table: "annotations" */
+  updateAnnotation?: Maybe<Annotations>;
+  /** update data of the table: "annotations" */
+  updateAnnotations?: Maybe<Annotations_Mutation_Response>;
+  /** update single row of the table: "api_keys" */
+  updateApiKey?: Maybe<Api_Keys>;
+  /** update data of the table: "api_keys" */
+  updateApiKeys?: Maybe<Api_Keys_Mutation_Response>;
+  /** update single row of the table: "dashboards" */
+  updateDashboard?: Maybe<Dashboards>;
+  /** update single row of the table: "dashboard_item_configs" */
+  updateDashboardItem?: Maybe<Dashboard_Item_Configs>;
+  /** update data of the table: "dashboard_item_configs" */
+  updateDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
+  /** update single row of the table: "dashboard_sections" */
+  updateDashboardSection?: Maybe<Dashboard_Sections>;
+  /** update data of the table: "dashboard_sections" */
+  updateDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
+  /** update data of the table: "dashboards" */
+  updateDashboards?: Maybe<Dashboards_Mutation_Response>;
+  /** update single row of the table: "metric_annotations" */
+  updateMetricAnnotation?: Maybe<Metric_Annotations>;
+  /** update data of the table: "metric_annotations" */
+  updateMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
+  /** update single row of the table: "metric_collections" */
+  updateMetricCollection?: Maybe<Metric_Collections>;
+  /** update data of the table: "metric_collections" */
+  updateMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
+  /** perform the action: "updateMyEmail" */
+  updateMyEmail?: Maybe<UpdateMyEmailOutput>;
+  /** update single row of the table: "org_mql_servers" */
+  updateOrgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** update data of the table: "org_mql_servers" */
+  updateOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
+  /** update single row of the table: "organizations" */
+  updateOrganization?: Maybe<Organizations>;
+  /** update data of the table: "organizations" */
+  updateOrganizations?: Maybe<Organizations_Mutation_Response>;
+  /** update single row of the table: "questions" */
+  updateQuestion?: Maybe<Questions>;
+  /** update data of the table: "question_replies" */
+  updateQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
+  /** update single row of the table: "question_replies" */
+  updateQuestionReply?: Maybe<Question_Replies>;
+  /** update data of the table: "questions" */
+  updateQuestions?: Maybe<Questions_Mutation_Response>;
+  /** update data of the table: "saved_queries" */
+  updateSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
+  /** update single row of the table: "saved_queries" */
+  updateSavedQuery?: Maybe<Saved_Queries>;
+  /** update single row of the table: "teams" */
+  updateTeam?: Maybe<Teams>;
+  /** update single row of the table: "team_members" */
+  updateTeamMember?: Maybe<Team_Members>;
+  /** update data of the table: "team_members" */
+  updateTeamMembers?: Maybe<Team_Members_Mutation_Response>;
+  /** update data of the table: "teams" */
+  updateTeams?: Maybe<Teams_Mutation_Response>;
+  /** update single row of the table: "users" */
+  updateUser?: Maybe<Users>;
+  /** update single row of the table: "user_prefs" */
+  updateUserPreference?: Maybe<User_Prefs>;
+  /** update data of the table: "user_prefs" */
+  updateUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
+  /** update single row of the table: "user_roles" */
+  updateUserRole?: Maybe<User_Roles>;
+  /** update data of the table: "user_roles" */
+  updateUserRoles?: Maybe<User_Roles_Mutation_Response>;
+  /** update data of the table: "users" */
+  updateUsers?: Maybe<Users_Mutation_Response>;
+  /** update data of the table: "metric_collection_metrics" */
+  update_metric_collection_metrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
+  /** update single row of the table: "metric_collection_metrics" */
+  update_metric_collection_metrics_by_pk?: Maybe<Metric_Collection_Metrics>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddMetricCollectionMetricArgs = {
+  object: Metric_Collection_Metrics_Insert_Input;
+  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddMetricCollectionMetricsArgs = {
+  objects: Array<Metric_Collection_Metrics_Insert_Input>;
+  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddTeamMemberArgs = {
+  object: Team_Members_Insert_Input;
+  on_conflict?: Maybe<Team_Members_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddTeamMembersArgs = {
+  objects: Array<Team_Members_Insert_Input>;
+  on_conflict?: Maybe<Team_Members_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddUserRoleArgs = {
+  input: AddUserRoleInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationApproveMetricArgs = {
+  object: Metric_Approvals_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationApproveMetricsArgs = {
+  objects: Array<Metric_Approvals_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAssignUserRoleArgs = {
+  object: User_Roles_Insert_Input;
+  on_conflict?: Maybe<User_Roles_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAssignUserRolesArgs = {
+  objects: Array<User_Roles_Insert_Input>;
+  on_conflict?: Maybe<User_Roles_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateAnnotationArgs = {
+  object: Annotations_Insert_Input;
+  on_conflict?: Maybe<Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateAnnotationsArgs = {
+  objects: Array<Annotations_Insert_Input>;
+  on_conflict?: Maybe<Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardArgs = {
+  object: Dashboards_Insert_Input;
+  on_conflict?: Maybe<Dashboards_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardItemArgs = {
+  object: Dashboard_Item_Configs_Insert_Input;
+  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardItemsArgs = {
+  objects: Array<Dashboard_Item_Configs_Insert_Input>;
+  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardSectionArgs = {
+  object: Dashboard_Sections_Insert_Input;
+  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardSectionsArgs = {
+  objects: Array<Dashboard_Sections_Insert_Input>;
+  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardsArgs = {
+  objects: Array<Dashboards_Insert_Input>;
+  on_conflict?: Maybe<Dashboards_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricAnnotationArgs = {
+  object: Metric_Annotations_Insert_Input;
+  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricAnnotationsArgs = {
+  objects: Array<Metric_Annotations_Insert_Input>;
+  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionArgs = {
+  object: Metric_Collections_Insert_Input;
+  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionViewArgs = {
+  object: Metric_Collection_View_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionViewsArgs = {
+  objects: Array<Metric_Collection_View_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionsArgs = {
+  objects: Array<Metric_Collections_Insert_Input>;
+  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricDescriptionArgs = {
+  object: Metric_Descriptions_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricDescriptionsArgs = {
+  objects: Array<Metric_Descriptions_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricTeamOwnerArgs = {
+  object: Metric_Team_Owners_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricTeamOwnersArgs = {
+  objects: Array<Metric_Team_Owners_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricUserOwnerArgs = {
+  object: Metric_User_Owners_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricUserOwnersArgs = {
+  objects: Array<Metric_User_Owners_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricViewArgs = {
+  object: Metric_View_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricViewsArgs = {
+  objects: Array<Metric_View_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMqlHeartbeatArgs = {
+  object: Mql_Heartbeats_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMqlHeartbeatsArgs = {
+  objects: Array<Mql_Heartbeats_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateOrgMqlServerArgs = {
+  object: Org_Mql_Servers_Insert_Input;
+  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateOrgMqlServersArgs = {
+  objects: Array<Org_Mql_Servers_Insert_Input>;
+  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionArgs = {
+  object: Questions_Insert_Input;
+  on_conflict?: Maybe<Questions_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionRepliesArgs = {
+  objects: Array<Question_Replies_Insert_Input>;
+  on_conflict?: Maybe<Question_Replies_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionReplyArgs = {
+  object: Question_Replies_Insert_Input;
+  on_conflict?: Maybe<Question_Replies_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionsArgs = {
+  objects: Array<Questions_Insert_Input>;
+  on_conflict?: Maybe<Questions_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateSavedQueriesArgs = {
+  objects: Array<Saved_Queries_Insert_Input>;
+  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateSavedQueryArgs = {
+  object: Saved_Queries_Insert_Input;
+  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamArgs = {
+  object: Teams_Insert_Input;
+  on_conflict?: Maybe<Teams_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamDashboardArgs = {
+  object: Team_Dashboards_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamDashboardsArgs = {
+  objects: Array<Team_Dashboards_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamViewArgs = {
+  object: Team_Views_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamViewsArgs = {
+  objects: Array<Team_Views_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamsArgs = {
+  objects: Array<Teams_Insert_Input>;
+  on_conflict?: Maybe<Teams_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateUserArgs = {
+  input: CreateUserInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateUserPreferenceArgs = {
+  object: User_Prefs_Insert_Input;
+  on_conflict?: Maybe<User_Prefs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateUserPreferencesArgs = {
+  objects: Array<User_Prefs_Insert_Input>;
+  on_conflict?: Maybe<User_Prefs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreatedSavedQueryMetricArgs = {
+  object: Saved_Query_Metrics_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreatedSavedQueryMetricsArgs = {
+  objects: Array<Saved_Query_Metrics_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeactivateUserArgs = {
+  input: DeactivateUserInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardItemArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardItemsArgs = {
+  where: Dashboard_Item_Configs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardSectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardSectionsArgs = {
+  where: Dashboard_Sections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricAnnotationsArgs = {
+  where: Metric_Annotations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricCollectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricCollectionsArgs = {
+  where: Metric_Collections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricDescriptionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricDescriptionsArgs = {
+  where: Metric_Descriptions_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricTeamOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricTeamOwnersArgs = {
+  where: Metric_Team_Owners_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricUserOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricUserOwnersArgs = {
+  where: Metric_User_Owners_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteOrgMqlServerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteOrgMqlServersArgs = {
+  where: Org_Mql_Servers_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteQuestionRepliesArgs = {
+  where: Question_Replies_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteQuestionReplyArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteSavedQueryMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteSavedQueryMetricsArgs = {
+  where: Saved_Query_Metrics_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteTeamDashboardArgs = {
+  dashboardId: Scalars['Int'];
+  team_id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteTeamDashboardsArgs = {
+  where: Team_Dashboards_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteUserPreferenceArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteUserPreferencesArgs = {
+  where: User_Prefs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDirectQuestionToArgs = {
+  object: Question_Directed_To_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDirectQuestionToMultipleArgs = {
+  objects: Array<Question_Directed_To_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationInsert_UsersArgs = {
+  objects: Array<Users_Insert_Input>;
+  on_conflict?: Maybe<Users_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationInsert_Users_OneArgs = {
+  object: Users_Insert_Input;
+  on_conflict?: Maybe<Users_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationLikeQuestionArgs = {
+  object: Question_Likes_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationLikeQuestionsArgs = {
+  objects: Array<Question_Likes_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationLogMqlLogArgs = {
+  level?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<Scalars['String']>>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationReactivateUserArgs = {
+  input: ReactivateUserInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveDirectQuestionToArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveDirectQuestionToMultipleArgs = {
+  where: Question_Directed_To_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricApprovalArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricApprovalsArgs = {
+  where: Metric_Approvals_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricCollectionMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricCollectionMetricsArgs = {
+  where: Metric_Collection_Metrics_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveTeamMemberArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveTeamMembersArgs = {
+  where: Team_Members_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveUserRoleArgs = {
+  input: RemoveUserRoleInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUnlikeQuestionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUnlikeQuestionsArgs = {
+  where: Question_Likes_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateAnnotationArgs = {
+  _set?: Maybe<Annotations_Set_Input>;
+  pk_columns: Annotations_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateAnnotationsArgs = {
+  _set?: Maybe<Annotations_Set_Input>;
+  where: Annotations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateApiKeyArgs = {
+  _set?: Maybe<Api_Keys_Set_Input>;
+  pk_columns: Api_Keys_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateApiKeysArgs = {
+  _set?: Maybe<Api_Keys_Set_Input>;
+  where: Api_Keys_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardArgs = {
+  _set?: Maybe<Dashboards_Set_Input>;
+  pk_columns: Dashboards_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardItemArgs = {
+  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
+  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
+  pk_columns: Dashboard_Item_Configs_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardItemsArgs = {
+  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
+  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
+  where: Dashboard_Item_Configs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardSectionArgs = {
+  _set?: Maybe<Dashboard_Sections_Set_Input>;
+  pk_columns: Dashboard_Sections_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardSectionsArgs = {
+  _set?: Maybe<Dashboard_Sections_Set_Input>;
+  where: Dashboard_Sections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardsArgs = {
+  _set?: Maybe<Dashboards_Set_Input>;
+  where: Dashboards_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricAnnotationArgs = {
+  _inc?: Maybe<Metric_Annotations_Inc_Input>;
+  _set?: Maybe<Metric_Annotations_Set_Input>;
+  pk_columns: Metric_Annotations_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricAnnotationsArgs = {
+  _inc?: Maybe<Metric_Annotations_Inc_Input>;
+  _set?: Maybe<Metric_Annotations_Set_Input>;
+  where: Metric_Annotations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricCollectionArgs = {
+  _inc?: Maybe<Metric_Collections_Inc_Input>;
+  _set?: Maybe<Metric_Collections_Set_Input>;
+  pk_columns: Metric_Collections_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricCollectionsArgs = {
+  _inc?: Maybe<Metric_Collections_Inc_Input>;
+  _set?: Maybe<Metric_Collections_Set_Input>;
+  where: Metric_Collections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMyEmailArgs = {
+  input: UpdateMyEmailInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrgMqlServerArgs = {
+  _set?: Maybe<Org_Mql_Servers_Set_Input>;
+  pk_columns: Org_Mql_Servers_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrgMqlServersArgs = {
+  _set?: Maybe<Org_Mql_Servers_Set_Input>;
+  where: Org_Mql_Servers_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrganizationArgs = {
+  _set?: Maybe<Organizations_Set_Input>;
+  pk_columns: Organizations_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrganizationsArgs = {
+  _set?: Maybe<Organizations_Set_Input>;
+  where: Organizations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionArgs = {
+  _inc?: Maybe<Questions_Inc_Input>;
+  _set?: Maybe<Questions_Set_Input>;
+  pk_columns: Questions_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionRepliesArgs = {
+  _set?: Maybe<Question_Replies_Set_Input>;
+  where: Question_Replies_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionReplyArgs = {
+  _set?: Maybe<Question_Replies_Set_Input>;
+  pk_columns: Question_Replies_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionsArgs = {
+  _inc?: Maybe<Questions_Inc_Input>;
+  _set?: Maybe<Questions_Set_Input>;
+  where: Questions_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateSavedQueriesArgs = {
+  _inc?: Maybe<Saved_Queries_Inc_Input>;
+  _set?: Maybe<Saved_Queries_Set_Input>;
+  where: Saved_Queries_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateSavedQueryArgs = {
+  _inc?: Maybe<Saved_Queries_Inc_Input>;
+  _set?: Maybe<Saved_Queries_Set_Input>;
+  pk_columns: Saved_Queries_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamArgs = {
+  _inc?: Maybe<Teams_Inc_Input>;
+  _set?: Maybe<Teams_Set_Input>;
+  pk_columns: Teams_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamMemberArgs = {
+  _set?: Maybe<Team_Members_Set_Input>;
+  pk_columns: Team_Members_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamMembersArgs = {
+  _set?: Maybe<Team_Members_Set_Input>;
+  where: Team_Members_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamsArgs = {
+  _inc?: Maybe<Teams_Inc_Input>;
+  _set?: Maybe<Teams_Set_Input>;
+  where: Teams_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserArgs = {
+  _set?: Maybe<Users_Set_Input>;
+  pk_columns: Users_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserPreferenceArgs = {
+  _set?: Maybe<User_Prefs_Set_Input>;
+  pk_columns: User_Prefs_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserPreferencesArgs = {
+  _set?: Maybe<User_Prefs_Set_Input>;
+  where: User_Prefs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserRoleArgs = {
+  _set?: Maybe<User_Roles_Set_Input>;
+  pk_columns: User_Roles_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserRolesArgs = {
+  _set?: Maybe<User_Roles_Set_Input>;
+  where: User_Roles_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUsersArgs = {
+  _set?: Maybe<Users_Set_Input>;
+  where: Users_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdate_Metric_Collection_MetricsArgs = {
+  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
+  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
+  where: Metric_Collection_Metrics_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdate_Metric_Collection_Metrics_By_PkArgs = {
+  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
+  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
+  pk_columns: Metric_Collection_Metrics_Pk_Columns_Input;
+};
+
+/** subscription root */
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** fetch data from the table: "annotations" using primary key columns */
+  annotation?: Maybe<Annotations>;
+  /** fetch data from the table: "annotations" */
+  annotations: Array<Annotations>;
+  /** fetch aggregated fields from the table: "annotations" */
+  annotationsAggregate: Annotations_Aggregate;
+  /** fetch data from the table: "api_keys" using primary key columns */
+  apiKey?: Maybe<Api_Keys>;
+  /** fetch data from the table: "api_keys" */
+  apiKeys: Array<Api_Keys>;
+  /** fetch aggregated fields from the table: "api_keys" */
+  apiKeysAggregate: Api_Keys_Aggregate;
+  /** fetch data from the table: "dashboards" using primary key columns */
+  dashboard?: Maybe<Dashboards>;
+  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
+  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
+  /** fetch data from the table: "dashboard_item_configs" */
+  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
+  /** fetch aggregated fields from the table: "dashboard_item_configs" */
+  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
+  /** fetch data from the table: "dashboard_sections" using primary key columns */
+  dashboardSection?: Maybe<Dashboard_Sections>;
+  /** fetch data from the table: "dashboard_sections" */
+  dashboardSections: Array<Dashboard_Sections>;
+  /** fetch aggregated fields from the table: "dashboard_sections" */
+  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
+  /** fetch data from the table: "dashboards" */
+  dashboards: Array<Dashboards>;
+  /** fetch aggregated fields from the table: "dashboards" */
+  dashboardsAggregate: Dashboards_Aggregate;
+  /** fetch data from the table: "org_data_sources" using primary key columns */
+  dataSource?: Maybe<Org_Data_Sources>;
+  /** fetch data from the table: "data_source_versions" using primary key columns */
+  dataSourceVersion?: Maybe<Data_Source_Versions>;
+  /** fetch data from the table: "data_source_versions" */
+  dataSourceVersions: Array<Data_Source_Versions>;
+  /** fetch aggregated fields from the table: "data_source_versions" */
+  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
+  /** fetch data from the table: "org_data_sources" */
+  dataSources: Array<Org_Data_Sources>;
+  /** fetch aggregated fields from the table: "org_data_sources" */
+  dataSourcesAggregate: Org_Data_Sources_Aggregate;
+  /** fetch data from the table: "features" using primary key columns */
+  feature?: Maybe<Features>;
+  /** fetch data from the table: "features" */
+  features: Array<Features>;
+  /** fetch aggregated fields from the table: "features" */
+  featuresAggregate: Features_Aggregate;
+  /** execute function "me" which returns "users" */
+  me: Array<Users>;
+  /** execute function "me" and query aggregates on result of table type "users" */
+  me_aggregate: Users_Aggregate;
+  /** fetch data from the table: "metric_annotations" using primary key columns */
+  metricAnnotation?: Maybe<Metric_Annotations>;
+  /** fetch data from the table: "metric_annotations" */
+  metricAnnotations: Array<Metric_Annotations>;
+  /** fetch aggregated fields from the table: "metric_annotations" */
+  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
+  /** fetch data from the table: "metric_approvals" using primary key columns */
+  metricApproval?: Maybe<Metric_Approvals>;
+  /** fetch data from the table: "metric_approvals" */
+  metricApprovals: Array<Metric_Approvals>;
+  /** fetch aggregated fields from the table: "metric_approvals" */
+  metricApprovalsAggregate: Metric_Approvals_Aggregate;
+  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
+  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
+  /** fetch data from the table: "metric_collections" using primary key columns */
+  metricCollection?: Maybe<Metric_Collections>;
+  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
+  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** fetch data from the table: "metric_collection_metrics" */
+  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
+  /** fetch aggregated fields from the table: "metric_collection_metrics" */
+  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
+  /** fetch data from the table: "metric_collection_view" using primary key columns */
+  metricCollectionView?: Maybe<Metric_Collection_View>;
+  /** fetch aggregated fields from the table: "metric_collection_view" */
+  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
+  /** fetch data from the table: "metric_collection_view" */
+  metricCollectionViews: Array<Metric_Collection_View>;
+  /** fetch data from the table: "metric_collections" */
+  metricCollections: Array<Metric_Collections>;
+  /** fetch aggregated fields from the table: "metric_collections" */
+  metricCollectionsAggregate: Metric_Collections_Aggregate;
+  /** fetch data from the table: "metric_current_description" */
+  metricCurrentDescriptions: Array<Metric_Current_Description>;
+  /** fetch data from the table: "metric_descriptions" using primary key columns */
+  metricDescription?: Maybe<Metric_Descriptions>;
+  /** fetch data from the table: "metric_descriptions" */
+  metricDescriptions: Array<Metric_Descriptions>;
+  /** fetch aggregated fields from the table: "metric_descriptions" */
+  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
+  /** fetch data from the table: "metric_team_owners" using primary key columns */
+  metricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** fetch data from the table: "metric_team_owners" */
+  metricTeamOwners: Array<Metric_Team_Owners>;
+  /** fetch aggregated fields from the table: "metric_team_owners" */
+  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
+  /** fetch data from the table: "metric_user_owners" using primary key columns */
+  metricUserOwner?: Maybe<Metric_User_Owners>;
+  /** fetch data from the table: "metric_user_owners" */
+  metricUserOwners: Array<Metric_User_Owners>;
+  /** fetch aggregated fields from the table: "metric_user_owners" */
+  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
+  /** fetch data from the table: "metric_versions" using primary key columns */
+  metricVersion?: Maybe<Metric_Versions>;
+  /** fetch data from the table: "metric_versions" */
+  metricVersions: Array<Metric_Versions>;
+  /** fetch aggregated fields from the table: "metric_versions" */
+  metricVersionsAggregate: Metric_Versions_Aggregate;
+  /** fetch data from the table: "metric_view" */
+  metricViews: Array<Metric_View>;
+  /** fetch aggregated fields from the table: "metric_view" */
+  metricViewsAggregate: Metric_View_Aggregate;
+  /** fetch aggregated fields from the table: "metric_current_description" */
+  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
+  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
+  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
+  /** fetch data from the table: "org_metrics_current_view" */
+  metrics: Array<Org_Metrics_Current_View>;
+  /** fetch aggregated fields from the table: "org_metrics_current_view" */
+  metricsAggregate: Org_Metrics_Current_View_Aggregate;
+  /** fetch data from the table: "models" using primary key columns */
+  model?: Maybe<Models>;
+  /** fetch data from the table: "model_data_sources" using primary key columns */
+  modelDataSource?: Maybe<Model_Data_Sources>;
+  /** fetch data from the table: "model_data_sources" */
+  modelDataSources: Array<Model_Data_Sources>;
+  /** fetch aggregated fields from the table: "model_data_sources" */
+  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
+  /** fetch data from the table: "model_metrics" using primary key columns */
+  modelMetric?: Maybe<Model_Metrics>;
+  /** fetch data from the table: "model_metrics" */
+  modelMetrics: Array<Model_Metrics>;
+  /** fetch aggregated fields from the table: "model_metrics" */
+  modelMetricsAggregate: Model_Metrics_Aggregate;
+  /** fetch data from the table: "model_current" */
+  model_current: Array<Model_Current>;
+  /** fetch data from the table: "models" */
+  models: Array<Models>;
+  /** fetch aggregated fields from the table: "models" */
+  modelsAggregate: Models_Aggregate;
+  /** fetch data from the table: "mql_heartbeats" using primary key columns */
+  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
+  /** fetch data from the table: "mql_heartbeats" */
+  mqlHeartbeats: Array<Mql_Heartbeats>;
+  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
+  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
+  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
+  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
+  /** execute function "my_org" which returns "organizations" */
+  my_org: Array<Organizations>;
+  /** fetch data from the table: "org_mql_servers" using primary key columns */
+  orgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** fetch data from the table: "org_mql_servers" */
+  orgMqlServers: Array<Org_Mql_Servers>;
+  /** fetch aggregated fields from the table: "org_mql_servers" */
+  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
+  /** fetch data from the table: "organizations" using primary key columns */
+  organization?: Maybe<Organizations>;
+  /** fetch data from the table: "organization_features" using primary key columns */
+  organizationFeature?: Maybe<Organization_Features>;
+  /** fetch data from the table: "organization_features" */
+  organizationFeatures: Array<Organization_Features>;
+  /** fetch aggregated fields from the table: "organization_features" */
+  organizationFeaturesAggregate: Organization_Features_Aggregate;
+  /** fetch data from the table: "organizations" */
+  organizations: Array<Organizations>;
+  /** fetch data from the table: "priorities" */
+  priorities: Array<Priorities>;
+  /** fetch data from the table: "priorities" using primary key columns */
+  priorities_by_pk?: Maybe<Priorities>;
+  /** fetch data from the table: "questions" using primary key columns */
+  question?: Maybe<Questions>;
+  /** fetch data from the table: "question_directed_to" */
+  questionDirectedTo: Array<Question_Directed_To>;
+  /** fetch aggregated fields from the table: "question_directed_to" */
+  questionDirectedToAggregate: Question_Directed_To_Aggregate;
+  /** fetch data from the table: "question_directed_to" using primary key columns */
+  questionDirectedToByPK?: Maybe<Question_Directed_To>;
+  /** fetch data from the table: "question_likes" using primary key columns */
+  questionLike?: Maybe<Question_Likes>;
+  /** fetch data from the table: "question_likes" */
+  questionLikes: Array<Question_Likes>;
+  /** fetch aggregated fields from the table: "question_likes" */
+  questionLikesAggregate: Question_Likes_Aggregate;
+  /** fetch data from the table: "question_replies" */
+  questionReplies: Array<Question_Replies>;
+  /** fetch aggregated fields from the table: "question_replies" */
+  questionRepliesAggregate: Question_Replies_Aggregate;
+  /** fetch data from the table: "question_replies" using primary key columns */
+  questionReply?: Maybe<Question_Replies>;
+  /** fetch data from the table: "questions" */
+  questions: Array<Questions>;
+  /** fetch aggregated fields from the table: "questions" */
+  questionsAggregate: Questions_Aggregate;
+  /** fetch data from the table: "saved_queries" */
+  savedQueries: Array<Saved_Queries>;
+  /** fetch aggregated fields from the table: "saved_queries" */
+  savedQueriesAggregate: Saved_Queries_Aggregate;
+  /** fetch data from the table: "saved_queries" using primary key columns */
+  savedQuery?: Maybe<Saved_Queries>;
+  /** fetch data from the table: "saved_query_metrics" using primary key columns */
+  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** fetch data from the table: "saved_query_metrics" */
+  savedQueryMetrics: Array<Saved_Query_Metrics>;
+  /** fetch aggregated fields from the table: "saved_query_metrics" */
+  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
+  /** fetch data from the table: "teams" using primary key columns */
+  team?: Maybe<Teams>;
+  /** fetch data from the table: "team_dashboards" using primary key columns */
+  teamDashboard?: Maybe<Team_Dashboards>;
+  /** fetch data from the table: "team_dashboards" */
+  teamDashboards: Array<Team_Dashboards>;
+  /** fetch aggregated fields from the table: "team_dashboards" */
+  teamDashboardsAggregate: Team_Dashboards_Aggregate;
+  /** fetch data from the table: "team_members" using primary key columns */
+  teamMember?: Maybe<Team_Members>;
+  /** fetch data from the table: "team_members" */
+  teamMembers: Array<Team_Members>;
+  /** fetch aggregated fields from the table: "team_members" */
+  teamMembersAggregate: Team_Members_Aggregate;
+  /** fetch data from the table: "team_views" */
+  team_views: Array<Team_Views>;
+  /** fetch data from the table: "team_views" using primary key columns */
+  team_views_by_pk?: Maybe<Team_Views>;
+  /** fetch data from the table: "teams" */
+  teams: Array<Teams>;
+  /** fetch aggregated fields from the table: "teams" */
+  teamsAggregate: Teams_Aggregate;
+  /** fetch data from the table: "users" using primary key columns */
+  user?: Maybe<Users>;
+  /** fetch data from the table: "user_features" using primary key columns */
+  userFeature?: Maybe<User_Features>;
+  /** fetch data from the table: "user_features" */
+  userFeatures: Array<User_Features>;
+  /** fetch aggregated fields from the table: "user_features" */
+  userFeaturesAggregate: User_Features_Aggregate;
+  /** fetch data from the table: "user_prefs" using primary key columns */
+  userPreference?: Maybe<User_Prefs>;
+  /** fetch data from the table: "user_prefs" */
+  userPreferences: Array<User_Prefs>;
+  /** fetch aggregated fields from the table: "user_prefs" */
+  userPreferencesAggregate: User_Prefs_Aggregate;
+  /** fetch data from the table: "user_roles" using primary key columns */
+  userRole?: Maybe<User_Roles>;
+  /** fetch data from the table: "user_roles" */
+  userRoles: Array<User_Roles>;
+  /** fetch aggregated fields from the table: "user_roles" */
+  userRolesAggregate: User_Roles_Aggregate;
+  /** fetch data from the table: "users" */
+  users: Array<Users>;
+  /** fetch aggregated fields from the table: "users" */
+  usersAggregate: Users_Aggregate;
+};
+
+
+/** subscription root */
+export type SubscriptionAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionApiKeyArgs = {
+  prefix: Scalars['String'];
+};
+
+
+/** subscription root */
+export type SubscriptionApiKeysArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionApiKeysAggregateArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardItemConfigArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardItemConfigsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardItemConfigsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardSectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardSectionsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardSectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardsArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceVersionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceVersionsArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionFeatureArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionFeaturesArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMeArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMe_AggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricApprovalArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricApprovalsArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricApprovalsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricByIdTempArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionMetricsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionViewArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionViewAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCurrentDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricDescriptionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricDescriptionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricTeamOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricTeamOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricTeamOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricUserOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricUserOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricUserOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricVersionArgs = {
+  id: Scalars['bigint'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricVersionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricViewsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Current_Description_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Lineage_Data_SourcesArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Lineage_Data_Sources_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Lineage_Data_Sources_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelArgs = {
+  id: Scalars['bigint'];
+};
+
+
+/** subscription root */
+export type SubscriptionModelDataSourceArgs = {
+  dataSourceVersionId: Scalars['Int'];
+  modelId: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionModelDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelMetricArgs = {
+  metricId: Scalars['bigint'];
+  metricVersionId: Scalars['bigint'];
+  modelId: Scalars['bigint'];
+};
+
+
+/** subscription root */
+export type SubscriptionModelMetricsArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModel_CurrentArgs = {
+  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Current_Order_By>>;
+  where?: Maybe<Model_Current_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelsArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelsAggregateArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMqlHeartbeatArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMqlHeartbeatsArgs = {
+  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
+  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMy_Most_Viewed_MetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMy_Most_Viewed_Metrics_AggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMy_OrgArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrgMqlServerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionOrgMqlServersArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrgMqlServersAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationFeatureArgs = {
+  featureId: Scalars['Int'];
+  organizationId: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationFeaturesArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationsArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionPrioritiesArgs = {
+  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Priorities_Order_By>>;
+  where?: Maybe<Priorities_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionPriorities_By_PkArgs = {
+  value: Scalars['String'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionDirectedToArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionDirectedToAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionDirectedToByPkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionLikeArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionLikesArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionLikesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionRepliesArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionRepliesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionReplyArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionsArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueriesArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueriesAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryMetricsArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamDashboardArgs = {
+  dashboardId: Scalars['Int'];
+  team_id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamDashboardsArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamMemberArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamMembersArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamMembersAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeam_ViewsArgs = {
+  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Views_Order_By>>;
+  where?: Maybe<Team_Views_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeam_Views_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamsArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamsAggregateArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserFeatureArgs = {
+  featureId: Scalars['Int'];
+  userId: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserFeaturesArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserPreferenceArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserPreferencesArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserPreferencesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserRoleArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserRolesArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserRolesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUsersArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUsersAggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
 };
 
 export type AddUserRoleInput = {
@@ -141,42 +3963,6 @@ export type MqlServerVersion = {
   versionHash?: Maybe<Scalars['String']>;
 };
 
-/** Base mutation object exposed by GraphQL. */
-export type Mutation = {
-  __typename?: 'Mutation';
-  logMqlLog?: Maybe<LogMqlLogs>;
-};
-
-
-/** Base mutation object exposed by GraphQL. */
-export type MutationLogMqlLogArgs = {
-  level?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<Scalars['String']>>;
-};
-
-/**
- * Base Query object exposed by GraphQL.
- *
- * Each field defined below is accessible by the API, by calling the equivalent resolver.
- */
-export type Query = {
-  __typename?: 'Query';
-  auth0Profile?: Maybe<Auth0Profile>;
-  latestMqlServer?: Maybe<MqlServerVersion>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-};
-
-
-/**
- * Base Query object exposed by GraphQL.
- *
- * Each field defined below is accessible by the API, by calling the equivalent resolver.
- */
-export type QueryAuth0ProfileArgs = {
-  auth0Id: Scalars['String'];
-};
-
 export type ReactivateUserInput = {
   userId: Scalars['Int'];
 };
@@ -252,17 +4038,12 @@ export type Annotations = {
   __typename?: 'annotations';
   /** An object relationship */
   author: Users;
-  authorId: Scalars['Int'];
   /** Timestamp indicating when the `Annotation` was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
   /** Last date when the `Annotation`  applies */
   dateEndedAt?: Maybe<Scalars['date']>;
   /** Date when the `Annotation` first applies */
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  /** Soft delete mechanism for an Annotation. Rows with non-null values are omitted from list results. */
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   /** A qualitative assessment of the expected impact helps contextualize the annotation for future consumers. */
   expectedImpact: Scalars['String'];
   /** ID field to identify an Annotation */
@@ -271,14 +4052,11 @@ export type Annotations = {
   metricAnnotations: Array<Metric_Annotations>;
   /** An aggregated array relationship */
   metricAnnotations_aggregate: Metric_Annotations_Aggregate;
-  notified_at?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   priority?: Maybe<Priorities_Enum>;
   /** The full description of an annotation with the complete context needed to understand what took place. */
   text: Scalars['String'];
-  timestamp_created?: Maybe<Scalars['Int']>;
   /** A short title to identify the annotation in a list view or tooltip */
   title: Scalars['String'];
   /** Timestamp indicating when the `Annotation` was last updated. */
@@ -369,18 +4147,12 @@ export type Annotations_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Annotations_Avg_Fields = {
   __typename?: 'annotations_avg_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "annotations" */
 export type Annotations_Avg_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "annotations". All fields are combined with a logical 'AND'. */
@@ -389,22 +4161,15 @@ export type Annotations_Bool_Exp = {
   _not?: Maybe<Annotations_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Annotations_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   dateEndedAt?: Maybe<Date_Comparison_Exp>;
   dateStartedAt?: Maybe<Date_Comparison_Exp>;
-  date_end?: Maybe<String_Comparison_Exp>;
-  date_start?: Maybe<String_Comparison_Exp>;
-  deletedAt?: Maybe<Timestamptz_Comparison_Exp>;
   expectedImpact?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metricAnnotations?: Maybe<Metric_Annotations_Bool_Exp>;
-  notified_at?: Maybe<Timestamptz_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   priority?: Maybe<Priorities_Enum_Comparison_Exp>;
   text?: Maybe<String_Comparison_Exp>;
-  timestamp_created?: Maybe<Int_Comparison_Exp>;
   title?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
 };
@@ -415,72 +4180,39 @@ export enum Annotations_Constraint {
   AnnotationsPkey = 'annotations_pkey'
 }
 
-/** input type for incrementing integer column in table "annotations" */
-export type Annotations_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "annotations" */
 export type Annotations_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
   metricAnnotations?: Maybe<Metric_Annotations_Arr_Rel_Insert_Input>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Annotations_Max_Fields = {
   __typename?: 'annotations_max_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "annotations" */
 export type Annotations_Max_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   dateEndedAt?: Maybe<Order_By>;
   dateStartedAt?: Maybe<Order_By>;
-  date_end?: Maybe<Order_By>;
-  date_start?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   expectedImpact?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -488,38 +4220,24 @@ export type Annotations_Max_Order_By = {
 /** aggregate min on columns */
 export type Annotations_Min_Fields = {
   __typename?: 'annotations_min_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "annotations" */
 export type Annotations_Min_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   dateEndedAt?: Maybe<Order_By>;
   dateStartedAt?: Maybe<Order_By>;
-  date_end?: Maybe<Order_By>;
-  date_start?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   expectedImpact?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -549,22 +4267,15 @@ export type Annotations_On_Conflict = {
 /** ordering options when selecting data from "annotations" */
 export type Annotations_Order_By = {
   author?: Maybe<Users_Order_By>;
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   dateEndedAt?: Maybe<Order_By>;
   dateStartedAt?: Maybe<Order_By>;
-  date_end?: Maybe<Order_By>;
-  date_start?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   expectedImpact?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricAnnotations_aggregate?: Maybe<Metric_Annotations_Aggregate_Order_By>;
-  notified_at?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   priority?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -578,33 +4289,19 @@ export type Annotations_Pk_Columns_Input = {
 /** select columns of table "annotations" */
 export enum Annotations_Select_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
   CreatedAt = 'createdAt',
   /** column name */
   DateEndedAt = 'dateEndedAt',
   /** column name */
   DateStartedAt = 'dateStartedAt',
   /** column name */
-  DateEnd = 'date_end',
-  /** column name */
-  DateStart = 'date_start',
-  /** column name */
-  DeletedAt = 'deletedAt',
-  /** column name */
   ExpectedImpact = 'expectedImpact',
   /** column name */
   Id = 'id',
   /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   Priority = 'priority',
   /** column name */
   Text = 'text',
-  /** column name */
-  TimestampCreated = 'timestamp_created',
   /** column name */
   Title = 'title',
   /** column name */
@@ -613,177 +4310,108 @@ export enum Annotations_Select_Column {
 
 /** input type for updating data in table "annotations" */
 export type Annotations_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Annotations_Stddev_Fields = {
   __typename?: 'annotations_stddev_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "annotations" */
 export type Annotations_Stddev_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Annotations_Stddev_Pop_Fields = {
   __typename?: 'annotations_stddev_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "annotations" */
 export type Annotations_Stddev_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Annotations_Stddev_Samp_Fields = {
   __typename?: 'annotations_stddev_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "annotations" */
 export type Annotations_Stddev_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Annotations_Sum_Fields = {
   __typename?: 'annotations_sum_fields';
-  authorId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "annotations" */
 export type Annotations_Sum_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** update columns of table "annotations" */
 export enum Annotations_Update_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
   DateEndedAt = 'dateEndedAt',
   /** column name */
   DateStartedAt = 'dateStartedAt',
-  /** column name */
-  DateEnd = 'date_end',
-  /** column name */
-  DateStart = 'date_start',
   /** column name */
   DeletedAt = 'deletedAt',
   /** column name */
   ExpectedImpact = 'expectedImpact',
   /** column name */
-  Id = 'id',
-  /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   Priority = 'priority',
   /** column name */
   Text = 'text',
   /** column name */
-  TimestampCreated = 'timestamp_created',
-  /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
 export type Annotations_Var_Pop_Fields = {
   __typename?: 'annotations_var_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "annotations" */
 export type Annotations_Var_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Annotations_Var_Samp_Fields = {
   __typename?: 'annotations_var_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "annotations" */
 export type Annotations_Var_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Annotations_Variance_Fields = {
   __typename?: 'annotations_variance_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "annotations" */
 export type Annotations_Variance_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /**
@@ -796,29 +4424,22 @@ export type Api_Keys = {
   __typename?: 'api_keys';
   /** A timestamp for when the `APIKey` was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
   /** A timestamp for the last time the `ApiKey` was used. */
   lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** The first few characters of the `ApiKey`. Useful for identifying the key without revealing it entirely. */
   prefix: Scalars['String'];
   /** If the `ApiKey` has been revoked (soft deleted), this is the timestamp for when it was revoked. */
   revokedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   revoker?: Maybe<Users>;
-  revokerId?: Maybe<Scalars['Int']>;
   scope?: Maybe<Scalars['String']>;
-  secretHash: Scalars['String'];
   type: Scalars['String'];
   /** A timestamp for the last time the `ApiKey` was used. */
   updatedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   user: Users;
-  userId: Scalars['Int'];
 };
 
 /** aggregated selection of "api_keys" */
@@ -831,17 +4452,9 @@ export type Api_Keys_Aggregate = {
 /** aggregate fields of "api_keys" */
 export type Api_Keys_Aggregate_Fields = {
   __typename?: 'api_keys_aggregate_fields';
-  avg?: Maybe<Api_Keys_Avg_Fields>;
   count?: Maybe<Scalars['Int']>;
   max?: Maybe<Api_Keys_Max_Fields>;
   min?: Maybe<Api_Keys_Min_Fields>;
-  stddev?: Maybe<Api_Keys_Stddev_Fields>;
-  stddev_pop?: Maybe<Api_Keys_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Api_Keys_Stddev_Samp_Fields>;
-  sum?: Maybe<Api_Keys_Sum_Fields>;
-  var_pop?: Maybe<Api_Keys_Var_Pop_Fields>;
-  var_samp?: Maybe<Api_Keys_Var_Samp_Fields>;
-  variance?: Maybe<Api_Keys_Variance_Fields>;
 };
 
 
@@ -853,44 +4466,9 @@ export type Api_Keys_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "api_keys" */
 export type Api_Keys_Aggregate_Order_By = {
-  avg?: Maybe<Api_Keys_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Api_Keys_Max_Order_By>;
   min?: Maybe<Api_Keys_Min_Order_By>;
-  stddev?: Maybe<Api_Keys_Stddev_Order_By>;
-  stddev_pop?: Maybe<Api_Keys_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Api_Keys_Stddev_Samp_Order_By>;
-  sum?: Maybe<Api_Keys_Sum_Order_By>;
-  var_pop?: Maybe<Api_Keys_Var_Pop_Order_By>;
-  var_samp?: Maybe<Api_Keys_Var_Samp_Order_By>;
-  variance?: Maybe<Api_Keys_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "api_keys" */
-export type Api_Keys_Arr_Rel_Insert_Input = {
-  data: Array<Api_Keys_Insert_Input>;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Api_Keys_Avg_Fields = {
-  __typename?: 'api_keys_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "api_keys" */
-export type Api_Keys_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "api_keys". All fields are combined with a logical 'AND'. */
@@ -899,22 +4477,15 @@ export type Api_Keys_Bool_Exp = {
   _not?: Maybe<Api_Keys_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Api_Keys_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
-  date_revoked?: Maybe<Int_Comparison_Exp>;
   lastUsedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  last_used_ts?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   prefix?: Maybe<String_Comparison_Exp>;
   revokedAt?: Maybe<Timestamptz_Comparison_Exp>;
   revoker?: Maybe<Users_Bool_Exp>;
-  revokerId?: Maybe<Int_Comparison_Exp>;
   scope?: Maybe<String_Comparison_Exp>;
-  secretHash?: Maybe<String_Comparison_Exp>;
   type?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "api_keys" */
@@ -923,109 +4494,50 @@ export enum Api_Keys_Constraint {
   ApiKeysPkey = 'api_keys_pkey'
 }
 
-/** input type for incrementing integer column in table "api_keys" */
-export type Api_Keys_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  revokerId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "api_keys" */
-export type Api_Keys_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  prefix?: Maybe<Scalars['String']>;
-  revokedAt?: Maybe<Scalars['timestamptz']>;
-  revoker?: Maybe<Users_Obj_Rel_Insert_Input>;
-  revokerId?: Maybe<Scalars['Int']>;
-  scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** aggregate max on columns */
 export type Api_Keys_Max_Fields = {
   __typename?: 'api_keys_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
   lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefix?: Maybe<Scalars['String']>;
   revokedAt?: Maybe<Scalars['timestamptz']>;
-  revokerId?: Maybe<Scalars['Int']>;
   scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "api_keys" */
 export type Api_Keys_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
   lastUsedAt?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   prefix?: Maybe<Order_By>;
   revokedAt?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
   scope?: Maybe<Order_By>;
-  secretHash?: Maybe<Order_By>;
   type?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Api_Keys_Min_Fields = {
   __typename?: 'api_keys_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
   lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefix?: Maybe<Scalars['String']>;
   revokedAt?: Maybe<Scalars['timestamptz']>;
-  revokerId?: Maybe<Scalars['Int']>;
   scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "api_keys" */
 export type Api_Keys_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
   lastUsedAt?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   prefix?: Maybe<Order_By>;
   revokedAt?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
   scope?: Maybe<Order_By>;
-  secretHash?: Maybe<Order_By>;
   type?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "api_keys" */
@@ -1035,12 +4547,6 @@ export type Api_Keys_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Api_Keys>;
-};
-
-/** input type for inserting object relation for remote table "api_keys" */
-export type Api_Keys_Obj_Rel_Insert_Input = {
-  data: Api_Keys_Insert_Input;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
 };
 
 /** on conflict condition type for table "api_keys" */
@@ -1053,22 +4559,15 @@ export type Api_Keys_On_Conflict = {
 /** ordering options when selecting data from "api_keys" */
 export type Api_Keys_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
   lastUsedAt?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   prefix?: Maybe<Order_By>;
   revokedAt?: Maybe<Order_By>;
   revoker?: Maybe<Users_Order_By>;
-  revokerId?: Maybe<Order_By>;
   scope?: Maybe<Order_By>;
-  secretHash?: Maybe<Order_By>;
   type?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "api_keys" */
@@ -1082,229 +4581,29 @@ export enum Api_Keys_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateRevoked = 'date_revoked',
-  /** column name */
   LastUsedAt = 'lastUsedAt',
-  /** column name */
-  LastUsedTs = 'last_used_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   Prefix = 'prefix',
   /** column name */
   RevokedAt = 'revokedAt',
   /** column name */
-  RevokerId = 'revokerId',
-  /** column name */
   Scope = 'scope',
-  /** column name */
-  SecretHash = 'secretHash',
   /** column name */
   Type = 'type',
   /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  UpdatedAt = 'updatedAt'
 }
 
 /** input type for updating data in table "api_keys" */
 export type Api_Keys_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  prefix?: Maybe<Scalars['String']>;
   revokedAt?: Maybe<Scalars['timestamptz']>;
-  revokerId?: Maybe<Scalars['Int']>;
-  scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Api_Keys_Stddev_Fields = {
-  __typename?: 'api_keys_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "api_keys" */
-export type Api_Keys_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Api_Keys_Stddev_Pop_Fields = {
-  __typename?: 'api_keys_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "api_keys" */
-export type Api_Keys_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Api_Keys_Stddev_Samp_Fields = {
-  __typename?: 'api_keys_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "api_keys" */
-export type Api_Keys_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Api_Keys_Sum_Fields = {
-  __typename?: 'api_keys_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  revokerId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "api_keys" */
-export type Api_Keys_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** update columns of table "api_keys" */
 export enum Api_Keys_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateRevoked = 'date_revoked',
-  /** column name */
-  LastUsedAt = 'lastUsedAt',
-  /** column name */
-  LastUsedTs = 'last_used_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Prefix = 'prefix',
-  /** column name */
-  RevokedAt = 'revokedAt',
-  /** column name */
-  RevokerId = 'revokerId',
-  /** column name */
-  Scope = 'scope',
-  /** column name */
-  SecretHash = 'secretHash',
-  /** column name */
-  Type = 'type',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  RevokedAt = 'revokedAt'
 }
-
-/** aggregate var_pop on columns */
-export type Api_Keys_Var_Pop_Fields = {
-  __typename?: 'api_keys_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "api_keys" */
-export type Api_Keys_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Api_Keys_Var_Samp_Fields = {
-  __typename?: 'api_keys_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "api_keys" */
-export type Api_Keys_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Api_Keys_Variance_Fields = {
-  __typename?: 'api_keys_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "api_keys" */
-export type Api_Keys_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
 
 
 /** expression to compare columns of type bigint. All fields are combined with logical 'AND'. */
@@ -1320,304 +4619,6 @@ export type Bigint_Comparison_Exp = {
   _nin?: Maybe<Array<Scalars['bigint']>>;
 };
 
-/** columns and relationships of "branch_metadatas" */
-export type Branch_Metadatas = {
-  __typename?: 'branch_metadatas';
-  commit: Scalars['String'];
-  id: Scalars['Int'];
-  model_key: Scalars['String'];
-  timestamp: Scalars['Int'];
-};
-
-/** aggregated selection of "branch_metadatas" */
-export type Branch_Metadatas_Aggregate = {
-  __typename?: 'branch_metadatas_aggregate';
-  aggregate?: Maybe<Branch_Metadatas_Aggregate_Fields>;
-  nodes: Array<Branch_Metadatas>;
-};
-
-/** aggregate fields of "branch_metadatas" */
-export type Branch_Metadatas_Aggregate_Fields = {
-  __typename?: 'branch_metadatas_aggregate_fields';
-  avg?: Maybe<Branch_Metadatas_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Branch_Metadatas_Max_Fields>;
-  min?: Maybe<Branch_Metadatas_Min_Fields>;
-  stddev?: Maybe<Branch_Metadatas_Stddev_Fields>;
-  stddev_pop?: Maybe<Branch_Metadatas_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Branch_Metadatas_Stddev_Samp_Fields>;
-  sum?: Maybe<Branch_Metadatas_Sum_Fields>;
-  var_pop?: Maybe<Branch_Metadatas_Var_Pop_Fields>;
-  var_samp?: Maybe<Branch_Metadatas_Var_Samp_Fields>;
-  variance?: Maybe<Branch_Metadatas_Variance_Fields>;
-};
-
-
-/** aggregate fields of "branch_metadatas" */
-export type Branch_Metadatas_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "branch_metadatas" */
-export type Branch_Metadatas_Aggregate_Order_By = {
-  avg?: Maybe<Branch_Metadatas_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Branch_Metadatas_Max_Order_By>;
-  min?: Maybe<Branch_Metadatas_Min_Order_By>;
-  stddev?: Maybe<Branch_Metadatas_Stddev_Order_By>;
-  stddev_pop?: Maybe<Branch_Metadatas_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Branch_Metadatas_Stddev_Samp_Order_By>;
-  sum?: Maybe<Branch_Metadatas_Sum_Order_By>;
-  var_pop?: Maybe<Branch_Metadatas_Var_Pop_Order_By>;
-  var_samp?: Maybe<Branch_Metadatas_Var_Samp_Order_By>;
-  variance?: Maybe<Branch_Metadatas_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "branch_metadatas" */
-export type Branch_Metadatas_Arr_Rel_Insert_Input = {
-  data: Array<Branch_Metadatas_Insert_Input>;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Branch_Metadatas_Avg_Fields = {
-  __typename?: 'branch_metadatas_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "branch_metadatas". All fields are combined with a logical 'AND'. */
-export type Branch_Metadatas_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Branch_Metadatas_Bool_Exp>>>;
-  _not?: Maybe<Branch_Metadatas_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Branch_Metadatas_Bool_Exp>>>;
-  commit?: Maybe<String_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
-  model_key?: Maybe<String_Comparison_Exp>;
-  timestamp?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "branch_metadatas" */
-export enum Branch_Metadatas_Constraint {
-  /** unique or primary key constraint */
-  BranchMetadatasPkey = 'branch_metadatas_pkey',
-  /** unique or primary key constraint */
-  IxBranchMetadatasModelKey = 'ix_branch_metadatas_model_key'
-}
-
-/** input type for incrementing integer column in table "branch_metadatas" */
-export type Branch_Metadatas_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "branch_metadatas" */
-export type Branch_Metadatas_Insert_Input = {
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type Branch_Metadatas_Max_Fields = {
-  __typename?: 'branch_metadatas_max_fields';
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Max_Order_By = {
-  commit?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  model_key?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Branch_Metadatas_Min_Fields = {
-  __typename?: 'branch_metadatas_min_fields';
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Min_Order_By = {
-  commit?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  model_key?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "branch_metadatas" */
-export type Branch_Metadatas_Mutation_Response = {
-  __typename?: 'branch_metadatas_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Branch_Metadatas>;
-};
-
-/** input type for inserting object relation for remote table "branch_metadatas" */
-export type Branch_Metadatas_Obj_Rel_Insert_Input = {
-  data: Branch_Metadatas_Insert_Input;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-/** on conflict condition type for table "branch_metadatas" */
-export type Branch_Metadatas_On_Conflict = {
-  constraint: Branch_Metadatas_Constraint;
-  update_columns: Array<Branch_Metadatas_Update_Column>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "branch_metadatas" */
-export type Branch_Metadatas_Order_By = {
-  commit?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  model_key?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "branch_metadatas" */
-export type Branch_Metadatas_Pk_Columns_Input = {
-  id: Scalars['Int'];
-};
-
-/** select columns of table "branch_metadatas" */
-export enum Branch_Metadatas_Select_Column {
-  /** column name */
-  Commit = 'commit',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  ModelKey = 'model_key',
-  /** column name */
-  Timestamp = 'timestamp'
-}
-
-/** input type for updating data in table "branch_metadatas" */
-export type Branch_Metadatas_Set_Input = {
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Branch_Metadatas_Stddev_Fields = {
-  __typename?: 'branch_metadatas_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Branch_Metadatas_Stddev_Pop_Fields = {
-  __typename?: 'branch_metadatas_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Branch_Metadatas_Stddev_Samp_Fields = {
-  __typename?: 'branch_metadatas_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Branch_Metadatas_Sum_Fields = {
-  __typename?: 'branch_metadatas_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** update columns of table "branch_metadatas" */
-export enum Branch_Metadatas_Update_Column {
-  /** column name */
-  Commit = 'commit',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  ModelKey = 'model_key',
-  /** column name */
-  Timestamp = 'timestamp'
-}
-
-/** aggregate var_pop on columns */
-export type Branch_Metadatas_Var_Pop_Fields = {
-  __typename?: 'branch_metadatas_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Branch_Metadatas_Var_Samp_Fields = {
-  __typename?: 'branch_metadatas_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Branch_Metadatas_Variance_Fields = {
-  __typename?: 'branch_metadatas_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
 /**
  * Dashboard Item Configs are the inputs that configure a DashboardItem.
  *
@@ -1629,7 +4630,6 @@ export type Dashboard_Item_Configs = {
   dashboardRenderableType: Dashboard_Renderable_Types_Enum;
   /** An object relationship */
   dashboardSection: Dashboard_Sections;
-  dashboardSectionId: Scalars['Int'];
   id: Scalars['Int'];
   /** An object relationship */
   metricCollection?: Maybe<Metric_Collections>;
@@ -1700,7 +4700,6 @@ export type Dashboard_Item_Configs_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Dashboard_Item_Configs_Avg_Fields = {
   __typename?: 'dashboard_item_configs_avg_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1711,7 +4710,6 @@ export type Dashboard_Item_Configs_Avg_Fields = {
 
 /** order by avg() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Avg_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1727,7 +4725,6 @@ export type Dashboard_Item_Configs_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Dashboard_Item_Configs_Bool_Exp>>>;
   dashboardRenderableType?: Maybe<Dashboard_Renderable_Types_Enum_Comparison_Exp>;
   dashboardSection?: Maybe<Dashboard_Sections_Bool_Exp>;
-  dashboardSectionId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metricCollection?: Maybe<Metric_Collections_Bool_Exp>;
   metricCollectionId?: Maybe<Int_Comparison_Exp>;
@@ -1750,7 +4747,6 @@ export enum Dashboard_Item_Configs_Constraint {
 /** input type for incrementing integer column in table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Inc_Input = {
   dashboardSectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
@@ -1763,7 +4759,6 @@ export type Dashboard_Item_Configs_Insert_Input = {
   dashboardRenderableType?: Maybe<Dashboard_Renderable_Types_Enum>;
   dashboardSection?: Maybe<Dashboard_Sections_Obj_Rel_Insert_Input>;
   dashboardSectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1779,7 +4774,6 @@ export type Dashboard_Item_Configs_Insert_Input = {
 /** aggregate max on columns */
 export type Dashboard_Item_Configs_Max_Fields = {
   __typename?: 'dashboard_item_configs_max_fields';
-  dashboardSectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1792,7 +4786,6 @@ export type Dashboard_Item_Configs_Max_Fields = {
 
 /** order by max() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Max_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1806,7 +4799,6 @@ export type Dashboard_Item_Configs_Max_Order_By = {
 /** aggregate min on columns */
 export type Dashboard_Item_Configs_Min_Fields = {
   __typename?: 'dashboard_item_configs_min_fields';
-  dashboardSectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1819,7 +4811,6 @@ export type Dashboard_Item_Configs_Min_Fields = {
 
 /** order by min() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Min_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1856,7 +4847,6 @@ export type Dashboard_Item_Configs_On_Conflict = {
 export type Dashboard_Item_Configs_Order_By = {
   dashboardRenderableType?: Maybe<Order_By>;
   dashboardSection?: Maybe<Dashboard_Sections_Order_By>;
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollection?: Maybe<Metric_Collections_Order_By>;
   metricCollectionId?: Maybe<Order_By>;
@@ -1880,8 +4870,6 @@ export enum Dashboard_Item_Configs_Select_Column {
   /** column name */
   DashboardRenderableType = 'dashboardRenderableType',
   /** column name */
-  DashboardSectionId = 'dashboardSectionId',
-  /** column name */
   Id = 'id',
   /** column name */
   MetricCollectionId = 'metricCollectionId',
@@ -1903,7 +4891,6 @@ export enum Dashboard_Item_Configs_Select_Column {
 export type Dashboard_Item_Configs_Set_Input = {
   dashboardRenderableType?: Maybe<Dashboard_Renderable_Types_Enum>;
   dashboardSectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
@@ -1916,7 +4903,6 @@ export type Dashboard_Item_Configs_Set_Input = {
 /** aggregate stddev on columns */
 export type Dashboard_Item_Configs_Stddev_Fields = {
   __typename?: 'dashboard_item_configs_stddev_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1927,7 +4913,6 @@ export type Dashboard_Item_Configs_Stddev_Fields = {
 
 /** order by stddev() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Stddev_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1939,7 +4924,6 @@ export type Dashboard_Item_Configs_Stddev_Order_By = {
 /** aggregate stddev_pop on columns */
 export type Dashboard_Item_Configs_Stddev_Pop_Fields = {
   __typename?: 'dashboard_item_configs_stddev_pop_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1950,7 +4934,6 @@ export type Dashboard_Item_Configs_Stddev_Pop_Fields = {
 
 /** order by stddev_pop() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Stddev_Pop_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1962,7 +4945,6 @@ export type Dashboard_Item_Configs_Stddev_Pop_Order_By = {
 /** aggregate stddev_samp on columns */
 export type Dashboard_Item_Configs_Stddev_Samp_Fields = {
   __typename?: 'dashboard_item_configs_stddev_samp_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1973,7 +4955,6 @@ export type Dashboard_Item_Configs_Stddev_Samp_Fields = {
 
 /** order by stddev_samp() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Stddev_Samp_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1985,7 +4966,6 @@ export type Dashboard_Item_Configs_Stddev_Samp_Order_By = {
 /** aggregate sum on columns */
 export type Dashboard_Item_Configs_Sum_Fields = {
   __typename?: 'dashboard_item_configs_sum_fields';
-  dashboardSectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1996,7 +4976,6 @@ export type Dashboard_Item_Configs_Sum_Fields = {
 
 /** order by sum() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Sum_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2011,8 +4990,6 @@ export enum Dashboard_Item_Configs_Update_Column {
   DashboardRenderableType = 'dashboardRenderableType',
   /** column name */
   DashboardSectionId = 'dashboardSectionId',
-  /** column name */
-  Id = 'id',
   /** column name */
   MetricCollectionId = 'metricCollectionId',
   /** column name */
@@ -2032,7 +5009,6 @@ export enum Dashboard_Item_Configs_Update_Column {
 /** aggregate var_pop on columns */
 export type Dashboard_Item_Configs_Var_Pop_Fields = {
   __typename?: 'dashboard_item_configs_var_pop_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -2043,7 +5019,6 @@ export type Dashboard_Item_Configs_Var_Pop_Fields = {
 
 /** order by var_pop() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Var_Pop_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2055,7 +5030,6 @@ export type Dashboard_Item_Configs_Var_Pop_Order_By = {
 /** aggregate var_samp on columns */
 export type Dashboard_Item_Configs_Var_Samp_Fields = {
   __typename?: 'dashboard_item_configs_var_samp_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -2066,7 +5040,6 @@ export type Dashboard_Item_Configs_Var_Samp_Fields = {
 
 /** order by var_samp() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Var_Samp_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2078,7 +5051,6 @@ export type Dashboard_Item_Configs_Var_Samp_Order_By = {
 /** aggregate variance on columns */
 export type Dashboard_Item_Configs_Variance_Fields = {
   __typename?: 'dashboard_item_configs_variance_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -2089,7 +5061,6 @@ export type Dashboard_Item_Configs_Variance_Fields = {
 
 /** order by variance() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Variance_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2097,68 +5068,6 @@ export type Dashboard_Item_Configs_Variance_Order_By = {
   teamId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
-
-/**
- * Enum for the possible layouts for a Dashboard
- *
- *
- * columns and relationships of "dashboard_layouts"
- */
-export type Dashboard_Layouts = {
-  __typename?: 'dashboard_layouts';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate = {
-  __typename?: 'dashboard_layouts_aggregate';
-  aggregate?: Maybe<Dashboard_Layouts_Aggregate_Fields>;
-  nodes: Array<Dashboard_Layouts>;
-};
-
-/** aggregate fields of "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate_Fields = {
-  __typename?: 'dashboard_layouts_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dashboard_Layouts_Max_Fields>;
-  min?: Maybe<Dashboard_Layouts_Min_Fields>;
-};
-
-
-/** aggregate fields of "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dashboard_Layouts_Max_Order_By>;
-  min?: Maybe<Dashboard_Layouts_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dashboard_layouts" */
-export type Dashboard_Layouts_Arr_Rel_Insert_Input = {
-  data: Array<Dashboard_Layouts_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dashboard_layouts". All fields are combined with a logical 'AND'. */
-export type Dashboard_Layouts_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dashboard_Layouts_Bool_Exp>>>;
-  _not?: Maybe<Dashboard_Layouts_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dashboard_Layouts_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dashboard_layouts" */
-export enum Dashboard_Layouts_Constraint {
-  /** unique or primary key constraint */
-  DashboardLayoutsPkey = 'dashboard_layouts_pkey'
-}
 
 export enum Dashboard_Layouts_Enum {
   /** This version has a side panel that collapses on small breakpoint. */
@@ -2175,155 +5084,6 @@ export type Dashboard_Layouts_Enum_Comparison_Exp = {
   _neq?: Maybe<Dashboard_Layouts_Enum>;
   _nin?: Maybe<Array<Dashboard_Layouts_Enum>>;
 };
-
-/** input type for inserting data into table "dashboard_layouts" */
-export type Dashboard_Layouts_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dashboard_Layouts_Max_Fields = {
-  __typename?: 'dashboard_layouts_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dashboard_layouts" */
-export type Dashboard_Layouts_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dashboard_Layouts_Min_Fields = {
-  __typename?: 'dashboard_layouts_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dashboard_layouts" */
-export type Dashboard_Layouts_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dashboard_layouts" */
-export type Dashboard_Layouts_Mutation_Response = {
-  __typename?: 'dashboard_layouts_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dashboard_Layouts>;
-};
-
-/** input type for inserting object relation for remote table "dashboard_layouts" */
-export type Dashboard_Layouts_Obj_Rel_Insert_Input = {
-  data: Dashboard_Layouts_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-/** on conflict condition type for table "dashboard_layouts" */
-export type Dashboard_Layouts_On_Conflict = {
-  constraint: Dashboard_Layouts_Constraint;
-  update_columns: Array<Dashboard_Layouts_Update_Column>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dashboard_layouts" */
-export type Dashboard_Layouts_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dashboard_layouts" */
-export type Dashboard_Layouts_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dashboard_layouts" */
-export enum Dashboard_Layouts_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dashboard_layouts" */
-export type Dashboard_Layouts_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dashboard_layouts" */
-export enum Dashboard_Layouts_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/**
- * Enum for Dashboard Renderable components. Note: It is expected that this be replaced by an Interface shortly.
- *
- *
- * columns and relationships of "dashboard_renderable_types"
- */
-export type Dashboard_Renderable_Types = {
-  __typename?: 'dashboard_renderable_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate = {
-  __typename?: 'dashboard_renderable_types_aggregate';
-  aggregate?: Maybe<Dashboard_Renderable_Types_Aggregate_Fields>;
-  nodes: Array<Dashboard_Renderable_Types>;
-};
-
-/** aggregate fields of "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate_Fields = {
-  __typename?: 'dashboard_renderable_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dashboard_Renderable_Types_Max_Fields>;
-  min?: Maybe<Dashboard_Renderable_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dashboard_Renderable_Types_Max_Order_By>;
-  min?: Maybe<Dashboard_Renderable_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Arr_Rel_Insert_Input = {
-  data: Array<Dashboard_Renderable_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dashboard_renderable_types". All fields are combined with a logical 'AND'. */
-export type Dashboard_Renderable_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dashboard_Renderable_Types_Bool_Exp>>>;
-  _not?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dashboard_Renderable_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dashboard_renderable_types" */
-export enum Dashboard_Renderable_Types_Constraint {
-  /** unique or primary key constraint */
-  DashboardRenderableTypesPkey = 'dashboard_renderable_types_pkey'
-}
 
 export enum Dashboard_Renderable_Types_Enum {
   /** Banners can let users know what's happening or be used as a page title. */
@@ -2353,155 +5113,6 @@ export type Dashboard_Renderable_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Dashboard_Renderable_Types_Enum>>;
 };
 
-/** input type for inserting data into table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dashboard_Renderable_Types_Max_Fields = {
-  __typename?: 'dashboard_renderable_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dashboard_Renderable_Types_Min_Fields = {
-  __typename?: 'dashboard_renderable_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Mutation_Response = {
-  __typename?: 'dashboard_renderable_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dashboard_Renderable_Types>;
-};
-
-/** input type for inserting object relation for remote table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Obj_Rel_Insert_Input = {
-  data: Dashboard_Renderable_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_On_Conflict = {
-  constraint: Dashboard_Renderable_Types_Constraint;
-  update_columns: Array<Dashboard_Renderable_Types_Update_Column>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dashboard_renderable_types" */
-export enum Dashboard_Renderable_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dashboard_renderable_types" */
-export enum Dashboard_Renderable_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/**
- * An Enum for the various Section Types on a Dashboard
- *
- *
- * columns and relationships of "dashboard_section_types"
- */
-export type Dashboard_Section_Types = {
-  __typename?: 'dashboard_section_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate = {
-  __typename?: 'dashboard_section_types_aggregate';
-  aggregate?: Maybe<Dashboard_Section_Types_Aggregate_Fields>;
-  nodes: Array<Dashboard_Section_Types>;
-};
-
-/** aggregate fields of "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate_Fields = {
-  __typename?: 'dashboard_section_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dashboard_Section_Types_Max_Fields>;
-  min?: Maybe<Dashboard_Section_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dashboard_Section_Types_Max_Order_By>;
-  min?: Maybe<Dashboard_Section_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dashboard_section_types" */
-export type Dashboard_Section_Types_Arr_Rel_Insert_Input = {
-  data: Array<Dashboard_Section_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dashboard_section_types". All fields are combined with a logical 'AND'. */
-export type Dashboard_Section_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dashboard_Section_Types_Bool_Exp>>>;
-  _not?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dashboard_Section_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dashboard_section_types" */
-export enum Dashboard_Section_Types_Constraint {
-  /** unique or primary key constraint */
-  DashboardSectionTypesPkey = 'dashboard_section_types_pkey'
-}
-
 export enum Dashboard_Section_Types_Enum {
   /** The Header appears at the top of the Dashboard and remains sticky during scrolling. */
   Header = 'HEADER',
@@ -2520,93 +5131,6 @@ export type Dashboard_Section_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Dashboard_Section_Types_Enum>>;
 };
 
-/** input type for inserting data into table "dashboard_section_types" */
-export type Dashboard_Section_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dashboard_Section_Types_Max_Fields = {
-  __typename?: 'dashboard_section_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dashboard_section_types" */
-export type Dashboard_Section_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dashboard_Section_Types_Min_Fields = {
-  __typename?: 'dashboard_section_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dashboard_section_types" */
-export type Dashboard_Section_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dashboard_section_types" */
-export type Dashboard_Section_Types_Mutation_Response = {
-  __typename?: 'dashboard_section_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dashboard_Section_Types>;
-};
-
-/** input type for inserting object relation for remote table "dashboard_section_types" */
-export type Dashboard_Section_Types_Obj_Rel_Insert_Input = {
-  data: Dashboard_Section_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "dashboard_section_types" */
-export type Dashboard_Section_Types_On_Conflict = {
-  constraint: Dashboard_Section_Types_Constraint;
-  update_columns: Array<Dashboard_Section_Types_Update_Column>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dashboard_section_types" */
-export type Dashboard_Section_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dashboard_section_types" */
-export type Dashboard_Section_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dashboard_section_types" */
-export enum Dashboard_Section_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dashboard_section_types" */
-export type Dashboard_Section_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dashboard_section_types" */
-export enum Dashboard_Section_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
 /**
  * Dashboard Sections are logical groupings of Dashboard Items within the UI. The type specifies where the section appears on the page.
  *
@@ -2623,7 +5147,6 @@ export type Dashboard_Sections = {
   dashboardItemConfigs_aggregate: Dashboard_Item_Configs_Aggregate;
   /** The Section Type indicates the "zone" on page where the section's items will go. */
   dashboardSectionType: Dashboard_Section_Types_Enum;
-  dashboard_id: Scalars['Int'];
   id: Scalars['Int'];
 };
 
@@ -2711,13 +5234,11 @@ export type Dashboard_Sections_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Dashboard_Sections_Avg_Fields = {
   __typename?: 'dashboard_sections_avg_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Avg_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2729,7 +5250,6 @@ export type Dashboard_Sections_Bool_Exp = {
   dashboard?: Maybe<Dashboards_Bool_Exp>;
   dashboardItemConfigs?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
   dashboardSectionType?: Maybe<Dashboard_Section_Types_Enum_Comparison_Exp>;
-  dashboard_id?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
 };
 
@@ -2739,44 +5259,33 @@ export enum Dashboard_Sections_Constraint {
   DashboardSectionsPkey = 'dashboard_sections_pkey'
 }
 
-/** input type for incrementing integer column in table "dashboard_sections" */
-export type Dashboard_Sections_Inc_Input = {
-  dashboard_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "dashboard_sections" */
 export type Dashboard_Sections_Insert_Input = {
   dashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
   dashboardItemConfigs?: Maybe<Dashboard_Item_Configs_Arr_Rel_Insert_Input>;
   dashboardSectionType?: Maybe<Dashboard_Section_Types_Enum>;
   dashboard_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Dashboard_Sections_Max_Fields = {
   __typename?: 'dashboard_sections_max_fields';
-  dashboard_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Max_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Dashboard_Sections_Min_Fields = {
   __typename?: 'dashboard_sections_min_fields';
-  dashboard_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Min_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2807,7 +5316,6 @@ export type Dashboard_Sections_Order_By = {
   dashboard?: Maybe<Dashboards_Order_By>;
   dashboardItemConfigs_aggregate?: Maybe<Dashboard_Item_Configs_Aggregate_Order_By>;
   dashboardSectionType?: Maybe<Order_By>;
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2821,116 +5329,94 @@ export enum Dashboard_Sections_Select_Column {
   /** column name */
   DashboardSectionType = 'dashboardSectionType',
   /** column name */
-  DashboardId = 'dashboard_id',
-  /** column name */
   Id = 'id'
 }
 
 /** input type for updating data in table "dashboard_sections" */
 export type Dashboard_Sections_Set_Input = {
   dashboardSectionType?: Maybe<Dashboard_Section_Types_Enum>;
-  dashboard_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type Dashboard_Sections_Stddev_Fields = {
   __typename?: 'dashboard_sections_stddev_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Stddev_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Dashboard_Sections_Stddev_Pop_Fields = {
   __typename?: 'dashboard_sections_stddev_pop_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Stddev_Pop_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Dashboard_Sections_Stddev_Samp_Fields = {
   __typename?: 'dashboard_sections_stddev_samp_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Stddev_Samp_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Dashboard_Sections_Sum_Fields = {
   __typename?: 'dashboard_sections_sum_fields';
-  dashboard_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Sum_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** update columns of table "dashboard_sections" */
 export enum Dashboard_Sections_Update_Column {
   /** column name */
-  DashboardSectionType = 'dashboardSectionType',
-  /** column name */
-  DashboardId = 'dashboard_id',
-  /** column name */
-  Id = 'id'
+  DashboardSectionType = 'dashboardSectionType'
 }
 
 /** aggregate var_pop on columns */
 export type Dashboard_Sections_Var_Pop_Fields = {
   __typename?: 'dashboard_sections_var_pop_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Var_Pop_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Dashboard_Sections_Var_Samp_Fields = {
   __typename?: 'dashboard_sections_var_samp_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Var_Samp_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Dashboard_Sections_Variance_Fields = {
   __typename?: 'dashboard_sections_variance_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Variance_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2948,11 +5434,9 @@ export type Dashboards = {
   dashboardSections: Array<Dashboard_Sections>;
   /** An aggregated array relationship */
   dashboardSections_aggregate: Dashboard_Sections_Aggregate;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organization_id: Scalars['Int'];
   /** An array relationship */
   teamOwners: Array<Team_Dashboards>;
   /** An aggregated array relationship */
@@ -2960,10 +5444,6 @@ export type Dashboards = {
   /** The Dashboard title appears in the header */
   title: Scalars['String'];
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  /** An array relationship */
-  userOwners: Array<User_Dashboards>;
-  /** An aggregated array relationship */
-  userOwners_aggregate: User_Dashboards_Aggregate;
 };
 
 
@@ -3026,36 +5506,6 @@ export type DashboardsTeamOwners_AggregateArgs = {
   where?: Maybe<Team_Dashboards_Bool_Exp>;
 };
 
-
-/**
- * Dashboards are a foundational tool for building custom pages in the Transform App
- *
- *
- * columns and relationships of "dashboards"
- */
-export type DashboardsUserOwnersArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/**
- * Dashboards are a foundational tool for building custom pages in the Transform App
- *
- *
- * columns and relationships of "dashboards"
- */
-export type DashboardsUserOwners_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
 /** aggregated selection of "dashboards" */
 export type Dashboards_Aggregate = {
   __typename?: 'dashboards_aggregate';
@@ -3111,13 +5561,11 @@ export type Dashboards_Arr_Rel_Insert_Input = {
 export type Dashboards_Avg_Fields = {
   __typename?: 'dashboards_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "dashboards" */
 export type Dashboards_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "dashboards". All fields are combined with a logical 'AND'. */
@@ -3128,14 +5576,11 @@ export type Dashboards_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   dashboardLayout?: Maybe<Dashboard_Layouts_Enum_Comparison_Exp>;
   dashboardSections?: Maybe<Dashboard_Sections_Bool_Exp>;
-  deletedAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
   teamOwners?: Maybe<Team_Dashboards_Bool_Exp>;
   title?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  userOwners?: Maybe<User_Dashboards_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "dashboards" */
@@ -3144,34 +5589,19 @@ export enum Dashboards_Constraint {
   DashboardsPkey = 'dashboards_pkey'
 }
 
-/** input type for incrementing integer column in table "dashboards" */
-export type Dashboards_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "dashboards" */
 export type Dashboards_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dashboardLayout?: Maybe<Dashboard_Layouts_Enum>;
   dashboardSections?: Maybe<Dashboard_Sections_Arr_Rel_Insert_Input>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organization_id?: Maybe<Scalars['Int']>;
   teamOwners?: Maybe<Team_Dashboards_Arr_Rel_Insert_Input>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userOwners?: Maybe<User_Dashboards_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Dashboards_Max_Fields = {
   __typename?: 'dashboards_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -3179,9 +5609,7 @@ export type Dashboards_Max_Fields = {
 /** order by max() on columns of table "dashboards" */
 export type Dashboards_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -3190,9 +5618,7 @@ export type Dashboards_Max_Order_By = {
 export type Dashboards_Min_Fields = {
   __typename?: 'dashboards_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -3200,9 +5626,7 @@ export type Dashboards_Min_Fields = {
 /** order by min() on columns of table "dashboards" */
 export type Dashboards_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -3234,14 +5658,11 @@ export type Dashboards_Order_By = {
   createdAt?: Maybe<Order_By>;
   dashboardLayout?: Maybe<Order_By>;
   dashboardSections_aggregate?: Maybe<Dashboard_Sections_Aggregate_Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organization_id?: Maybe<Order_By>;
   teamOwners_aggregate?: Maybe<Team_Dashboards_Aggregate_Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  userOwners_aggregate?: Maybe<User_Dashboards_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: "dashboards" */
@@ -3256,11 +5677,7 @@ export enum Dashboards_Select_Column {
   /** column name */
   DashboardLayout = 'dashboardLayout',
   /** column name */
-  DeletedAt = 'deletedAt',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
   /** column name */
   Title = 'title',
   /** column name */
@@ -3269,122 +5686,96 @@ export enum Dashboards_Select_Column {
 
 /** input type for updating data in table "dashboards" */
 export type Dashboards_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dashboardLayout?: Maybe<Dashboard_Layouts_Enum>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Dashboards_Stddev_Fields = {
   __typename?: 'dashboards_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "dashboards" */
 export type Dashboards_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Dashboards_Stddev_Pop_Fields = {
   __typename?: 'dashboards_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "dashboards" */
 export type Dashboards_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Dashboards_Stddev_Samp_Fields = {
   __typename?: 'dashboards_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "dashboards" */
 export type Dashboards_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Dashboards_Sum_Fields = {
   __typename?: 'dashboards_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "dashboards" */
 export type Dashboards_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** update columns of table "dashboards" */
 export enum Dashboards_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
   DashboardLayout = 'dashboardLayout',
   /** column name */
   DeletedAt = 'deletedAt',
   /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
 export type Dashboards_Var_Pop_Fields = {
   __typename?: 'dashboards_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "dashboards" */
 export type Dashboards_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Dashboards_Var_Samp_Fields = {
   __typename?: 'dashboards_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "dashboards" */
 export type Dashboards_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Dashboards_Variance_Fields = {
   __typename?: 'dashboards_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "dashboards" */
 export type Dashboards_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "data_source_versions" */
@@ -3413,7 +5804,6 @@ export type Data_Source_Versions = {
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
-  owners: Scalars['json'];
   sqlQuery?: Maybe<Scalars['String']>;
   sqlTable?: Maybe<Scalars['String']>;
 };
@@ -3494,12 +5884,6 @@ export type Data_Source_VersionsMutabilityArgs = {
   path?: Maybe<Scalars['String']>;
 };
 
-
-/** columns and relationships of "data_source_versions" */
-export type Data_Source_VersionsOwnersArgs = {
-  path?: Maybe<Scalars['String']>;
-};
-
 /** aggregated selection of "data_source_versions" */
 export type Data_Source_Versions_Aggregate = {
   __typename?: 'data_source_versions_aggregate';
@@ -3545,12 +5929,6 @@ export type Data_Source_Versions_Aggregate_Order_By = {
   variance?: Maybe<Data_Source_Versions_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "data_source_versions" */
-export type Data_Source_Versions_Arr_Rel_Insert_Input = {
-  data: Array<Data_Source_Versions_Insert_Input>;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Data_Source_Versions_Avg_Fields = {
   __typename?: 'data_source_versions_avg_fields';
@@ -3585,46 +5963,8 @@ export type Data_Source_Versions_Bool_Exp = {
   name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
-  owners?: Maybe<Json_Comparison_Exp>;
   sqlQuery?: Maybe<String_Comparison_Exp>;
   sqlTable?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "data_source_versions" */
-export enum Data_Source_Versions_Constraint {
-  /** unique or primary key constraint */
-  DataSourceVersionsHashOrganizationIdKey = 'data_source_versions_hash_organization_id_key',
-  /** unique or primary key constraint */
-  DataSourceVersionsPkey = 'data_source_versions_pkey'
-}
-
-/** input type for incrementing integer column in table "data_source_versions" */
-export type Data_Source_Versions_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "data_source_versions" */
-export type Data_Source_Versions_Insert_Input = {
-  connection?: Maybe<Scalars['String']>;
-  constraint?: Maybe<Scalars['json']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceMetadata?: Maybe<Scalars['json']>;
-  description?: Maybe<Scalars['String']>;
-  dimensions?: Maybe<Scalars['json']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  identifiers?: Maybe<Scalars['json']>;
-  measures?: Maybe<Scalars['json']>;
-  metricVersions?: Maybe<Metric_Lineage_Data_Sources_Arr_Rel_Insert_Input>;
-  modelDataSources?: Maybe<Model_Data_Sources_Arr_Rel_Insert_Input>;
-  mutability?: Maybe<Scalars['json']>;
-  name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  owners?: Maybe<Scalars['json']>;
-  sqlQuery?: Maybe<Scalars['String']>;
-  sqlTable?: Maybe<Scalars['String']>;
 };
 
 /** aggregate max on columns */
@@ -3681,28 +6021,6 @@ export type Data_Source_Versions_Min_Order_By = {
   sqlTable?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "data_source_versions" */
-export type Data_Source_Versions_Mutation_Response = {
-  __typename?: 'data_source_versions_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Data_Source_Versions>;
-};
-
-/** input type for inserting object relation for remote table "data_source_versions" */
-export type Data_Source_Versions_Obj_Rel_Insert_Input = {
-  data: Data_Source_Versions_Insert_Input;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
-/** on conflict condition type for table "data_source_versions" */
-export type Data_Source_Versions_On_Conflict = {
-  constraint: Data_Source_Versions_Constraint;
-  update_columns: Array<Data_Source_Versions_Update_Column>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "data_source_versions" */
 export type Data_Source_Versions_Order_By = {
   connection?: Maybe<Order_By>;
@@ -3721,7 +6039,6 @@ export type Data_Source_Versions_Order_By = {
   name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
-  owners?: Maybe<Order_By>;
   sqlQuery?: Maybe<Order_By>;
   sqlTable?: Maybe<Order_By>;
 };
@@ -3760,32 +6077,10 @@ export enum Data_Source_Versions_Select_Column {
   /** column name */
   OrganizationId = 'organizationId',
   /** column name */
-  Owners = 'owners',
-  /** column name */
   SqlQuery = 'sqlQuery',
   /** column name */
   SqlTable = 'sqlTable'
 }
-
-/** input type for updating data in table "data_source_versions" */
-export type Data_Source_Versions_Set_Input = {
-  connection?: Maybe<Scalars['String']>;
-  constraint?: Maybe<Scalars['json']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceMetadata?: Maybe<Scalars['json']>;
-  description?: Maybe<Scalars['String']>;
-  dimensions?: Maybe<Scalars['json']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  identifiers?: Maybe<Scalars['json']>;
-  measures?: Maybe<Scalars['json']>;
-  mutability?: Maybe<Scalars['json']>;
-  name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  owners?: Maybe<Scalars['json']>;
-  sqlQuery?: Maybe<Scalars['String']>;
-  sqlTable?: Maybe<Scalars['String']>;
-};
 
 /** aggregate stddev on columns */
 export type Data_Source_Versions_Stddev_Fields = {
@@ -3839,42 +6134,6 @@ export type Data_Source_Versions_Sum_Order_By = {
   organizationId?: Maybe<Order_By>;
 };
 
-/** update columns of table "data_source_versions" */
-export enum Data_Source_Versions_Update_Column {
-  /** column name */
-  Connection = 'connection',
-  /** column name */
-  Constraint = 'constraint',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DataSourceMetadata = 'dataSourceMetadata',
-  /** column name */
-  Description = 'description',
-  /** column name */
-  Dimensions = 'dimensions',
-  /** column name */
-  Hash = 'hash',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Identifiers = 'identifiers',
-  /** column name */
-  Measures = 'measures',
-  /** column name */
-  Mutability = 'mutability',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Owners = 'owners',
-  /** column name */
-  SqlQuery = 'sqlQuery',
-  /** column name */
-  SqlTable = 'sqlTable'
-}
-
 /** aggregate var_pop on columns */
 export type Data_Source_Versions_Var_Pop_Fields = {
   __typename?: 'data_source_versions_var_pop_fields';
@@ -3926,192 +6185,6 @@ export type Date_Comparison_Exp = {
   _lte?: Maybe<Scalars['date']>;
   _neq?: Maybe<Scalars['date']>;
   _nin?: Maybe<Array<Scalars['date']>>;
-};
-
-/** columns and relationships of "dw_engines" */
-export type Dw_Engines = {
-  __typename?: 'dw_engines';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dw_engines" */
-export type Dw_Engines_Aggregate = {
-  __typename?: 'dw_engines_aggregate';
-  aggregate?: Maybe<Dw_Engines_Aggregate_Fields>;
-  nodes: Array<Dw_Engines>;
-};
-
-/** aggregate fields of "dw_engines" */
-export type Dw_Engines_Aggregate_Fields = {
-  __typename?: 'dw_engines_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dw_Engines_Max_Fields>;
-  min?: Maybe<Dw_Engines_Min_Fields>;
-};
-
-
-/** aggregate fields of "dw_engines" */
-export type Dw_Engines_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dw_Engines_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dw_engines" */
-export type Dw_Engines_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dw_Engines_Max_Order_By>;
-  min?: Maybe<Dw_Engines_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dw_engines" */
-export type Dw_Engines_Arr_Rel_Insert_Input = {
-  data: Array<Dw_Engines_Insert_Input>;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dw_engines". All fields are combined with a logical 'AND'. */
-export type Dw_Engines_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dw_Engines_Bool_Exp>>>;
-  _not?: Maybe<Dw_Engines_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dw_Engines_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dw_engines" */
-export enum Dw_Engines_Constraint {
-  /** unique or primary key constraint */
-  DwEnginesPkey = 'dw_engines_pkey'
-}
-
-export enum Dw_Engines_Enum {
-  /** Data Bricks */
-  Databricks = 'DATABRICKS',
-  /** Livy */
-  Livy = 'LIVY',
-  /** mysql */
-  Mysql = 'MYSQL',
-  /** postgresql */
-  Postgresql = 'POSTGRESQL',
-  /** Presto Hive */
-  PrestoHive = 'PRESTO_HIVE',
-  /** Redshift */
-  Redshift = 'REDSHIFT',
-  /** Snowflake */
-  Snowflake = 'SNOWFLAKE',
-  /** sqlite */
-  Sqlite = 'SQLITE'
-}
-
-/** expression to compare columns of type dw_engines_enum. All fields are combined with logical 'AND'. */
-export type Dw_Engines_Enum_Comparison_Exp = {
-  _eq?: Maybe<Dw_Engines_Enum>;
-  _in?: Maybe<Array<Dw_Engines_Enum>>;
-  _is_null?: Maybe<Scalars['Boolean']>;
-  _neq?: Maybe<Dw_Engines_Enum>;
-  _nin?: Maybe<Array<Dw_Engines_Enum>>;
-};
-
-/** input type for inserting data into table "dw_engines" */
-export type Dw_Engines_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dw_Engines_Max_Fields = {
-  __typename?: 'dw_engines_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dw_engines" */
-export type Dw_Engines_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dw_Engines_Min_Fields = {
-  __typename?: 'dw_engines_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dw_engines" */
-export type Dw_Engines_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dw_engines" */
-export type Dw_Engines_Mutation_Response = {
-  __typename?: 'dw_engines_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dw_Engines>;
-};
-
-/** input type for inserting object relation for remote table "dw_engines" */
-export type Dw_Engines_Obj_Rel_Insert_Input = {
-  data: Dw_Engines_Insert_Input;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-/** on conflict condition type for table "dw_engines" */
-export type Dw_Engines_On_Conflict = {
-  constraint: Dw_Engines_Constraint;
-  update_columns: Array<Dw_Engines_Update_Column>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dw_engines" */
-export type Dw_Engines_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dw_engines" */
-export type Dw_Engines_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dw_engines" */
-export enum Dw_Engines_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dw_engines" */
-export type Dw_Engines_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dw_engines" */
-export enum Dw_Engines_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-
-/** expression to compare columns of type entity. All fields are combined with logical 'AND'. */
-export type Entity_Comparison_Exp = {
-  _eq?: Maybe<Scalars['entity']>;
-  _gt?: Maybe<Scalars['entity']>;
-  _gte?: Maybe<Scalars['entity']>;
-  _in?: Maybe<Array<Scalars['entity']>>;
-  _is_null?: Maybe<Scalars['Boolean']>;
-  _lt?: Maybe<Scalars['entity']>;
-  _lte?: Maybe<Scalars['entity']>;
-  _neq?: Maybe<Scalars['entity']>;
-  _nin?: Maybe<Array<Scalars['entity']>>;
 };
 
 /** columns and relationships of "features" */
@@ -4217,12 +6290,6 @@ export type Features_Aggregate_Order_By = {
   variance?: Maybe<Features_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "features" */
-export type Features_Arr_Rel_Insert_Input = {
-  data: Array<Features_Insert_Input>;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Features_Avg_Fields = {
   __typename?: 'features_avg_fields';
@@ -4246,28 +6313,6 @@ export type Features_Bool_Exp = {
   retiredAt?: Maybe<Timestamptz_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   users?: Maybe<User_Features_Bool_Exp>;
-};
-
-/** unique or primary key constraints on table "features" */
-export enum Features_Constraint {
-  /** unique or primary key constraint */
-  FeaturesPkey = 'features_pkey'
-}
-
-/** input type for incrementing integer column in table "features" */
-export type Features_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "features" */
-export type Features_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organizations?: Maybe<Organization_Features_Arr_Rel_Insert_Input>;
-  retiredAt?: Maybe<Scalars['timestamptz']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  users?: Maybe<User_Features_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -4308,28 +6353,6 @@ export type Features_Min_Order_By = {
   updatedAt?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "features" */
-export type Features_Mutation_Response = {
-  __typename?: 'features_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Features>;
-};
-
-/** input type for inserting object relation for remote table "features" */
-export type Features_Obj_Rel_Insert_Input = {
-  data: Features_Insert_Input;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
-/** on conflict condition type for table "features" */
-export type Features_On_Conflict = {
-  constraint: Features_Constraint;
-  update_columns: Array<Features_Update_Column>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "features" */
 export type Features_Order_By = {
   createdAt?: Maybe<Order_By>;
@@ -4359,15 +6382,6 @@ export enum Features_Select_Column {
   /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "features" */
-export type Features_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  retiredAt?: Maybe<Scalars['timestamptz']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Features_Stddev_Fields = {
@@ -4412,20 +6426,6 @@ export type Features_Sum_Fields = {
 export type Features_Sum_Order_By = {
   id?: Maybe<Order_By>;
 };
-
-/** update columns of table "features" */
-export enum Features_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  RetiredAt = 'retiredAt',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
 
 /** aggregate var_pop on columns */
 export type Features_Var_Pop_Fields = {
@@ -4503,19 +6503,13 @@ export type Metric_Annotations = {
   __typename?: 'metric_annotations';
   /** An object relationship */
   annotation: Annotations;
-  annotationId: Scalars['Int'];
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name: Scalars['String'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregated selection of "metric_annotations" */
@@ -4572,18 +6566,12 @@ export type Metric_Annotations_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Metric_Annotations_Avg_Fields = {
   __typename?: 'metric_annotations_avg_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_annotations" */
 export type Metric_Annotations_Avg_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_annotations". All fields are combined with a logical 'AND'. */
@@ -4592,17 +6580,11 @@ export type Metric_Annotations_Bool_Exp = {
   _not?: Maybe<Metric_Annotations_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Annotations_Bool_Exp>>>;
   annotation?: Maybe<Annotations_Bool_Exp>;
-  annotationId?: Maybe<Int_Comparison_Exp>;
-  created_at?: Maybe<Timestamptz_Comparison_Exp>;
   dimensionName?: Maybe<String_Comparison_Exp>;
   dimensionValue?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-  updated_at?: Maybe<Timestamptz_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "metric_annotations" */
@@ -4614,79 +6596,47 @@ export enum Metric_Annotations_Constraint {
 /** input type for incrementing integer column in table "metric_annotations" */
 export type Metric_Annotations_Inc_Input = {
   annotationId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_annotations" */
 export type Metric_Annotations_Insert_Input = {
   annotation?: Maybe<Annotations_Obj_Rel_Insert_Input>;
   annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
   metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Annotations_Max_Fields = {
   __typename?: 'metric_annotations_max_fields';
-  annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "metric_annotations" */
 export type Metric_Annotations_Max_Order_By = {
-  annotationId?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
   dimensionName?: Maybe<Order_By>;
   dimensionValue?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updated_at?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Annotations_Min_Fields = {
   __typename?: 'metric_annotations_min_fields';
-  annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "metric_annotations" */
 export type Metric_Annotations_Min_Order_By = {
-  annotationId?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
   dimensionName?: Maybe<Order_By>;
   dimensionValue?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updated_at?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_annotations" */
@@ -4714,17 +6664,11 @@ export type Metric_Annotations_On_Conflict = {
 /** ordering options when selecting data from "metric_annotations" */
 export type Metric_Annotations_Order_By = {
   annotation?: Maybe<Annotations_Order_By>;
-  annotationId?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
   dimensionName?: Maybe<Order_By>;
   dimensionValue?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updated_at?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_annotations" */
@@ -4735,104 +6679,63 @@ export type Metric_Annotations_Pk_Columns_Input = {
 /** select columns of table "metric_annotations" */
 export enum Metric_Annotations_Select_Column {
   /** column name */
-  AnnotationId = 'annotationId',
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
   DimensionName = 'dimensionName',
   /** column name */
   DimensionValue = 'dimensionValue',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updated_at'
+  Id = 'id'
 }
 
 /** input type for updating data in table "metric_annotations" */
 export type Metric_Annotations_Set_Input = {
   annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Metric_Annotations_Stddev_Fields = {
   __typename?: 'metric_annotations_stddev_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_annotations" */
 export type Metric_Annotations_Stddev_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Annotations_Stddev_Pop_Fields = {
   __typename?: 'metric_annotations_stddev_pop_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_annotations" */
 export type Metric_Annotations_Stddev_Pop_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Annotations_Stddev_Samp_Fields = {
   __typename?: 'metric_annotations_stddev_samp_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_annotations" */
 export type Metric_Annotations_Stddev_Samp_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Annotations_Sum_Fields = {
   __typename?: 'metric_annotations_sum_fields';
-  annotationId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_annotations" */
 export type Metric_Annotations_Sum_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** update columns of table "metric_annotations" */
@@ -4840,91 +6743,58 @@ export enum Metric_Annotations_Update_Column {
   /** column name */
   AnnotationId = 'annotationId',
   /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
   DimensionName = 'dimensionName',
   /** column name */
   DimensionValue = 'dimensionValue',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updated_at'
+  MetricId = 'metricId'
 }
 
 /** aggregate var_pop on columns */
 export type Metric_Annotations_Var_Pop_Fields = {
   __typename?: 'metric_annotations_var_pop_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_annotations" */
 export type Metric_Annotations_Var_Pop_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Annotations_Var_Samp_Fields = {
   __typename?: 'metric_annotations_var_samp_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_annotations" */
 export type Metric_Annotations_Var_Samp_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Annotations_Variance_Fields = {
   __typename?: 'metric_annotations_variance_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_annotations" */
 export type Metric_Annotations_Variance_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "metric_approvals" */
 export type Metric_Approvals = {
   __typename?: 'metric_approvals';
-  approval_ts?: Maybe<Scalars['Int']>;
   /** Timestamp indicating when the approval was created */
   approvedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   approver: Users;
-  approverId: Scalars['Int'];
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_approvals" */
@@ -4975,26 +6845,17 @@ export type Metric_Approvals_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_approvals" */
 export type Metric_Approvals_Arr_Rel_Insert_Input = {
   data: Array<Metric_Approvals_Insert_Input>;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_Approvals_Avg_Fields = {
   __typename?: 'metric_approvals_avg_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_approvals" */
 export type Metric_Approvals_Avg_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_approvals". All fields are combined with a logical 'AND'. */
@@ -5002,91 +6863,43 @@ export type Metric_Approvals_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Metric_Approvals_Bool_Exp>>>;
   _not?: Maybe<Metric_Approvals_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Approvals_Bool_Exp>>>;
-  approval_ts?: Maybe<Int_Comparison_Exp>;
   approvedAt?: Maybe<Timestamptz_Comparison_Exp>;
   approver?: Maybe<Users_Bool_Exp>;
-  approverId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_approvals" */
-export enum Metric_Approvals_Constraint {
-  /** unique or primary key constraint */
-  MetricApprovalsPkey = 'metric_approvals_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_approvals" */
-export type Metric_Approvals_Inc_Input = {
-  approval_ts?: Maybe<Scalars['Int']>;
-  approverId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_approvals" */
 export type Metric_Approvals_Insert_Input = {
-  approval_ts?: Maybe<Scalars['Int']>;
-  approvedAt?: Maybe<Scalars['timestamptz']>;
   approver?: Maybe<Users_Obj_Rel_Insert_Input>;
-  approverId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Approvals_Max_Fields = {
   __typename?: 'metric_approvals_max_fields';
-  approval_ts?: Maybe<Scalars['Int']>;
   approvedAt?: Maybe<Scalars['timestamptz']>;
-  approverId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_approvals" */
 export type Metric_Approvals_Max_Order_By = {
-  approval_ts?: Maybe<Order_By>;
   approvedAt?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Approvals_Min_Fields = {
   __typename?: 'metric_approvals_min_fields';
-  approval_ts?: Maybe<Scalars['Int']>;
   approvedAt?: Maybe<Scalars['timestamptz']>;
-  approverId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_approvals" */
 export type Metric_Approvals_Min_Order_By = {
-  approval_ts?: Maybe<Order_By>;
   approvedAt?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_approvals" */
@@ -5101,28 +6914,15 @@ export type Metric_Approvals_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_approvals" */
 export type Metric_Approvals_Obj_Rel_Insert_Input = {
   data: Metric_Approvals_Insert_Input;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_approvals" */
-export type Metric_Approvals_On_Conflict = {
-  constraint: Metric_Approvals_Constraint;
-  update_columns: Array<Metric_Approvals_Update_Column>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_approvals" */
 export type Metric_Approvals_Order_By = {
-  approval_ts?: Maybe<Order_By>;
   approvedAt?: Maybe<Order_By>;
   approver?: Maybe<Users_Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_approvals" */
@@ -5133,181 +6933,86 @@ export type Metric_Approvals_Pk_Columns_Input = {
 /** select columns of table "metric_approvals" */
 export enum Metric_Approvals_Select_Column {
   /** column name */
-  ApprovalTs = 'approval_ts',
-  /** column name */
   ApprovedAt = 'approvedAt',
   /** column name */
-  ApproverId = 'approverId',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_approvals" */
-export type Metric_Approvals_Set_Input = {
-  approval_ts?: Maybe<Scalars['Int']>;
-  approvedAt?: Maybe<Scalars['timestamptz']>;
-  approverId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Approvals_Stddev_Fields = {
   __typename?: 'metric_approvals_stddev_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_approvals" */
 export type Metric_Approvals_Stddev_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Approvals_Stddev_Pop_Fields = {
   __typename?: 'metric_approvals_stddev_pop_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_approvals" */
 export type Metric_Approvals_Stddev_Pop_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Approvals_Stddev_Samp_Fields = {
   __typename?: 'metric_approvals_stddev_samp_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_approvals" */
 export type Metric_Approvals_Stddev_Samp_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Approvals_Sum_Fields = {
   __typename?: 'metric_approvals_sum_fields';
-  approval_ts?: Maybe<Scalars['Int']>;
-  approverId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_approvals" */
 export type Metric_Approvals_Sum_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_approvals" */
-export enum Metric_Approvals_Update_Column {
-  /** column name */
-  ApprovalTs = 'approval_ts',
-  /** column name */
-  ApprovedAt = 'approvedAt',
-  /** column name */
-  ApproverId = 'approverId',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_Approvals_Var_Pop_Fields = {
   __typename?: 'metric_approvals_var_pop_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_approvals" */
 export type Metric_Approvals_Var_Pop_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Approvals_Var_Samp_Fields = {
   __typename?: 'metric_approvals_var_samp_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_approvals" */
 export type Metric_Approvals_Var_Samp_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Approvals_Variance_Fields = {
   __typename?: 'metric_approvals_variance_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_approvals" */
 export type Metric_Approvals_Variance_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /**
@@ -5327,8 +7032,6 @@ export type Metric_Collection_Metrics = {
   metric: Org_Metrics_Current_View;
   /** An object relationship */
   metricCollection: Metric_Collections;
-  metricCollectionId: Scalars['Int'];
-  metricId: Scalars['Int'];
   /** Integer used for ordering Metrics within a Metric Collection */
   position: Scalars['Int'];
   /** Timestamp indicating when the record was last updated */
@@ -5391,8 +7094,6 @@ export type Metric_Collection_Metrics_Avg_Fields = {
   __typename?: 'metric_collection_metrics_avg_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5400,8 +7101,6 @@ export type Metric_Collection_Metrics_Avg_Fields = {
 export type Metric_Collection_Metrics_Avg_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5415,8 +7114,6 @@ export type Metric_Collection_Metrics_Bool_Exp = {
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
   metricCollection?: Maybe<Metric_Collections_Bool_Exp>;
-  metricCollectionId?: Maybe<Int_Comparison_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   position?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
 };
@@ -5432,23 +7129,16 @@ export enum Metric_Collection_Metrics_Constraint {
 /** input type for incrementing integer column in table "metric_collection_metrics" */
 export type Metric_Collection_Metrics_Inc_Input = {
   emphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_collection_metrics" */
 export type Metric_Collection_Metrics_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricCollection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -5457,8 +7147,6 @@ export type Metric_Collection_Metrics_Max_Fields = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -5468,8 +7156,6 @@ export type Metric_Collection_Metrics_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -5480,8 +7166,6 @@ export type Metric_Collection_Metrics_Min_Fields = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -5491,8 +7175,6 @@ export type Metric_Collection_Metrics_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -5526,8 +7208,6 @@ export type Metric_Collection_Metrics_Order_By = {
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
   metricCollection?: Maybe<Metric_Collections_Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -5546,10 +7226,6 @@ export enum Metric_Collection_Metrics_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  MetricCollectionId = 'metricCollectionId',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
   Position = 'position',
   /** column name */
   UpdatedAt = 'updatedAt'
@@ -5557,13 +7233,8 @@ export enum Metric_Collection_Metrics_Select_Column {
 
 /** input type for updating data in table "metric_collection_metrics" */
 export type Metric_Collection_Metrics_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
@@ -5571,8 +7242,6 @@ export type Metric_Collection_Metrics_Stddev_Fields = {
   __typename?: 'metric_collection_metrics_stddev_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5580,8 +7249,6 @@ export type Metric_Collection_Metrics_Stddev_Fields = {
 export type Metric_Collection_Metrics_Stddev_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5590,8 +7257,6 @@ export type Metric_Collection_Metrics_Stddev_Pop_Fields = {
   __typename?: 'metric_collection_metrics_stddev_pop_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5599,8 +7264,6 @@ export type Metric_Collection_Metrics_Stddev_Pop_Fields = {
 export type Metric_Collection_Metrics_Stddev_Pop_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5609,8 +7272,6 @@ export type Metric_Collection_Metrics_Stddev_Samp_Fields = {
   __typename?: 'metric_collection_metrics_stddev_samp_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5618,8 +7279,6 @@ export type Metric_Collection_Metrics_Stddev_Samp_Fields = {
 export type Metric_Collection_Metrics_Stddev_Samp_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5628,8 +7287,6 @@ export type Metric_Collection_Metrics_Sum_Fields = {
   __typename?: 'metric_collection_metrics_sum_fields';
   emphasis?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
 };
 
@@ -5637,27 +7294,15 @@ export type Metric_Collection_Metrics_Sum_Fields = {
 export type Metric_Collection_Metrics_Sum_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
 /** update columns of table "metric_collection_metrics" */
 export enum Metric_Collection_Metrics_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
   Emphasis = 'emphasis',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricCollectionId = 'metricCollectionId',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  Position = 'position',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Position = 'position'
 }
 
 /** aggregate var_pop on columns */
@@ -5665,8 +7310,6 @@ export type Metric_Collection_Metrics_Var_Pop_Fields = {
   __typename?: 'metric_collection_metrics_var_pop_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5674,8 +7317,6 @@ export type Metric_Collection_Metrics_Var_Pop_Fields = {
 export type Metric_Collection_Metrics_Var_Pop_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5684,8 +7325,6 @@ export type Metric_Collection_Metrics_Var_Samp_Fields = {
   __typename?: 'metric_collection_metrics_var_samp_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5693,8 +7332,6 @@ export type Metric_Collection_Metrics_Var_Samp_Fields = {
 export type Metric_Collection_Metrics_Var_Samp_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5703,8 +7340,6 @@ export type Metric_Collection_Metrics_Variance_Fields = {
   __typename?: 'metric_collection_metrics_variance_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5712,8 +7347,6 @@ export type Metric_Collection_Metrics_Variance_Fields = {
 export type Metric_Collection_Metrics_Variance_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5721,12 +7354,8 @@ export type Metric_Collection_Metrics_Variance_Order_By = {
 export type Metric_Collection_View = {
   __typename?: 'metric_collection_view';
   created_at: Scalars['timestamptz'];
-  id: Scalars['Int'];
   /** An object relationship */
   metric_collection?: Maybe<Metric_Collections>;
-  metric_collection_id: Scalars['Int'];
-  organization_id: Scalars['Int'];
-  user_id: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_collection_view" */
@@ -5739,17 +7368,9 @@ export type Metric_Collection_View_Aggregate = {
 /** aggregate fields of "metric_collection_view" */
 export type Metric_Collection_View_Aggregate_Fields = {
   __typename?: 'metric_collection_view_aggregate_fields';
-  avg?: Maybe<Metric_Collection_View_Avg_Fields>;
   count?: Maybe<Scalars['Int']>;
   max?: Maybe<Metric_Collection_View_Max_Fields>;
   min?: Maybe<Metric_Collection_View_Min_Fields>;
-  stddev?: Maybe<Metric_Collection_View_Stddev_Fields>;
-  stddev_pop?: Maybe<Metric_Collection_View_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Metric_Collection_View_Stddev_Samp_Fields>;
-  sum?: Maybe<Metric_Collection_View_Sum_Fields>;
-  var_pop?: Maybe<Metric_Collection_View_Var_Pop_Fields>;
-  var_samp?: Maybe<Metric_Collection_View_Var_Samp_Fields>;
-  variance?: Maybe<Metric_Collection_View_Variance_Fields>;
 };
 
 
@@ -5761,40 +7382,14 @@ export type Metric_Collection_View_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "metric_collection_view" */
 export type Metric_Collection_View_Aggregate_Order_By = {
-  avg?: Maybe<Metric_Collection_View_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Metric_Collection_View_Max_Order_By>;
   min?: Maybe<Metric_Collection_View_Min_Order_By>;
-  stddev?: Maybe<Metric_Collection_View_Stddev_Order_By>;
-  stddev_pop?: Maybe<Metric_Collection_View_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Metric_Collection_View_Stddev_Samp_Order_By>;
-  sum?: Maybe<Metric_Collection_View_Sum_Order_By>;
-  var_pop?: Maybe<Metric_Collection_View_Var_Pop_Order_By>;
-  var_samp?: Maybe<Metric_Collection_View_Var_Samp_Order_By>;
-  variance?: Maybe<Metric_Collection_View_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "metric_collection_view" */
 export type Metric_Collection_View_Arr_Rel_Insert_Input = {
   data: Array<Metric_Collection_View_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Metric_Collection_View_Avg_Fields = {
-  __typename?: 'metric_collection_view_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_collection_view". All fields are combined with a logical 'AND'. */
@@ -5803,73 +7398,35 @@ export type Metric_Collection_View_Bool_Exp = {
   _not?: Maybe<Metric_Collection_View_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Collection_View_Bool_Exp>>>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
   metric_collection?: Maybe<Metric_Collections_Bool_Exp>;
-  metric_collection_id?: Maybe<Int_Comparison_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_collection_view" */
-export enum Metric_Collection_View_Constraint {
-  /** unique or primary key constraint */
-  MetricCollectionViewPkey = 'metric_collection_view_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_collection_view" */
-export type Metric_Collection_View_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_collection_view" */
 export type Metric_Collection_View_Insert_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
   metric_collection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
   metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Collection_View_Max_Fields = {
   __typename?: 'metric_collection_view_max_fields';
   created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_collection_view" */
 export type Metric_Collection_View_Max_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Collection_View_Min_Fields = {
   __typename?: 'metric_collection_view_min_fields';
   created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_collection_view" */
 export type Metric_Collection_View_Min_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_collection_view" */
@@ -5884,24 +7441,12 @@ export type Metric_Collection_View_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_collection_view" */
 export type Metric_Collection_View_Obj_Rel_Insert_Input = {
   data: Metric_Collection_View_Insert_Input;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_collection_view" */
-export type Metric_Collection_View_On_Conflict = {
-  constraint: Metric_Collection_View_Constraint;
-  update_columns: Array<Metric_Collection_View_Update_Column>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_collection_view" */
 export type Metric_Collection_View_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
   metric_collection?: Maybe<Metric_Collections_Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_collection_view" */
@@ -5912,158 +7457,8 @@ export type Metric_Collection_View_Pk_Columns_Input = {
 /** select columns of table "metric_collection_view" */
 export enum Metric_Collection_View_Select_Column {
   /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricCollectionId = 'metric_collection_id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  UserId = 'user_id'
+  CreatedAt = 'created_at'
 }
-
-/** input type for updating data in table "metric_collection_view" */
-export type Metric_Collection_View_Set_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Metric_Collection_View_Stddev_Fields = {
-  __typename?: 'metric_collection_view_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Metric_Collection_View_Stddev_Pop_Fields = {
-  __typename?: 'metric_collection_view_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Metric_Collection_View_Stddev_Samp_Fields = {
-  __typename?: 'metric_collection_view_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Metric_Collection_View_Sum_Fields = {
-  __typename?: 'metric_collection_view_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "metric_collection_view" */
-export enum Metric_Collection_View_Update_Column {
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricCollectionId = 'metric_collection_id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** aggregate var_pop on columns */
-export type Metric_Collection_View_Var_Pop_Fields = {
-  __typename?: 'metric_collection_view_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Metric_Collection_View_Var_Samp_Fields = {
-  __typename?: 'metric_collection_view_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Metric_Collection_View_Variance_Fields = {
-  __typename?: 'metric_collection_view_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
 
 /**
  * Metric Collections are useful groupings of Metrics for analysis and easy filtering
@@ -6274,34 +7669,23 @@ export enum Metric_Collections_Constraint {
 
 /** input type for incrementing integer column in table "metric_collections" */
 export type Metric_Collections_Inc_Input = {
-  createdBy?: Maybe<Scalars['Int']>;
   defaultEmphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_collections" */
 export type Metric_Collections_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   createdByUser?: Maybe<Users_Obj_Rel_Insert_Input>;
   defaultEmphasis?: Maybe<Scalars['Int']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
   metric_collection_views?: Maybe<Metric_Collection_View_Arr_Rel_Insert_Input>;
   metrics?: Maybe<Metric_Collection_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeam?: Maybe<Teams_Obj_Rel_Insert_Input>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   primaryDashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -6449,18 +7833,13 @@ export enum Metric_Collections_Select_Column {
 
 /** input type for updating data in table "metric_collections" */
 export type Metric_Collections_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   defaultEmphasis?: Maybe<Scalars['Int']>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
@@ -6550,19 +7929,11 @@ export type Metric_Collections_Sum_Order_By = {
 /** update columns of table "metric_collections" */
 export enum Metric_Collections_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedBy = 'createdBy',
-  /** column name */
   DefaultEmphasis = 'defaultEmphasis',
   /** column name */
   DeletedAt = 'deletedAt',
   /** column name */
   Description = 'description',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   OwnerTeamId = 'ownerTeamId',
   /** column name */
@@ -6570,9 +7941,7 @@ export enum Metric_Collections_Update_Column {
   /** column name */
   Slug = 'slug',
   /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
@@ -6648,14 +8017,11 @@ export type Metric_Current_Description = {
   __typename?: 'metric_current_description';
   /** An object relationship */
   author?: Maybe<Users>;
-  author_id?: Maybe<Scalars['Int']>;
   created_at?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "metric_current_description" */
@@ -6703,26 +8069,15 @@ export type Metric_Current_Description_Aggregate_Order_By = {
   variance?: Maybe<Metric_Current_Description_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "metric_current_description" */
-export type Metric_Current_Description_Arr_Rel_Insert_Input = {
-  data: Array<Metric_Current_Description_Insert_Input>;
-};
-
 /** aggregate avg on columns */
 export type Metric_Current_Description_Avg_Fields = {
   __typename?: 'metric_current_description_avg_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Avg_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_current_description". All fields are combined with a logical 'AND'. */
@@ -6731,246 +8086,136 @@ export type Metric_Current_Description_Bool_Exp = {
   _not?: Maybe<Metric_Current_Description_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Current_Description_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  author_id?: Maybe<Int_Comparison_Exp>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
   description?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metric_id?: Maybe<Int_Comparison_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** input type for incrementing integer column in table "metric_current_description" */
-export type Metric_Current_Description_Inc_Input = {
-  author_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "metric_current_description" */
-export type Metric_Current_Description_Insert_Input = {
-  author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  author_id?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Current_Description_Max_Fields = {
   __typename?: 'metric_current_description_max_fields';
-  author_id?: Maybe<Scalars['Int']>;
   created_at?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Max_Order_By = {
-  author_id?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Current_Description_Min_Fields = {
   __typename?: 'metric_current_description_min_fields';
-  author_id?: Maybe<Scalars['Int']>;
   created_at?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Min_Order_By = {
-  author_id?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "metric_current_description" */
-export type Metric_Current_Description_Mutation_Response = {
-  __typename?: 'metric_current_description_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Metric_Current_Description>;
-};
-
-/** input type for inserting object relation for remote table "metric_current_description" */
-export type Metric_Current_Description_Obj_Rel_Insert_Input = {
-  data: Metric_Current_Description_Insert_Input;
 };
 
 /** ordering options when selecting data from "metric_current_description" */
 export type Metric_Current_Description_Order_By = {
   author?: Maybe<Users_Order_By>;
-  author_id?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** select columns of table "metric_current_description" */
 export enum Metric_Current_Description_Select_Column {
   /** column name */
-  AuthorId = 'author_id',
-  /** column name */
   CreatedAt = 'created_at',
   /** column name */
   Description = 'description',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metric_id',
-  /** column name */
-  OrganizationId = 'organization_id'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_current_description" */
-export type Metric_Current_Description_Set_Input = {
-  author_id?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Current_Description_Stddev_Fields = {
   __typename?: 'metric_current_description_stddev_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Stddev_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Current_Description_Stddev_Pop_Fields = {
   __typename?: 'metric_current_description_stddev_pop_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Stddev_Pop_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Current_Description_Stddev_Samp_Fields = {
   __typename?: 'metric_current_description_stddev_samp_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Stddev_Samp_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Current_Description_Sum_Fields = {
   __typename?: 'metric_current_description_sum_fields';
-  author_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Sum_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
 export type Metric_Current_Description_Var_Pop_Fields = {
   __typename?: 'metric_current_description_var_pop_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Var_Pop_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Current_Description_Var_Samp_Fields = {
   __typename?: 'metric_current_description_var_samp_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Var_Samp_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Current_Description_Variance_Fields = {
   __typename?: 'metric_current_description_variance_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Variance_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /**
@@ -6983,16 +8228,13 @@ export type Metric_Descriptions = {
   __typename?: 'metric_descriptions';
   /** An object relationship */
   author: Users;
-  authorId: Scalars['Int'];
   createdAt: Scalars['timestamptz'];
   description: Scalars['String'];
   id: Scalars['Int'];
   /** An object relationship */
   metric: Org_Metrics_Current_View;
-  metricId: Scalars['Int'];
   /** An object relationship */
   organization?: Maybe<Organizations>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "metric_descriptions" */
@@ -7043,24 +8285,17 @@ export type Metric_Descriptions_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_descriptions" */
 export type Metric_Descriptions_Arr_Rel_Insert_Input = {
   data: Array<Metric_Descriptions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_Descriptions_Avg_Fields = {
   __typename?: 'metric_descriptions_avg_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Avg_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_descriptions". All fields are combined with a logical 'AND'. */
@@ -7069,83 +8304,48 @@ export type Metric_Descriptions_Bool_Exp = {
   _not?: Maybe<Metric_Descriptions_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Descriptions_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   description?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_descriptions" */
-export enum Metric_Descriptions_Constraint {
-  /** unique or primary key constraint */
-  MetricDescriptionsPkey = 'metric_descriptions_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_descriptions" */
-export type Metric_Descriptions_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_descriptions" */
 export type Metric_Descriptions_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Descriptions_Max_Fields = {
   __typename?: 'metric_descriptions_max_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Max_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Descriptions_Min_Fields = {
   __typename?: 'metric_descriptions_min_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Min_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_descriptions" */
@@ -7160,27 +8360,16 @@ export type Metric_Descriptions_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_descriptions" */
 export type Metric_Descriptions_Obj_Rel_Insert_Input = {
   data: Metric_Descriptions_Insert_Input;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_descriptions" */
-export type Metric_Descriptions_On_Conflict = {
-  constraint: Metric_Descriptions_Constraint;
-  update_columns: Array<Metric_Descriptions_Update_Column>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_descriptions" */
 export type Metric_Descriptions_Order_By = {
   author?: Maybe<Users_Order_By>;
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_descriptions" */
@@ -7191,162 +8380,88 @@ export type Metric_Descriptions_Pk_Columns_Input = {
 /** select columns of table "metric_descriptions" */
 export enum Metric_Descriptions_Select_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
   CreatedAt = 'createdAt',
   /** column name */
   Description = 'description',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_descriptions" */
-export type Metric_Descriptions_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Descriptions_Stddev_Fields = {
   __typename?: 'metric_descriptions_stddev_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Stddev_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Descriptions_Stddev_Pop_Fields = {
   __typename?: 'metric_descriptions_stddev_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Stddev_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Descriptions_Stddev_Samp_Fields = {
   __typename?: 'metric_descriptions_stddev_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Stddev_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Descriptions_Sum_Fields = {
   __typename?: 'metric_descriptions_sum_fields';
-  authorId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Sum_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_descriptions" */
-export enum Metric_Descriptions_Update_Column {
-  /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Description = 'description',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_Descriptions_Var_Pop_Fields = {
   __typename?: 'metric_descriptions_var_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Var_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Descriptions_Var_Samp_Fields = {
   __typename?: 'metric_descriptions_var_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Var_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Descriptions_Variance_Fields = {
   __typename?: 'metric_descriptions_variance_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Variance_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "metric_lineage_data_sources" */
@@ -7411,12 +8526,6 @@ export type Metric_Lineage_Data_Sources_Aggregate_Order_By = {
   variance?: Maybe<Metric_Lineage_Data_Sources_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Arr_Rel_Insert_Input = {
-  data: Array<Metric_Lineage_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Metric_Lineage_Data_Sources_Avg_Fields = {
   __typename?: 'metric_lineage_data_sources_avg_fields';
@@ -7448,35 +8557,6 @@ export type Metric_Lineage_Data_Sources_Bool_Exp = {
   organization?: Maybe<Organizations_Bool_Exp>;
   organization_id?: Maybe<Int_Comparison_Exp>;
   updated_at?: Maybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_lineage_data_sources" */
-export enum Metric_Lineage_Data_Sources_Constraint {
-  /** unique or primary key constraint */
-  MetricLineageDataSourcesMetricVersionIdDataSourceVKey = 'metric_lineage_data_sources_metric_version_id_data_source_v_key',
-  /** unique or primary key constraint */
-  MetricLineageDataSourcesPkey = 'metric_lineage_data_sources_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Inc_Input = {
-  data_source_version_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_version_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Insert_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  dataSourceVersion?: Maybe<Data_Source_Versions_Obj_Rel_Insert_Input>;
-  data_source_version_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricVersion?: Maybe<Metric_Versions_Obj_Rel_Insert_Input>;
-  metric_version_id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organization_id?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -7521,28 +8601,6 @@ export type Metric_Lineage_Data_Sources_Min_Order_By = {
   updated_at?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Mutation_Response = {
-  __typename?: 'metric_lineage_data_sources_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Metric_Lineage_Data_Sources>;
-};
-
-/** input type for inserting object relation for remote table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Obj_Rel_Insert_Input = {
-  data: Metric_Lineage_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_On_Conflict = {
-  constraint: Metric_Lineage_Data_Sources_Constraint;
-  update_columns: Array<Metric_Lineage_Data_Sources_Update_Column>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "metric_lineage_data_sources" */
 export type Metric_Lineage_Data_Sources_Order_By = {
   created_at?: Maybe<Order_By>;
@@ -7576,16 +8634,6 @@ export enum Metric_Lineage_Data_Sources_Select_Column {
   /** column name */
   UpdatedAt = 'updated_at'
 }
-
-/** input type for updating data in table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Set_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  data_source_version_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_version_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Lineage_Data_Sources_Stddev_Fields = {
@@ -7655,22 +8703,6 @@ export type Metric_Lineage_Data_Sources_Sum_Order_By = {
   organization_id?: Maybe<Order_By>;
 };
 
-/** update columns of table "metric_lineage_data_sources" */
-export enum Metric_Lineage_Data_Sources_Update_Column {
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  DataSourceVersionId = 'data_source_version_id',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricVersionId = 'metric_version_id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  UpdatedAt = 'updated_at'
-}
-
 /** aggregate var_pop on columns */
 export type Metric_Lineage_Data_Sources_Var_Pop_Fields = {
   __typename?: 'metric_lineage_data_sources_var_pop_fields';
@@ -7726,18 +8758,13 @@ export type Metric_Lineage_Data_Sources_Variance_Order_By = {
 export type Metric_Team_Owners = {
   __typename?: 'metric_team_owners';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   team: Teams;
-  teamId: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_team_owners" */
@@ -7788,26 +8815,17 @@ export type Metric_Team_Owners_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_team_owners" */
 export type Metric_Team_Owners_Arr_Rel_Insert_Input = {
   data: Array<Metric_Team_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_Team_Owners_Avg_Fields = {
   __typename?: 'metric_team_owners_avg_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Avg_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_team_owners". All fields are combined with a logical 'AND'. */
@@ -7816,44 +8834,15 @@ export type Metric_Team_Owners_Bool_Exp = {
   _not?: Maybe<Metric_Team_Owners_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Team_Owners_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   team?: Maybe<Teams_Bool_Exp>;
-  teamId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_team_owners" */
-export enum Metric_Team_Owners_Constraint {
-  /** unique or primary key constraint */
-  MetricTeamOwnersOrgMetricIdTeamIdKey = 'metric_team_owners_org_metric_id_team_id_key',
-  /** unique or primary key constraint */
-  MetricTeamOwnersPkey = 'metric_team_owners_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_team_owners" */
-export type Metric_Team_Owners_Inc_Input = {
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_team_owners" */
 export type Metric_Team_Owners_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   team?: Maybe<Teams_Obj_Rel_Insert_Input>;
   teamId?: Maybe<Scalars['Int']>;
 };
@@ -7862,46 +8851,26 @@ export type Metric_Team_Owners_Insert_Input = {
 export type Metric_Team_Owners_Max_Fields = {
   __typename?: 'metric_team_owners_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Team_Owners_Min_Fields = {
   __typename?: 'metric_team_owners_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_team_owners" */
@@ -7916,28 +8885,15 @@ export type Metric_Team_Owners_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_team_owners" */
 export type Metric_Team_Owners_Obj_Rel_Insert_Input = {
   data: Metric_Team_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_team_owners" */
-export type Metric_Team_Owners_On_Conflict = {
-  constraint: Metric_Team_Owners_Constraint;
-  update_columns: Array<Metric_Team_Owners_Update_Column>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_team_owners" */
 export type Metric_Team_Owners_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   team?: Maybe<Teams_Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_team_owners" */
@@ -7950,179 +8906,84 @@ export enum Metric_Team_Owners_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_team_owners" */
-export type Metric_Team_Owners_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Team_Owners_Stddev_Fields = {
   __typename?: 'metric_team_owners_stddev_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Stddev_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Team_Owners_Stddev_Pop_Fields = {
   __typename?: 'metric_team_owners_stddev_pop_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Stddev_Pop_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Team_Owners_Stddev_Samp_Fields = {
   __typename?: 'metric_team_owners_stddev_samp_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Stddev_Samp_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Team_Owners_Sum_Fields = {
   __typename?: 'metric_team_owners_sum_fields';
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Sum_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_team_owners" */
-export enum Metric_Team_Owners_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_Team_Owners_Var_Pop_Fields = {
   __typename?: 'metric_team_owners_var_pop_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Var_Pop_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Team_Owners_Var_Samp_Fields = {
   __typename?: 'metric_team_owners_var_samp_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Var_Samp_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Team_Owners_Variance_Fields = {
   __typename?: 'metric_team_owners_variance_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Variance_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /**
@@ -8138,13 +8999,10 @@ export type Metric_User_Owners = {
   id: Scalars['Int'];
   /** An object relationship */
   metric: Org_Metrics_Current_View;
-  metricId: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   user: Users;
-  user_id: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_user_owners" */
@@ -8195,24 +9053,17 @@ export type Metric_User_Owners_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_user_owners" */
 export type Metric_User_Owners_Arr_Rel_Insert_Input = {
   data: Array<Metric_User_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_User_Owners_Avg_Fields = {
   __typename?: 'metric_user_owners_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_user_owners". All fields are combined with a logical 'AND'. */
@@ -8223,35 +9074,13 @@ export type Metric_User_Owners_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_user_owners" */
-export enum Metric_User_Owners_Constraint {
-  /** unique or primary key constraint */
-  MetricUserOwnersPkey = 'metric_user_owners_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_user_owners" */
-export type Metric_User_Owners_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_user_owners" */
 export type Metric_User_Owners_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
   user_id?: Maybe<Scalars['Int']>;
 };
@@ -8261,18 +9090,12 @@ export type Metric_User_Owners_Max_Fields = {
   __typename?: 'metric_user_owners_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -8280,18 +9103,12 @@ export type Metric_User_Owners_Min_Fields = {
   __typename?: 'metric_user_owners_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_user_owners" */
@@ -8306,14 +9123,6 @@ export type Metric_User_Owners_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_user_owners" */
 export type Metric_User_Owners_Obj_Rel_Insert_Input = {
   data: Metric_User_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_user_owners" */
-export type Metric_User_Owners_On_Conflict = {
-  constraint: Metric_User_Owners_Constraint;
-  update_columns: Array<Metric_User_Owners_Update_Column>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_user_owners" */
@@ -8321,11 +9130,8 @@ export type Metric_User_Owners_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_user_owners" */
@@ -8338,155 +9144,84 @@ export enum Metric_User_Owners_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UserId = 'user_id'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_user_owners" */
-export type Metric_User_Owners_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_User_Owners_Stddev_Fields = {
   __typename?: 'metric_user_owners_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_User_Owners_Stddev_Pop_Fields = {
   __typename?: 'metric_user_owners_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_User_Owners_Stddev_Samp_Fields = {
   __typename?: 'metric_user_owners_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_User_Owners_Sum_Fields = {
   __typename?: 'metric_user_owners_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_user_owners" */
-export enum Metric_User_Owners_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UserId = 'user_id'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_User_Owners_Var_Pop_Fields = {
   __typename?: 'metric_user_owners_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_User_Owners_Var_Samp_Fields = {
   __typename?: 'metric_user_owners_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_User_Owners_Variance_Fields = {
   __typename?: 'metric_user_owners_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /**
@@ -8500,7 +9235,6 @@ export type Metric_Versions = {
   createdAt: Scalars['timestamptz'];
   /** An object relationship */
   dataSource?: Maybe<Org_Data_Sources>;
-  dataSourceId?: Maybe<Scalars['Int']>;
   /** An array relationship */
   dataSources: Array<Metric_Lineage_Data_Sources>;
   /** An aggregated array relationship */
@@ -8519,7 +9253,6 @@ export type Metric_Versions = {
   organization: Organizations;
   organizationId: Scalars['Int'];
   params: Scalars['jsonb'];
-  source_data_source_versions?: Maybe<Scalars['json']>;
   tier: Scalars['Int'];
 };
 
@@ -8605,17 +9338,6 @@ export type Metric_VersionsParamsArgs = {
   path?: Maybe<Scalars['String']>;
 };
 
-
-/**
- * The exact definition from the configs a metric live here. Only updated when a definition changes, so this represents a version of a metric.
- *
- *
- * columns and relationships of "metric_versions"
- */
-export type Metric_VersionsSource_Data_Source_VersionsArgs = {
-  path?: Maybe<Scalars['String']>;
-};
-
 /** aggregated selection of "metric_versions" */
 export type Metric_Versions_Aggregate = {
   __typename?: 'metric_versions_aggregate';
@@ -8661,22 +9383,9 @@ export type Metric_Versions_Aggregate_Order_By = {
   variance?: Maybe<Metric_Versions_Variance_Order_By>;
 };
 
-/** append existing jsonb value of filtered columns with new jsonb value */
-export type Metric_Versions_Append_Input = {
-  metadata?: Maybe<Scalars['jsonb']>;
-  params?: Maybe<Scalars['jsonb']>;
-};
-
-/** input type for inserting array relation for remote table "metric_versions" */
-export type Metric_Versions_Arr_Rel_Insert_Input = {
-  data: Array<Metric_Versions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Metric_Versions_Avg_Fields = {
   __typename?: 'metric_versions_avg_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8685,7 +9394,6 @@ export type Metric_Versions_Avg_Fields = {
 
 /** order by avg() on columns of table "metric_versions" */
 export type Metric_Versions_Avg_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8699,7 +9407,6 @@ export type Metric_Versions_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Metric_Versions_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   dataSource?: Maybe<Org_Data_Sources_Bool_Exp>;
-  dataSourceId?: Maybe<Int_Comparison_Exp>;
   dataSources?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
   description?: Maybe<String_Comparison_Exp>;
   displayName?: Maybe<String_Comparison_Exp>;
@@ -8711,70 +9418,13 @@ export type Metric_Versions_Bool_Exp = {
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   params?: Maybe<Jsonb_Comparison_Exp>;
-  source_data_source_versions?: Maybe<Json_Comparison_Exp>;
   tier?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_versions" */
-export enum Metric_Versions_Constraint {
-  /** unique or primary key constraint */
-  MetricVersionsHashOrganizationIdKey = 'metric_versions_hash_organization_id_key',
-  /** unique or primary key constraint */
-  MetricVersionsPkey = 'metric_versions_pkey'
-}
-
-/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
-export type Metric_Versions_Delete_At_Path_Input = {
-  metadata?: Maybe<Array<Maybe<Scalars['String']>>>;
-  params?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
-export type Metric_Versions_Delete_Elem_Input = {
-  metadata?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['Int']>;
-};
-
-/** delete key/value pair or string element. key/value pairs are matched based on their key value */
-export type Metric_Versions_Delete_Key_Input = {
-  metadata?: Maybe<Scalars['String']>;
-  params?: Maybe<Scalars['String']>;
-};
-
-/** input type for incrementing integer column in table "metric_versions" */
-export type Metric_Versions_Inc_Input = {
-  dataSourceId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['bigint']>;
-  metricType?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  tier?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "metric_versions" */
-export type Metric_Versions_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSource?: Maybe<Org_Data_Sources_Obj_Rel_Insert_Input>;
-  dataSourceId?: Maybe<Scalars['Int']>;
-  dataSources?: Maybe<Metric_Lineage_Data_Sources_Arr_Rel_Insert_Input>;
-  description?: Maybe<Scalars['String']>;
-  displayName?: Maybe<Scalars['String']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  metadata?: Maybe<Scalars['jsonb']>;
-  metricType?: Maybe<Scalars['Int']>;
-  modelMetrics?: Maybe<Model_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['jsonb']>;
-  source_data_source_versions?: Maybe<Scalars['json']>;
-  tier?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Versions_Max_Fields = {
   __typename?: 'metric_versions_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceId?: Maybe<Scalars['Int']>;
   description?: Maybe<Scalars['String']>;
   displayName?: Maybe<Scalars['String']>;
   hash?: Maybe<Scalars['String']>;
@@ -8787,7 +9437,6 @@ export type Metric_Versions_Max_Fields = {
 /** order by max() on columns of table "metric_versions" */
 export type Metric_Versions_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dataSourceId?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   displayName?: Maybe<Order_By>;
   hash?: Maybe<Order_By>;
@@ -8801,7 +9450,6 @@ export type Metric_Versions_Max_Order_By = {
 export type Metric_Versions_Min_Fields = {
   __typename?: 'metric_versions_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceId?: Maybe<Scalars['Int']>;
   description?: Maybe<Scalars['String']>;
   displayName?: Maybe<Scalars['String']>;
   hash?: Maybe<Scalars['String']>;
@@ -8814,7 +9462,6 @@ export type Metric_Versions_Min_Fields = {
 /** order by min() on columns of table "metric_versions" */
 export type Metric_Versions_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dataSourceId?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   displayName?: Maybe<Order_By>;
   hash?: Maybe<Order_By>;
@@ -8824,33 +9471,10 @@ export type Metric_Versions_Min_Order_By = {
   tier?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "metric_versions" */
-export type Metric_Versions_Mutation_Response = {
-  __typename?: 'metric_versions_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Metric_Versions>;
-};
-
-/** input type for inserting object relation for remote table "metric_versions" */
-export type Metric_Versions_Obj_Rel_Insert_Input = {
-  data: Metric_Versions_Insert_Input;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_versions" */
-export type Metric_Versions_On_Conflict = {
-  constraint: Metric_Versions_Constraint;
-  update_columns: Array<Metric_Versions_Update_Column>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "metric_versions" */
 export type Metric_Versions_Order_By = {
   createdAt?: Maybe<Order_By>;
   dataSource?: Maybe<Org_Data_Sources_Order_By>;
-  dataSourceId?: Maybe<Order_By>;
   dataSources_aggregate?: Maybe<Metric_Lineage_Data_Sources_Aggregate_Order_By>;
   description?: Maybe<Order_By>;
   displayName?: Maybe<Order_By>;
@@ -8862,7 +9486,6 @@ export type Metric_Versions_Order_By = {
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   params?: Maybe<Order_By>;
-  source_data_source_versions?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
 };
 
@@ -8871,18 +9494,10 @@ export type Metric_Versions_Pk_Columns_Input = {
   id: Scalars['bigint'];
 };
 
-/** prepend existing jsonb value of filtered columns with new jsonb value */
-export type Metric_Versions_Prepend_Input = {
-  metadata?: Maybe<Scalars['jsonb']>;
-  params?: Maybe<Scalars['jsonb']>;
-};
-
 /** select columns of table "metric_versions" */
 export enum Metric_Versions_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
-  /** column name */
-  DataSourceId = 'dataSourceId',
   /** column name */
   Description = 'description',
   /** column name */
@@ -8900,31 +9515,12 @@ export enum Metric_Versions_Select_Column {
   /** column name */
   Params = 'params',
   /** column name */
-  SourceDataSourceVersions = 'source_data_source_versions',
-  /** column name */
   Tier = 'tier'
 }
-
-/** input type for updating data in table "metric_versions" */
-export type Metric_Versions_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceId?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  displayName?: Maybe<Scalars['String']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  metadata?: Maybe<Scalars['jsonb']>;
-  metricType?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['jsonb']>;
-  source_data_source_versions?: Maybe<Scalars['json']>;
-  tier?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Versions_Stddev_Fields = {
   __typename?: 'metric_versions_stddev_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8933,7 +9529,6 @@ export type Metric_Versions_Stddev_Fields = {
 
 /** order by stddev() on columns of table "metric_versions" */
 export type Metric_Versions_Stddev_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8943,7 +9538,6 @@ export type Metric_Versions_Stddev_Order_By = {
 /** aggregate stddev_pop on columns */
 export type Metric_Versions_Stddev_Pop_Fields = {
   __typename?: 'metric_versions_stddev_pop_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8952,7 +9546,6 @@ export type Metric_Versions_Stddev_Pop_Fields = {
 
 /** order by stddev_pop() on columns of table "metric_versions" */
 export type Metric_Versions_Stddev_Pop_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8962,7 +9555,6 @@ export type Metric_Versions_Stddev_Pop_Order_By = {
 /** aggregate stddev_samp on columns */
 export type Metric_Versions_Stddev_Samp_Fields = {
   __typename?: 'metric_versions_stddev_samp_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8971,7 +9563,6 @@ export type Metric_Versions_Stddev_Samp_Fields = {
 
 /** order by stddev_samp() on columns of table "metric_versions" */
 export type Metric_Versions_Stddev_Samp_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8981,7 +9572,6 @@ export type Metric_Versions_Stddev_Samp_Order_By = {
 /** aggregate sum on columns */
 export type Metric_Versions_Sum_Fields = {
   __typename?: 'metric_versions_sum_fields';
-  dataSourceId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['bigint']>;
   metricType?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
@@ -8990,45 +9580,15 @@ export type Metric_Versions_Sum_Fields = {
 
 /** order by sum() on columns of table "metric_versions" */
 export type Metric_Versions_Sum_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
 };
 
-/** update columns of table "metric_versions" */
-export enum Metric_Versions_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DataSourceId = 'dataSourceId',
-  /** column name */
-  Description = 'description',
-  /** column name */
-  DisplayName = 'displayName',
-  /** column name */
-  Hash = 'hash',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Metadata = 'metadata',
-  /** column name */
-  MetricType = 'metricType',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Params = 'params',
-  /** column name */
-  SourceDataSourceVersions = 'source_data_source_versions',
-  /** column name */
-  Tier = 'tier'
-}
-
 /** aggregate var_pop on columns */
 export type Metric_Versions_Var_Pop_Fields = {
   __typename?: 'metric_versions_var_pop_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -9037,7 +9597,6 @@ export type Metric_Versions_Var_Pop_Fields = {
 
 /** order by var_pop() on columns of table "metric_versions" */
 export type Metric_Versions_Var_Pop_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -9047,7 +9606,6 @@ export type Metric_Versions_Var_Pop_Order_By = {
 /** aggregate var_samp on columns */
 export type Metric_Versions_Var_Samp_Fields = {
   __typename?: 'metric_versions_var_samp_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -9056,7 +9614,6 @@ export type Metric_Versions_Var_Samp_Fields = {
 
 /** order by var_samp() on columns of table "metric_versions" */
 export type Metric_Versions_Var_Samp_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -9066,7 +9623,6 @@ export type Metric_Versions_Var_Samp_Order_By = {
 /** aggregate variance on columns */
 export type Metric_Versions_Variance_Fields = {
   __typename?: 'metric_versions_variance_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -9075,7 +9631,6 @@ export type Metric_Versions_Variance_Fields = {
 
 /** order by variance() on columns of table "metric_versions" */
 export type Metric_Versions_Variance_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -9089,14 +9644,12 @@ export type Metric_View = {
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
   /** An object relationship */
   user: Users;
   userId: Scalars['Int'];
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "metric_view" */
@@ -9155,7 +9708,6 @@ export type Metric_View_Avg_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_view" */
@@ -9163,7 +9715,6 @@ export type Metric_View_Avg_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_view". All fields are combined with a logical 'AND'. */
@@ -9174,33 +9725,16 @@ export type Metric_View_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
   metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
   userId?: Maybe<Int_Comparison_Exp>;
-  viewed_ts?: Maybe<Int_Comparison_Exp>;
-};
-
-/** input type for incrementing integer column in table "metric_view" */
-export type Metric_View_Inc_Input = {
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_view" */
 export type Metric_View_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -9208,20 +9742,16 @@ export type Metric_View_Max_Fields = {
   __typename?: 'metric_view_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_view" */
 export type Metric_View_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -9229,20 +9759,16 @@ export type Metric_View_Min_Fields = {
   __typename?: 'metric_view_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_view" */
 export type Metric_View_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_view" */
@@ -9264,12 +9790,10 @@ export type Metric_View_Order_By = {
   createdAt?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
   metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** select columns of table "metric_view" */
@@ -9279,24 +9803,10 @@ export enum Metric_View_Select_Column {
   /** column name */
   MetricId = 'metricId',
   /** column name */
-  MetricName = 'metric_name',
-  /** column name */
   OrganizationId = 'organizationId',
   /** column name */
-  UserId = 'userId',
-  /** column name */
-  ViewedTs = 'viewed_ts'
+  UserId = 'userId'
 }
-
-/** input type for updating data in table "metric_view" */
-export type Metric_View_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_View_Stddev_Fields = {
@@ -9304,7 +9814,6 @@ export type Metric_View_Stddev_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_view" */
@@ -9312,7 +9821,6 @@ export type Metric_View_Stddev_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -9321,7 +9829,6 @@ export type Metric_View_Stddev_Pop_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_view" */
@@ -9329,7 +9836,6 @@ export type Metric_View_Stddev_Pop_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -9338,7 +9844,6 @@ export type Metric_View_Stddev_Samp_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_view" */
@@ -9346,7 +9851,6 @@ export type Metric_View_Stddev_Samp_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -9355,7 +9859,6 @@ export type Metric_View_Sum_Fields = {
   metricId?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_view" */
@@ -9363,7 +9866,6 @@ export type Metric_View_Sum_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
@@ -9372,7 +9874,6 @@ export type Metric_View_Var_Pop_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_view" */
@@ -9380,7 +9881,6 @@ export type Metric_View_Var_Pop_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -9389,7 +9889,6 @@ export type Metric_View_Var_Samp_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_view" */
@@ -9397,7 +9896,6 @@ export type Metric_View_Var_Samp_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -9406,7 +9904,6 @@ export type Metric_View_Variance_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_view" */
@@ -9414,7 +9911,6 @@ export type Metric_View_Variance_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /**
@@ -9433,64 +9929,6 @@ export type Model_Current = {
   organization_id?: Maybe<Scalars['Int']>;
 };
 
-/** aggregated selection of "model_current" */
-export type Model_Current_Aggregate = {
-  __typename?: 'model_current_aggregate';
-  aggregate?: Maybe<Model_Current_Aggregate_Fields>;
-  nodes: Array<Model_Current>;
-};
-
-/** aggregate fields of "model_current" */
-export type Model_Current_Aggregate_Fields = {
-  __typename?: 'model_current_aggregate_fields';
-  avg?: Maybe<Model_Current_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Model_Current_Max_Fields>;
-  min?: Maybe<Model_Current_Min_Fields>;
-  stddev?: Maybe<Model_Current_Stddev_Fields>;
-  stddev_pop?: Maybe<Model_Current_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Model_Current_Stddev_Samp_Fields>;
-  sum?: Maybe<Model_Current_Sum_Fields>;
-  var_pop?: Maybe<Model_Current_Var_Pop_Fields>;
-  var_samp?: Maybe<Model_Current_Var_Samp_Fields>;
-  variance?: Maybe<Model_Current_Variance_Fields>;
-};
-
-
-/** aggregate fields of "model_current" */
-export type Model_Current_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Model_Current_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "model_current" */
-export type Model_Current_Aggregate_Order_By = {
-  avg?: Maybe<Model_Current_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Model_Current_Max_Order_By>;
-  min?: Maybe<Model_Current_Min_Order_By>;
-  stddev?: Maybe<Model_Current_Stddev_Order_By>;
-  stddev_pop?: Maybe<Model_Current_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Model_Current_Stddev_Samp_Order_By>;
-  sum?: Maybe<Model_Current_Sum_Order_By>;
-  var_pop?: Maybe<Model_Current_Var_Pop_Order_By>;
-  var_samp?: Maybe<Model_Current_Var_Samp_Order_By>;
-  variance?: Maybe<Model_Current_Variance_Order_By>;
-};
-
-/** aggregate avg on columns */
-export type Model_Current_Avg_Fields = {
-  __typename?: 'model_current_avg_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "model_current" */
-export type Model_Current_Avg_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
 /** Boolean expression to filter rows from the table "model_current". All fields are combined with a logical 'AND'. */
 export type Model_Current_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Model_Current_Bool_Exp>>>;
@@ -9500,32 +9938,6 @@ export type Model_Current_Bool_Exp = {
   model_id?: Maybe<Bigint_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organization_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Model_Current_Max_Fields = {
-  __typename?: 'model_current_max_fields';
-  model_id?: Maybe<Scalars['bigint']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "model_current" */
-export type Model_Current_Max_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Model_Current_Min_Fields = {
-  __typename?: 'model_current_min_fields';
-  model_id?: Maybe<Scalars['bigint']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "model_current" */
-export type Model_Current_Min_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** ordering options when selecting data from "model_current" */
@@ -9544,97 +9956,6 @@ export enum Model_Current_Select_Column {
   OrganizationId = 'organization_id'
 }
 
-/** aggregate stddev on columns */
-export type Model_Current_Stddev_Fields = {
-  __typename?: 'model_current_stddev_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "model_current" */
-export type Model_Current_Stddev_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Model_Current_Stddev_Pop_Fields = {
-  __typename?: 'model_current_stddev_pop_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "model_current" */
-export type Model_Current_Stddev_Pop_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Model_Current_Stddev_Samp_Fields = {
-  __typename?: 'model_current_stddev_samp_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "model_current" */
-export type Model_Current_Stddev_Samp_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Model_Current_Sum_Fields = {
-  __typename?: 'model_current_sum_fields';
-  model_id?: Maybe<Scalars['bigint']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "model_current" */
-export type Model_Current_Sum_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_pop on columns */
-export type Model_Current_Var_Pop_Fields = {
-  __typename?: 'model_current_var_pop_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "model_current" */
-export type Model_Current_Var_Pop_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Model_Current_Var_Samp_Fields = {
-  __typename?: 'model_current_var_samp_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "model_current" */
-export type Model_Current_Var_Samp_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Model_Current_Variance_Fields = {
-  __typename?: 'model_current_variance_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "model_current" */
-export type Model_Current_Variance_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
 /**
  * Lookup table to find the data source version for a given org_data_source ID and model ID combo
  *
@@ -9651,7 +9972,6 @@ export type Model_Data_Sources = {
   modelId: Scalars['Int'];
   /** An object relationship */
   orgDataSource?: Maybe<Org_Data_Sources>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "model_data_sources" */
@@ -9699,25 +10019,17 @@ export type Model_Data_Sources_Aggregate_Order_By = {
   variance?: Maybe<Model_Data_Sources_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "model_data_sources" */
-export type Model_Data_Sources_Arr_Rel_Insert_Input = {
-  data: Array<Model_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Model_Data_Sources_Avg_Fields = {
   __typename?: 'model_data_sources_avg_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Avg_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "model_data_sources". All fields are combined with a logical 'AND'. */
@@ -9730,30 +10042,6 @@ export type Model_Data_Sources_Bool_Exp = {
   model?: Maybe<Models_Bool_Exp>;
   modelId?: Maybe<Int_Comparison_Exp>;
   orgDataSource?: Maybe<Org_Data_Sources_Bool_Exp>;
-  org_data_source_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "model_data_sources" */
-export enum Model_Data_Sources_Constraint {
-  /** unique or primary key constraint */
-  ModelDataSourcesPkey = 'model_data_sources_pkey'
-}
-
-/** input type for incrementing integer column in table "model_data_sources" */
-export type Model_Data_Sources_Inc_Input = {
-  dataSourceVersionId?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "model_data_sources" */
-export type Model_Data_Sources_Insert_Input = {
-  dataSourceVersion?: Maybe<Data_Source_Versions_Obj_Rel_Insert_Input>;
-  dataSourceVersionId?: Maybe<Scalars['Int']>;
-  model?: Maybe<Models_Obj_Rel_Insert_Input>;
-  modelId?: Maybe<Scalars['Int']>;
-  orgDataSource?: Maybe<Org_Data_Sources_Obj_Rel_Insert_Input>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -9761,14 +10049,12 @@ export type Model_Data_Sources_Max_Fields = {
   __typename?: 'model_data_sources_max_fields';
   dataSourceVersionId?: Maybe<Scalars['Int']>;
   modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Max_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -9776,36 +10062,12 @@ export type Model_Data_Sources_Min_Fields = {
   __typename?: 'model_data_sources_min_fields';
   dataSourceVersionId?: Maybe<Scalars['Int']>;
   modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Min_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "model_data_sources" */
-export type Model_Data_Sources_Mutation_Response = {
-  __typename?: 'model_data_sources_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Model_Data_Sources>;
-};
-
-/** input type for inserting object relation for remote table "model_data_sources" */
-export type Model_Data_Sources_Obj_Rel_Insert_Input = {
-  data: Model_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
-/** on conflict condition type for table "model_data_sources" */
-export type Model_Data_Sources_On_Conflict = {
-  constraint: Model_Data_Sources_Constraint;
-  update_columns: Array<Model_Data_Sources_Update_Column>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "model_data_sources" */
@@ -9815,7 +10077,6 @@ export type Model_Data_Sources_Order_By = {
   model?: Maybe<Models_Order_By>;
   modelId?: Maybe<Order_By>;
   orgDataSource?: Maybe<Org_Data_Sources_Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "model_data_sources" */
@@ -9829,31 +10090,20 @@ export enum Model_Data_Sources_Select_Column {
   /** column name */
   DataSourceVersionId = 'dataSourceVersionId',
   /** column name */
-  ModelId = 'modelId',
-  /** column name */
-  OrgDataSourceId = 'org_data_source_id'
+  ModelId = 'modelId'
 }
-
-/** input type for updating data in table "model_data_sources" */
-export type Model_Data_Sources_Set_Input = {
-  dataSourceVersionId?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Model_Data_Sources_Stddev_Fields = {
   __typename?: 'model_data_sources_stddev_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Stddev_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -9861,14 +10111,12 @@ export type Model_Data_Sources_Stddev_Pop_Fields = {
   __typename?: 'model_data_sources_stddev_pop_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Stddev_Pop_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -9876,14 +10124,12 @@ export type Model_Data_Sources_Stddev_Samp_Fields = {
   __typename?: 'model_data_sources_stddev_samp_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Stddev_Samp_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -9891,39 +10137,25 @@ export type Model_Data_Sources_Sum_Fields = {
   __typename?: 'model_data_sources_sum_fields';
   dataSourceVersionId?: Maybe<Scalars['Int']>;
   modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Sum_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
-
-/** update columns of table "model_data_sources" */
-export enum Model_Data_Sources_Update_Column {
-  /** column name */
-  DataSourceVersionId = 'dataSourceVersionId',
-  /** column name */
-  ModelId = 'modelId',
-  /** column name */
-  OrgDataSourceId = 'org_data_source_id'
-}
 
 /** aggregate var_pop on columns */
 export type Model_Data_Sources_Var_Pop_Fields = {
   __typename?: 'model_data_sources_var_pop_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Var_Pop_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -9931,14 +10163,12 @@ export type Model_Data_Sources_Var_Samp_Fields = {
   __typename?: 'model_data_sources_var_samp_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Var_Samp_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -9946,14 +10176,12 @@ export type Model_Data_Sources_Variance_Fields = {
   __typename?: 'model_data_sources_variance_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Variance_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "model_metrics" */
@@ -10015,12 +10243,6 @@ export type Model_Metrics_Aggregate_Order_By = {
   variance?: Maybe<Model_Metrics_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "model_metrics" */
-export type Model_Metrics_Arr_Rel_Insert_Input = {
-  data: Array<Model_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Model_Metrics_Avg_Fields = {
   __typename?: 'model_metrics_avg_fields';
@@ -10047,31 +10269,6 @@ export type Model_Metrics_Bool_Exp = {
   metricVersionId?: Maybe<Bigint_Comparison_Exp>;
   model?: Maybe<Models_Bool_Exp>;
   modelId?: Maybe<Bigint_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "model_metrics" */
-export enum Model_Metrics_Constraint {
-  /** unique or primary key constraint */
-  ModelMetricsOrgMetricIdModelIdKey = 'model_metrics_org_metric_id_model_id_key',
-  /** unique or primary key constraint */
-  ModelMetricsPkey = 'model_metrics_pkey'
-}
-
-/** input type for incrementing integer column in table "model_metrics" */
-export type Model_Metrics_Inc_Input = {
-  metricId?: Maybe<Scalars['bigint']>;
-  metricVersionId?: Maybe<Scalars['bigint']>;
-  modelId?: Maybe<Scalars['bigint']>;
-};
-
-/** input type for inserting data into table "model_metrics" */
-export type Model_Metrics_Insert_Input = {
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
-  metricId?: Maybe<Scalars['bigint']>;
-  metricVersion?: Maybe<Metric_Versions_Obj_Rel_Insert_Input>;
-  metricVersionId?: Maybe<Scalars['bigint']>;
-  model?: Maybe<Models_Obj_Rel_Insert_Input>;
-  modelId?: Maybe<Scalars['bigint']>;
 };
 
 /** aggregate max on columns */
@@ -10104,28 +10301,6 @@ export type Model_Metrics_Min_Order_By = {
   modelId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "model_metrics" */
-export type Model_Metrics_Mutation_Response = {
-  __typename?: 'model_metrics_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Model_Metrics>;
-};
-
-/** input type for inserting object relation for remote table "model_metrics" */
-export type Model_Metrics_Obj_Rel_Insert_Input = {
-  data: Model_Metrics_Insert_Input;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
-/** on conflict condition type for table "model_metrics" */
-export type Model_Metrics_On_Conflict = {
-  constraint: Model_Metrics_Constraint;
-  update_columns: Array<Model_Metrics_Update_Column>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "model_metrics" */
 export type Model_Metrics_Order_By = {
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
@@ -10152,13 +10327,6 @@ export enum Model_Metrics_Select_Column {
   /** column name */
   ModelId = 'modelId'
 }
-
-/** input type for updating data in table "model_metrics" */
-export type Model_Metrics_Set_Input = {
-  metricId?: Maybe<Scalars['bigint']>;
-  metricVersionId?: Maybe<Scalars['bigint']>;
-  modelId?: Maybe<Scalars['bigint']>;
-};
 
 /** aggregate stddev on columns */
 export type Model_Metrics_Stddev_Fields = {
@@ -10219,16 +10387,6 @@ export type Model_Metrics_Sum_Order_By = {
   metricVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
 };
-
-/** update columns of table "model_metrics" */
-export enum Model_Metrics_Update_Column {
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricVersionId = 'metricVersionId',
-  /** column name */
-  ModelId = 'modelId'
-}
 
 /** aggregate var_pop on columns */
 export type Model_Metrics_Var_Pop_Fields = {
@@ -10308,7 +10466,6 @@ export type Models = {
   organizationId: Scalars['Int'];
   /** An object relationship */
   uploader: Users;
-  uploaderId: Scalars['Int'];
 };
 
 
@@ -10446,25 +10603,17 @@ export type Models_Aggregate_Order_By = {
   variance?: Maybe<Models_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "models" */
-export type Models_Arr_Rel_Insert_Input = {
-  data: Array<Models_Insert_Input>;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Models_Avg_Fields = {
   __typename?: 'models_avg_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "models" */
 export type Models_Avg_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "models". All fields are combined with a logical 'AND'. */
@@ -10486,39 +10635,6 @@ export type Models_Bool_Exp = {
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   uploader?: Maybe<Users_Bool_Exp>;
-  uploaderId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "models" */
-export enum Models_Constraint {
-  /** unique or primary key constraint */
-  ModelsPkey = 'models_pkey'
-}
-
-/** input type for incrementing integer column in table "models" */
-export type Models_Inc_Input = {
-  id?: Maybe<Scalars['bigint']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "models" */
-export type Models_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSources?: Maybe<Model_Data_Sources_Arr_Rel_Insert_Input>;
-  executionContext?: Maybe<Scalars['String']>;
-  gitBranch?: Maybe<Scalars['String']>;
-  gitCommit?: Maybe<Scalars['String']>;
-  gitIsDirty?: Maybe<Scalars['Boolean']>;
-  gitRepo?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  isCurrent?: Maybe<Scalars['Boolean']>;
-  metrics?: Maybe<Org_Metrics_Current_View_Arr_Rel_Insert_Input>;
-  modelMetrics?: Maybe<Model_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  uploader?: Maybe<Users_Obj_Rel_Insert_Input>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -10531,7 +10647,6 @@ export type Models_Max_Fields = {
   gitRepo?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['bigint']>;
   organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "models" */
@@ -10543,7 +10658,6 @@ export type Models_Max_Order_By = {
   gitRepo?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -10556,7 +10670,6 @@ export type Models_Min_Fields = {
   gitRepo?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['bigint']>;
   organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "models" */
@@ -10568,29 +10681,6 @@ export type Models_Min_Order_By = {
   gitRepo?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "models" */
-export type Models_Mutation_Response = {
-  __typename?: 'models_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Models>;
-};
-
-/** input type for inserting object relation for remote table "models" */
-export type Models_Obj_Rel_Insert_Input = {
-  data: Models_Insert_Input;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
-/** on conflict condition type for table "models" */
-export type Models_On_Conflict = {
-  constraint: Models_Constraint;
-  update_columns: Array<Models_Update_Column>;
-  where?: Maybe<Models_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "models" */
@@ -10609,7 +10699,6 @@ export type Models_Order_By = {
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   uploader?: Maybe<Users_Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "models" */
@@ -10636,38 +10725,20 @@ export enum Models_Select_Column {
   /** column name */
   IsCurrent = 'isCurrent',
   /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UploaderId = 'uploaderId'
+  OrganizationId = 'organizationId'
 }
-
-/** input type for updating data in table "models" */
-export type Models_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  executionContext?: Maybe<Scalars['String']>;
-  gitBranch?: Maybe<Scalars['String']>;
-  gitCommit?: Maybe<Scalars['String']>;
-  gitIsDirty?: Maybe<Scalars['Boolean']>;
-  gitRepo?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  isCurrent?: Maybe<Scalars['Boolean']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Models_Stddev_Fields = {
   __typename?: 'models_stddev_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "models" */
 export type Models_Stddev_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -10675,14 +10746,12 @@ export type Models_Stddev_Pop_Fields = {
   __typename?: 'models_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "models" */
 export type Models_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -10690,14 +10759,12 @@ export type Models_Stddev_Samp_Fields = {
   __typename?: 'models_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "models" */
 export type Models_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -10705,53 +10772,25 @@ export type Models_Sum_Fields = {
   __typename?: 'models_sum_fields';
   id?: Maybe<Scalars['bigint']>;
   organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "models" */
 export type Models_Sum_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
-
-/** update columns of table "models" */
-export enum Models_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  ExecutionContext = 'executionContext',
-  /** column name */
-  GitBranch = 'gitBranch',
-  /** column name */
-  GitCommit = 'gitCommit',
-  /** column name */
-  GitIsDirty = 'gitIsDirty',
-  /** column name */
-  GitRepo = 'gitRepo',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  IsCurrent = 'isCurrent',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UploaderId = 'uploaderId'
-}
 
 /** aggregate var_pop on columns */
 export type Models_Var_Pop_Fields = {
   __typename?: 'models_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "models" */
 export type Models_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -10759,14 +10798,12 @@ export type Models_Var_Samp_Fields = {
   __typename?: 'models_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "models" */
 export type Models_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -10774,14 +10811,12 @@ export type Models_Variance_Fields = {
   __typename?: 'models_variance_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "models" */
 export type Models_Variance_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /**
@@ -10797,7 +10832,6 @@ export type Mql_Heartbeats = {
   id: Scalars['Int'];
   /** An object relationship */
   mqlServer?: Maybe<Org_Mql_Servers>;
-  mqlServerid?: Maybe<Scalars['Int']>;
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
@@ -10819,72 +10853,9 @@ export type Mql_HeartbeatsDetailsArgs = {
   path?: Maybe<Scalars['String']>;
 };
 
-/** aggregated selection of "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate = {
-  __typename?: 'mql_heartbeats_aggregate';
-  aggregate?: Maybe<Mql_Heartbeats_Aggregate_Fields>;
-  nodes: Array<Mql_Heartbeats>;
-};
-
-/** aggregate fields of "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate_Fields = {
-  __typename?: 'mql_heartbeats_aggregate_fields';
-  avg?: Maybe<Mql_Heartbeats_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Mql_Heartbeats_Max_Fields>;
-  min?: Maybe<Mql_Heartbeats_Min_Fields>;
-  stddev?: Maybe<Mql_Heartbeats_Stddev_Fields>;
-  stddev_pop?: Maybe<Mql_Heartbeats_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Mql_Heartbeats_Stddev_Samp_Fields>;
-  sum?: Maybe<Mql_Heartbeats_Sum_Fields>;
-  var_pop?: Maybe<Mql_Heartbeats_Var_Pop_Fields>;
-  var_samp?: Maybe<Mql_Heartbeats_Var_Samp_Fields>;
-  variance?: Maybe<Mql_Heartbeats_Variance_Fields>;
-};
-
-
-/** aggregate fields of "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate_Order_By = {
-  avg?: Maybe<Mql_Heartbeats_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Mql_Heartbeats_Max_Order_By>;
-  min?: Maybe<Mql_Heartbeats_Min_Order_By>;
-  stddev?: Maybe<Mql_Heartbeats_Stddev_Order_By>;
-  stddev_pop?: Maybe<Mql_Heartbeats_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Mql_Heartbeats_Stddev_Samp_Order_By>;
-  sum?: Maybe<Mql_Heartbeats_Sum_Order_By>;
-  var_pop?: Maybe<Mql_Heartbeats_Var_Pop_Order_By>;
-  var_samp?: Maybe<Mql_Heartbeats_Var_Samp_Order_By>;
-  variance?: Maybe<Mql_Heartbeats_Variance_Order_By>;
-};
-
 /** input type for inserting array relation for remote table "mql_heartbeats" */
 export type Mql_Heartbeats_Arr_Rel_Insert_Input = {
   data: Array<Mql_Heartbeats_Insert_Input>;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Mql_Heartbeats_Avg_Fields = {
-  __typename?: 'mql_heartbeats_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "mql_heartbeats". All fields are combined with a logical 'AND'. */
@@ -10896,7 +10867,6 @@ export type Mql_Heartbeats_Bool_Exp = {
   details?: Maybe<Json_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   mqlServer?: Maybe<Org_Mql_Servers_Bool_Exp>;
-  mqlServerid?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   status?: Maybe<String_Comparison_Exp>;
@@ -10905,79 +10875,13 @@ export type Mql_Heartbeats_Bool_Exp = {
   versionSha?: Maybe<String_Comparison_Exp>;
 };
 
-/** unique or primary key constraints on table "mql_heartbeats" */
-export enum Mql_Heartbeats_Constraint {
-  /** unique or primary key constraint */
-  MqlHeartbeatsPkey = 'mql_heartbeats_pkey'
-}
-
-/** input type for incrementing integer column in table "mql_heartbeats" */
-export type Mql_Heartbeats_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "mql_heartbeats" */
 export type Mql_Heartbeats_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   details?: Maybe<Scalars['json']>;
-  id?: Maybe<Scalars['Int']>;
   mqlServer?: Maybe<Org_Mql_Servers_Obj_Rel_Insert_Input>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   status?: Maybe<Scalars['String']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
   versionSha?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Mql_Heartbeats_Max_Fields = {
-  __typename?: 'mql_heartbeats_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  status?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
-  versionSha?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  status?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-  versionSha?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Mql_Heartbeats_Min_Fields = {
-  __typename?: 'mql_heartbeats_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  status?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
-  versionSha?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  status?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-  versionSha?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "mql_heartbeats" */
@@ -10992,14 +10896,6 @@ export type Mql_Heartbeats_Mutation_Response = {
 /** input type for inserting object relation for remote table "mql_heartbeats" */
 export type Mql_Heartbeats_Obj_Rel_Insert_Input = {
   data: Mql_Heartbeats_Insert_Input;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-/** on conflict condition type for table "mql_heartbeats" */
-export type Mql_Heartbeats_On_Conflict = {
-  constraint: Mql_Heartbeats_Constraint;
-  update_columns: Array<Mql_Heartbeats_Update_Column>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "mql_heartbeats" */
@@ -11008,7 +10904,6 @@ export type Mql_Heartbeats_Order_By = {
   details?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   mqlServer?: Maybe<Org_Mql_Servers_Order_By>;
-  mqlServerid?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   status?: Maybe<Order_By>;
@@ -11031,8 +10926,6 @@ export enum Mql_Heartbeats_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  MqlServerid = 'mqlServerid',
-  /** column name */
   OrganizationId = 'organizationId',
   /** column name */
   Status = 'status',
@@ -11041,3068 +10934,6 @@ export enum Mql_Heartbeats_Select_Column {
   /** column name */
   VersionSha = 'versionSha'
 }
-
-/** input type for updating data in table "mql_heartbeats" */
-export type Mql_Heartbeats_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  details?: Maybe<Scalars['json']>;
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  status?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
-  versionSha?: Maybe<Scalars['String']>;
-};
-
-/** aggregate stddev on columns */
-export type Mql_Heartbeats_Stddev_Fields = {
-  __typename?: 'mql_heartbeats_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Mql_Heartbeats_Stddev_Pop_Fields = {
-  __typename?: 'mql_heartbeats_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Mql_Heartbeats_Stddev_Samp_Fields = {
-  __typename?: 'mql_heartbeats_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Mql_Heartbeats_Sum_Fields = {
-  __typename?: 'mql_heartbeats_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** update columns of table "mql_heartbeats" */
-export enum Mql_Heartbeats_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Details = 'details',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MqlServerid = 'mqlServerid',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Status = 'status',
-  /** column name */
-  UserId = 'userId',
-  /** column name */
-  VersionSha = 'versionSha'
-}
-
-/** aggregate var_pop on columns */
-export type Mql_Heartbeats_Var_Pop_Fields = {
-  __typename?: 'mql_heartbeats_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Mql_Heartbeats_Var_Samp_Fields = {
-  __typename?: 'mql_heartbeats_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Mql_Heartbeats_Variance_Fields = {
-  __typename?: 'mql_heartbeats_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** mutation root */
-export type Mutation_Root = {
-  __typename?: 'mutation_root';
-  /** insert a single row into the table: "metric_collection_metrics" */
-  addMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** insert data into the table: "metric_collection_metrics" */
-  addMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
-  /** insert a single row into the table: "team_members" */
-  addTeamMember?: Maybe<Team_Members>;
-  /** insert data into the table: "team_members" */
-  addTeamMembers?: Maybe<Team_Members_Mutation_Response>;
-  /** perform the action: "addUserRole" */
-  addUserRole?: Maybe<AddUserRoleOutput>;
-  /** insert a single row into the table: "metric_approvals" */
-  approveMetric?: Maybe<Metric_Approvals>;
-  /** insert data into the table: "metric_approvals" */
-  approveMetrics?: Maybe<Metric_Approvals_Mutation_Response>;
-  /** insert a single row into the table: "user_roles" */
-  assignUserRole?: Maybe<User_Roles>;
-  /** insert data into the table: "user_roles" */
-  assignUserRoles?: Maybe<User_Roles_Mutation_Response>;
-  /** insert a single row into the table: "annotations" */
-  createAnnotation?: Maybe<Annotations>;
-  /** insert data into the table: "annotations" */
-  createAnnotations?: Maybe<Annotations_Mutation_Response>;
-  /** perform the action: "createApiKey" */
-  createApiKey?: Maybe<CreateApiKeyOutput>;
-  /** perform the action: "createApiKeyForUser" */
-  createApiKeyForUser?: Maybe<CreateApiKeyForUserOutput>;
-  /** insert a single row into the table: "dashboards" */
-  createDashboard?: Maybe<Dashboards>;
-  /** insert a single row into the table: "dashboard_item_configs" */
-  createDashboardItem?: Maybe<Dashboard_Item_Configs>;
-  /** insert data into the table: "dashboard_item_configs" */
-  createDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_sections" */
-  createDashboardSection?: Maybe<Dashboard_Sections>;
-  /** insert data into the table: "dashboard_sections" */
-  createDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
-  /** insert data into the table: "dashboards" */
-  createDashboards?: Maybe<Dashboards_Mutation_Response>;
-  /** insert a single row into the table: "features" */
-  createFeature?: Maybe<Features>;
-  /** insert data into the table: "features" */
-  createFeatures?: Maybe<Features_Mutation_Response>;
-  /** insert a single row into the table: "metric_annotations" */
-  createMetricAnnotation?: Maybe<Metric_Annotations>;
-  /** insert data into the table: "metric_annotations" */
-  createMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
-  /** insert a single row into the table: "metric_collections" */
-  createMetricCollection?: Maybe<Metric_Collections>;
-  /** insert a single row into the table: "metric_collection_view" */
-  createMetricCollectionView?: Maybe<Metric_Collection_View>;
-  /** insert data into the table: "metric_collection_view" */
-  createMetricCollectionViews?: Maybe<Metric_Collection_View_Mutation_Response>;
-  /** insert data into the table: "metric_collections" */
-  createMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
-  /** insert a single row into the table: "metric_descriptions" */
-  createMetricDescription?: Maybe<Metric_Descriptions>;
-  /** insert data into the table: "metric_descriptions" */
-  createMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
-  /** insert a single row into the table: "metric_team_owners" */
-  createMetricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** insert data into the table: "metric_team_owners" */
-  createMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
-  /** insert a single row into the table: "metric_user_owners" */
-  createMetricUserOwner?: Maybe<Metric_User_Owners>;
-  /** insert data into the table: "metric_user_owners" */
-  createMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
-  /** insert a single row into the table: "metric_view" */
-  createMetricView?: Maybe<Metric_View>;
-  /** insert data into the table: "metric_view" */
-  createMetricViews?: Maybe<Metric_View_Mutation_Response>;
-  /** insert a single row into the table: "mql_heartbeats" */
-  createMqlHeartbeat?: Maybe<Mql_Heartbeats>;
-  /** insert data into the table: "mql_heartbeats" */
-  createMqlHeartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
-  /** insert a single row into the table: "org_mql_servers" */
-  createOrgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** insert data into the table: "org_mql_servers" */
-  createOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
-  /** insert a single row into the table: "organizations" */
-  createOrganization?: Maybe<Organizations>;
-  /** insert a single row into the table: "organization_features" */
-  createOrganizationFeature?: Maybe<Organization_Features>;
-  /** insert data into the table: "organization_features" */
-  createOrganizationFeatures?: Maybe<Organization_Features_Mutation_Response>;
-  /** insert data into the table: "organizations" */
-  createOrganizations?: Maybe<Organizations_Mutation_Response>;
-  /** insert a single row into the table: "questions" */
-  createQuestion?: Maybe<Questions>;
-  /** insert data into the table: "question_replies" */
-  createQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
-  /** insert a single row into the table: "question_replies" */
-  createQuestionReply?: Maybe<Question_Replies>;
-  /** insert data into the table: "questions" */
-  createQuestions?: Maybe<Questions_Mutation_Response>;
-  /** insert data into the table: "saved_queries" */
-  createSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
-  /** insert a single row into the table: "saved_queries" */
-  createSavedQuery?: Maybe<Saved_Queries>;
-  /** insert a single row into the table: "teams" */
-  createTeam?: Maybe<Teams>;
-  /** insert a single row into the table: "team_dashboards" */
-  createTeamDashboard?: Maybe<Team_Dashboards>;
-  /** insert data into the table: "team_dashboards" */
-  createTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
-  /** insert a single row into the table: "team_views" */
-  createTeamView?: Maybe<Team_Views>;
-  /** insert data into the table: "team_views" */
-  createTeamViews?: Maybe<Team_Views_Mutation_Response>;
-  /** insert data into the table: "teams" */
-  createTeams?: Maybe<Teams_Mutation_Response>;
-  /** insert a single row into the table: "unsubscribes" */
-  createUnsubscribe?: Maybe<Unsubscribes>;
-  /** insert data into the table: "unsubscribes" */
-  createUnsubscribes?: Maybe<Unsubscribes_Mutation_Response>;
-  /** perform the action: "createUser" */
-  createUser?: Maybe<CreateUserOutput>;
-  /** insert a single row into the table: "user_dashboards" */
-  createUserDashboard?: Maybe<User_Dashboards>;
-  /** insert data into the table: "user_dashboards" */
-  createUserDashboards?: Maybe<User_Dashboards_Mutation_Response>;
-  /** insert a single row into the table: "user_features" */
-  createUserFeature?: Maybe<User_Features>;
-  /** insert data into the table: "user_features" */
-  createUserFeatures?: Maybe<User_Features_Mutation_Response>;
-  /** perform the action: "createUserForOrg" */
-  createUserForOrg?: Maybe<CreateUserOutput>;
-  /** insert a single row into the table: "user_prefs" */
-  createUserPreference?: Maybe<User_Prefs>;
-  /** insert data into the table: "user_prefs" */
-  createUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
-  /** insert a single row into the table: "saved_query_metrics" */
-  createdSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** insert data into the table: "saved_query_metrics" */
-  createdSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
-  /** perform the action: "deactivateUser" */
-  deactivateUser?: Maybe<DeactivateUserOutput>;
-  /** delete single row from the table: "annotations" */
-  deleteAnnotation?: Maybe<Annotations>;
-  /** delete data from the table: "annotations" */
-  deleteAnnotations?: Maybe<Annotations_Mutation_Response>;
-  /** delete single row from the table: "dashboard_item_configs" */
-  deleteDashboardItem?: Maybe<Dashboard_Item_Configs>;
-  /** delete data from the table: "dashboard_item_configs" */
-  deleteDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
-  /** delete single row from the table: "dashboard_sections" */
-  deleteDashboardSection?: Maybe<Dashboard_Sections>;
-  /** delete data from the table: "dashboard_sections" */
-  deleteDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
-  /** delete single row from the table: "features" */
-  deleteFeature?: Maybe<Features>;
-  /** delete data from the table: "features" */
-  deleteFeatures?: Maybe<Features_Mutation_Response>;
-  /** delete single row from the table: "metric_annotations" */
-  deleteMetricAnnotation?: Maybe<Metric_Annotations>;
-  /** delete data from the table: "metric_annotations" */
-  deleteMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
-  /** delete single row from the table: "metric_collections" */
-  deleteMetricCollection?: Maybe<Metric_Collections>;
-  /** delete data from the table: "metric_collections" */
-  deleteMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
-  /** delete single row from the table: "metric_descriptions" */
-  deleteMetricDescription?: Maybe<Metric_Descriptions>;
-  /** delete data from the table: "metric_descriptions" */
-  deleteMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
-  /** delete single row from the table: "metric_team_owners" */
-  deleteMetricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** delete data from the table: "metric_team_owners" */
-  deleteMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
-  /** delete single row from the table: "metric_user_owners" */
-  deleteMetricUserOwner?: Maybe<Metric_User_Owners>;
-  /** delete data from the table: "metric_user_owners" */
-  deleteMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
-  /** delete single row from the table: "org_mql_servers" */
-  deleteOrgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** delete data from the table: "org_mql_servers" */
-  deleteOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
-  /** delete single row from the table: "organizations" */
-  deleteOrganization?: Maybe<Organizations>;
-  /** delete single row from the table: "organization_features" */
-  deleteOrganizationFeature?: Maybe<Organization_Features>;
-  /** delete data from the table: "organization_features" */
-  deleteOrganizationFeatures?: Maybe<Organization_Features_Mutation_Response>;
-  /** delete data from the table: "organizations" */
-  deleteOrganizations?: Maybe<Organizations_Mutation_Response>;
-  /** delete data from the table: "question_replies" */
-  deleteQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
-  /** delete single row from the table: "question_replies" */
-  deleteQuestionReply?: Maybe<Question_Replies>;
-  /** delete single row from the table: "saved_query_metrics" */
-  deleteSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** delete data from the table: "saved_query_metrics" */
-  deleteSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
-  /** delete single row from the table: "team_dashboards" */
-  deleteTeamDashboard?: Maybe<Team_Dashboards>;
-  /** delete data from the table: "team_dashboards" */
-  deleteTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
-  /** delete single row from the table: "unsubscribes" */
-  deleteUnsubscribe?: Maybe<Unsubscribes>;
-  /** delete data from the table: "unsubscribes" */
-  deleteUnsubscribes?: Maybe<Unsubscribes_Mutation_Response>;
-  /** delete single row from the table: "user_dashboards" */
-  deleteUserDashboard?: Maybe<User_Dashboards>;
-  /** delete data from the table: "user_dashboards" */
-  deleteUserDashboards?: Maybe<User_Dashboards_Mutation_Response>;
-  /** delete single row from the table: "user_features" */
-  deleteUserFeature?: Maybe<User_Features>;
-  /** delete data from the table: "user_features" */
-  deleteUserFeatures?: Maybe<User_Features_Mutation_Response>;
-  /** delete single row from the table: "user_prefs" */
-  deleteUserPreference?: Maybe<User_Prefs>;
-  /** delete data from the table: "user_prefs" */
-  deleteUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
-  /** delete single row from the table: "user_roles" */
-  deleteUserRole?: Maybe<User_Roles>;
-  /** delete data from the table: "user_roles" */
-  deleteUserRoles?: Maybe<User_Roles_Mutation_Response>;
-  /** delete data from the table: "api_keys" */
-  delete_api_keys?: Maybe<Api_Keys_Mutation_Response>;
-  /** delete single row from the table: "api_keys" */
-  delete_api_keys_by_pk?: Maybe<Api_Keys>;
-  /** delete data from the table: "branch_metadatas" */
-  delete_branch_metadatas?: Maybe<Branch_Metadatas_Mutation_Response>;
-  /** delete single row from the table: "branch_metadatas" */
-  delete_branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** delete data from the table: "dashboard_layouts" */
-  delete_dashboard_layouts?: Maybe<Dashboard_Layouts_Mutation_Response>;
-  /** delete single row from the table: "dashboard_layouts" */
-  delete_dashboard_layouts_by_pk?: Maybe<Dashboard_Layouts>;
-  /** delete data from the table: "dashboard_renderable_types" */
-  delete_dashboard_renderable_types?: Maybe<Dashboard_Renderable_Types_Mutation_Response>;
-  /** delete single row from the table: "dashboard_renderable_types" */
-  delete_dashboard_renderable_types_by_pk?: Maybe<Dashboard_Renderable_Types>;
-  /** delete data from the table: "dashboard_section_types" */
-  delete_dashboard_section_types?: Maybe<Dashboard_Section_Types_Mutation_Response>;
-  /** delete single row from the table: "dashboard_section_types" */
-  delete_dashboard_section_types_by_pk?: Maybe<Dashboard_Section_Types>;
-  /** delete data from the table: "dashboards" */
-  delete_dashboards?: Maybe<Dashboards_Mutation_Response>;
-  /** delete single row from the table: "dashboards" */
-  delete_dashboards_by_pk?: Maybe<Dashboards>;
-  /** delete data from the table: "data_source_versions" */
-  delete_data_source_versions?: Maybe<Data_Source_Versions_Mutation_Response>;
-  /** delete single row from the table: "data_source_versions" */
-  delete_data_source_versions_by_pk?: Maybe<Data_Source_Versions>;
-  /** delete data from the table: "dw_engines" */
-  delete_dw_engines?: Maybe<Dw_Engines_Mutation_Response>;
-  /** delete single row from the table: "dw_engines" */
-  delete_dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** delete data from the table: "metric_collection_view" */
-  delete_metric_collection_view?: Maybe<Metric_Collection_View_Mutation_Response>;
-  /** delete single row from the table: "metric_collection_view" */
-  delete_metric_collection_view_by_pk?: Maybe<Metric_Collection_View>;
-  /** delete data from the table: "metric_current_description" */
-  delete_metric_current_description?: Maybe<Metric_Current_Description_Mutation_Response>;
-  /** delete data from the table: "metric_lineage_data_sources" */
-  delete_metric_lineage_data_sources?: Maybe<Metric_Lineage_Data_Sources_Mutation_Response>;
-  /** delete single row from the table: "metric_lineage_data_sources" */
-  delete_metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** delete data from the table: "metric_versions" */
-  delete_metric_versions?: Maybe<Metric_Versions_Mutation_Response>;
-  /** delete single row from the table: "metric_versions" */
-  delete_metric_versions_by_pk?: Maybe<Metric_Versions>;
-  /** delete data from the table: "metric_view" */
-  delete_metric_view?: Maybe<Metric_View_Mutation_Response>;
-  /** delete data from the table: "model_data_sources" */
-  delete_model_data_sources?: Maybe<Model_Data_Sources_Mutation_Response>;
-  /** delete single row from the table: "model_data_sources" */
-  delete_model_data_sources_by_pk?: Maybe<Model_Data_Sources>;
-  /** delete data from the table: "model_metrics" */
-  delete_model_metrics?: Maybe<Model_Metrics_Mutation_Response>;
-  /** delete single row from the table: "model_metrics" */
-  delete_model_metrics_by_pk?: Maybe<Model_Metrics>;
-  /** delete data from the table: "models" */
-  delete_models?: Maybe<Models_Mutation_Response>;
-  /** delete single row from the table: "models" */
-  delete_models_by_pk?: Maybe<Models>;
-  /** delete data from the table: "mql_heartbeats" */
-  delete_mql_heartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
-  /** delete single row from the table: "mql_heartbeats" */
-  delete_mql_heartbeats_by_pk?: Maybe<Mql_Heartbeats>;
-  /** delete data from the table: "org_data_sources" */
-  delete_org_data_sources?: Maybe<Org_Data_Sources_Mutation_Response>;
-  /** delete single row from the table: "org_data_sources" */
-  delete_org_data_sources_by_pk?: Maybe<Org_Data_Sources>;
-  /** delete data from the table: "org_metrics_current_view" */
-  delete_org_metrics_current_view?: Maybe<Org_Metrics_Current_View_Mutation_Response>;
-  /** delete single row from the table: "org_metrics_current_view" */
-  delete_org_metrics_current_view_by_pk?: Maybe<Org_Metrics_Current_View>;
-  /** delete data from the table: "org_mql_server_logs_types" */
-  delete_org_mql_server_logs_types?: Maybe<Org_Mql_Server_Logs_Types_Mutation_Response>;
-  /** delete single row from the table: "org_mql_server_logs_types" */
-  delete_org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** delete data from the table: "priorities" */
-  delete_priorities?: Maybe<Priorities_Mutation_Response>;
-  /** delete single row from the table: "priorities" */
-  delete_priorities_by_pk?: Maybe<Priorities>;
-  /** delete data from the table: "questions" */
-  delete_questions?: Maybe<Questions_Mutation_Response>;
-  /** delete single row from the table: "questions" */
-  delete_questions_by_pk?: Maybe<Questions>;
-  /** delete data from the table: "saved_queries" */
-  delete_saved_queries?: Maybe<Saved_Queries_Mutation_Response>;
-  /** delete single row from the table: "saved_queries" */
-  delete_saved_queries_by_pk?: Maybe<Saved_Queries>;
-  /** delete data from the table: "team_page_theme_colors" */
-  delete_team_page_theme_colors?: Maybe<Team_Page_Theme_Colors_Mutation_Response>;
-  /** delete single row from the table: "team_page_theme_colors" */
-  delete_team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** delete data from the table: "team_views" */
-  delete_team_views?: Maybe<Team_Views_Mutation_Response>;
-  /** delete single row from the table: "team_views" */
-  delete_team_views_by_pk?: Maybe<Team_Views>;
-  /** delete data from the table: "teams" */
-  delete_teams?: Maybe<Teams_Mutation_Response>;
-  /** delete single row from the table: "teams" */
-  delete_teams_by_pk?: Maybe<Teams>;
-  /** delete data from the table: "user_role_types" */
-  delete_user_role_types?: Maybe<User_Role_Types_Mutation_Response>;
-  /** delete single row from the table: "user_role_types" */
-  delete_user_role_types_by_pk?: Maybe<User_Role_Types>;
-  /** delete data from the table: "users" */
-  delete_users?: Maybe<Users_Mutation_Response>;
-  /** delete single row from the table: "users" */
-  delete_users_by_pk?: Maybe<Users>;
-  /** insert a single row into the table: "question_directed_to" */
-  directQuestionTo?: Maybe<Question_Directed_To>;
-  /** insert data into the table: "question_directed_to" */
-  directQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
-  /** insert data into the table: "api_keys" */
-  insert_api_keys?: Maybe<Api_Keys_Mutation_Response>;
-  /** insert a single row into the table: "api_keys" */
-  insert_api_keys_one?: Maybe<Api_Keys>;
-  /** insert data into the table: "branch_metadatas" */
-  insert_branch_metadatas?: Maybe<Branch_Metadatas_Mutation_Response>;
-  /** insert a single row into the table: "branch_metadatas" */
-  insert_branch_metadatas_one?: Maybe<Branch_Metadatas>;
-  /** insert data into the table: "dashboard_layouts" */
-  insert_dashboard_layouts?: Maybe<Dashboard_Layouts_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_layouts" */
-  insert_dashboard_layouts_one?: Maybe<Dashboard_Layouts>;
-  /** insert data into the table: "dashboard_renderable_types" */
-  insert_dashboard_renderable_types?: Maybe<Dashboard_Renderable_Types_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_renderable_types" */
-  insert_dashboard_renderable_types_one?: Maybe<Dashboard_Renderable_Types>;
-  /** insert data into the table: "dashboard_section_types" */
-  insert_dashboard_section_types?: Maybe<Dashboard_Section_Types_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_section_types" */
-  insert_dashboard_section_types_one?: Maybe<Dashboard_Section_Types>;
-  /** insert data into the table: "data_source_versions" */
-  insert_data_source_versions?: Maybe<Data_Source_Versions_Mutation_Response>;
-  /** insert a single row into the table: "data_source_versions" */
-  insert_data_source_versions_one?: Maybe<Data_Source_Versions>;
-  /** insert data into the table: "dw_engines" */
-  insert_dw_engines?: Maybe<Dw_Engines_Mutation_Response>;
-  /** insert a single row into the table: "dw_engines" */
-  insert_dw_engines_one?: Maybe<Dw_Engines>;
-  /** insert data into the table: "metric_current_description" */
-  insert_metric_current_description?: Maybe<Metric_Current_Description_Mutation_Response>;
-  /** insert a single row into the table: "metric_current_description" */
-  insert_metric_current_description_one?: Maybe<Metric_Current_Description>;
-  /** insert data into the table: "metric_lineage_data_sources" */
-  insert_metric_lineage_data_sources?: Maybe<Metric_Lineage_Data_Sources_Mutation_Response>;
-  /** insert a single row into the table: "metric_lineage_data_sources" */
-  insert_metric_lineage_data_sources_one?: Maybe<Metric_Lineage_Data_Sources>;
-  /** insert data into the table: "metric_versions" */
-  insert_metric_versions?: Maybe<Metric_Versions_Mutation_Response>;
-  /** insert a single row into the table: "metric_versions" */
-  insert_metric_versions_one?: Maybe<Metric_Versions>;
-  /** insert data into the table: "model_data_sources" */
-  insert_model_data_sources?: Maybe<Model_Data_Sources_Mutation_Response>;
-  /** insert a single row into the table: "model_data_sources" */
-  insert_model_data_sources_one?: Maybe<Model_Data_Sources>;
-  /** insert data into the table: "model_metrics" */
-  insert_model_metrics?: Maybe<Model_Metrics_Mutation_Response>;
-  /** insert a single row into the table: "model_metrics" */
-  insert_model_metrics_one?: Maybe<Model_Metrics>;
-  /** insert data into the table: "models" */
-  insert_models?: Maybe<Models_Mutation_Response>;
-  /** insert a single row into the table: "models" */
-  insert_models_one?: Maybe<Models>;
-  /** insert data into the table: "org_data_sources" */
-  insert_org_data_sources?: Maybe<Org_Data_Sources_Mutation_Response>;
-  /** insert a single row into the table: "org_data_sources" */
-  insert_org_data_sources_one?: Maybe<Org_Data_Sources>;
-  /** insert data into the table: "org_metrics_current_view" */
-  insert_org_metrics_current_view?: Maybe<Org_Metrics_Current_View_Mutation_Response>;
-  /** insert a single row into the table: "org_metrics_current_view" */
-  insert_org_metrics_current_view_one?: Maybe<Org_Metrics_Current_View>;
-  /** insert data into the table: "org_mql_server_logs_types" */
-  insert_org_mql_server_logs_types?: Maybe<Org_Mql_Server_Logs_Types_Mutation_Response>;
-  /** insert a single row into the table: "org_mql_server_logs_types" */
-  insert_org_mql_server_logs_types_one?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** insert data into the table: "priorities" */
-  insert_priorities?: Maybe<Priorities_Mutation_Response>;
-  /** insert a single row into the table: "priorities" */
-  insert_priorities_one?: Maybe<Priorities>;
-  /** insert data into the table: "team_page_theme_colors" */
-  insert_team_page_theme_colors?: Maybe<Team_Page_Theme_Colors_Mutation_Response>;
-  /** insert a single row into the table: "team_page_theme_colors" */
-  insert_team_page_theme_colors_one?: Maybe<Team_Page_Theme_Colors>;
-  /** insert data into the table: "user_role_types" */
-  insert_user_role_types?: Maybe<User_Role_Types_Mutation_Response>;
-  /** insert a single row into the table: "user_role_types" */
-  insert_user_role_types_one?: Maybe<User_Role_Types>;
-  /** insert data into the table: "users" */
-  insert_users?: Maybe<Users_Mutation_Response>;
-  /** insert a single row into the table: "users" */
-  insert_users_one?: Maybe<Users>;
-  /** insert a single row into the table: "question_likes" */
-  likeQuestion?: Maybe<Question_Likes>;
-  /** insert data into the table: "question_likes" */
-  likeQuestions?: Maybe<Question_Likes_Mutation_Response>;
-  logMqlLog?: Maybe<LogMqlLogs>;
-  /** perform the action: "reactivateUser" */
-  reactivateUser?: Maybe<ReactivateUserOutput>;
-  /** delete single row from the table: "question_directed_to" */
-  removeDirectQuestionTo?: Maybe<Question_Directed_To>;
-  /** delete data from the table: "question_directed_to" */
-  removeDirectQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
-  /** delete single row from the table: "metric_approvals" */
-  removeMetricApproval?: Maybe<Metric_Approvals>;
-  /** delete data from the table: "metric_approvals" */
-  removeMetricApprovals?: Maybe<Metric_Approvals_Mutation_Response>;
-  /** delete single row from the table: "metric_collection_metrics" */
-  removeMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** delete data from the table: "metric_collection_metrics" */
-  removeMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
-  /** delete single row from the table: "team_members" */
-  removeTeamMember?: Maybe<Team_Members>;
-  /** delete data from the table: "team_members" */
-  removeTeamMembers?: Maybe<Team_Members_Mutation_Response>;
-  /** perform the action: "removeUserRole" */
-  removeUserRole?: Maybe<RemoveUserRoleOutput>;
-  /** delete single row from the table: "question_likes" */
-  unlikeQuestion?: Maybe<Question_Likes>;
-  /** delete data from the table: "question_likes" */
-  unlikeQuestions?: Maybe<Question_Likes_Mutation_Response>;
-  /** update single row of the table: "annotations" */
-  updateAnnotation?: Maybe<Annotations>;
-  /** update data of the table: "annotations" */
-  updateAnnotations?: Maybe<Annotations_Mutation_Response>;
-  /** update single row of the table: "api_keys" */
-  updateApiKey?: Maybe<Api_Keys>;
-  /** update data of the table: "api_keys" */
-  updateApiKeys?: Maybe<Api_Keys_Mutation_Response>;
-  /** update single row of the table: "dashboards" */
-  updateDashboard?: Maybe<Dashboards>;
-  /** update single row of the table: "dashboard_item_configs" */
-  updateDashboardItem?: Maybe<Dashboard_Item_Configs>;
-  /** update data of the table: "dashboard_item_configs" */
-  updateDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
-  /** update single row of the table: "dashboard_sections" */
-  updateDashboardSection?: Maybe<Dashboard_Sections>;
-  /** update data of the table: "dashboard_sections" */
-  updateDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
-  /** update data of the table: "dashboards" */
-  updateDashboards?: Maybe<Dashboards_Mutation_Response>;
-  /** update single row of the table: "features" */
-  updateFeature?: Maybe<Features>;
-  /** update data of the table: "features" */
-  updateFeatures?: Maybe<Features_Mutation_Response>;
-  /** update single row of the table: "metric_annotations" */
-  updateMetricAnnotation?: Maybe<Metric_Annotations>;
-  /** update data of the table: "metric_annotations" */
-  updateMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
-  /** update single row of the table: "metric_collections" */
-  updateMetricCollection?: Maybe<Metric_Collections>;
-  /** update data of the table: "metric_collections" */
-  updateMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
-  /** perform the action: "updateMyEmail" */
-  updateMyEmail?: Maybe<UpdateMyEmailOutput>;
-  /** update single row of the table: "org_mql_servers" */
-  updateOrgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** update data of the table: "org_mql_servers" */
-  updateOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
-  /** update single row of the table: "organizations" */
-  updateOrganization?: Maybe<Organizations>;
-  /** update single row of the table: "organization_features" */
-  updateOrganizationFeature?: Maybe<Organization_Features>;
-  /** update data of the table: "organization_features" */
-  updateOrganizationFeatures?: Maybe<Organization_Features_Mutation_Response>;
-  /** update data of the table: "organizations" */
-  updateOrganizations?: Maybe<Organizations_Mutation_Response>;
-  /** update single row of the table: "questions" */
-  updateQuestion?: Maybe<Questions>;
-  /** update data of the table: "question_replies" */
-  updateQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
-  /** update single row of the table: "question_replies" */
-  updateQuestionReply?: Maybe<Question_Replies>;
-  /** update data of the table: "questions" */
-  updateQuestions?: Maybe<Questions_Mutation_Response>;
-  /** update data of the table: "saved_queries" */
-  updateSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
-  /** update single row of the table: "saved_queries" */
-  updateSavedQuery?: Maybe<Saved_Queries>;
-  /** update single row of the table: "teams" */
-  updateTeam?: Maybe<Teams>;
-  /** update single row of the table: "team_dashboards" */
-  updateTeamDashboard?: Maybe<Team_Dashboards>;
-  /** update data of the table: "team_dashboards" */
-  updateTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
-  /** update single row of the table: "team_members" */
-  updateTeamMember?: Maybe<Team_Members>;
-  /** update data of the table: "team_members" */
-  updateTeamMembers?: Maybe<Team_Members_Mutation_Response>;
-  /** update data of the table: "teams" */
-  updateTeams?: Maybe<Teams_Mutation_Response>;
-  /** update single row of the table: "users" */
-  updateUser?: Maybe<Users>;
-  /** update single row of the table: "user_dashboards" */
-  updateUserDashboard?: Maybe<User_Dashboards>;
-  /** update data of the table: "user_dashboards" */
-  updateUserDashboards?: Maybe<User_Dashboards_Mutation_Response>;
-  /** perform the action: "updateUserEmailForOrg" */
-  updateUserEmailForOrg?: Maybe<UpdateUserEmailForOrgOutput>;
-  /** update single row of the table: "user_features" */
-  updateUserFeature?: Maybe<User_Features>;
-  /** update data of the table: "user_features" */
-  updateUserFeatures?: Maybe<User_Features_Mutation_Response>;
-  /** update single row of the table: "user_prefs" */
-  updateUserPreference?: Maybe<User_Prefs>;
-  /** update data of the table: "user_prefs" */
-  updateUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
-  /** update single row of the table: "user_roles" */
-  updateUserRole?: Maybe<User_Roles>;
-  /** update data of the table: "user_roles" */
-  updateUserRoles?: Maybe<User_Roles_Mutation_Response>;
-  /** update data of the table: "users" */
-  updateUsers?: Maybe<Users_Mutation_Response>;
-  /** update data of the table: "branch_metadatas" */
-  update_branch_metadatas?: Maybe<Branch_Metadatas_Mutation_Response>;
-  /** update single row of the table: "branch_metadatas" */
-  update_branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** update data of the table: "dashboard_layouts" */
-  update_dashboard_layouts?: Maybe<Dashboard_Layouts_Mutation_Response>;
-  /** update single row of the table: "dashboard_layouts" */
-  update_dashboard_layouts_by_pk?: Maybe<Dashboard_Layouts>;
-  /** update data of the table: "dashboard_renderable_types" */
-  update_dashboard_renderable_types?: Maybe<Dashboard_Renderable_Types_Mutation_Response>;
-  /** update single row of the table: "dashboard_renderable_types" */
-  update_dashboard_renderable_types_by_pk?: Maybe<Dashboard_Renderable_Types>;
-  /** update data of the table: "dashboard_section_types" */
-  update_dashboard_section_types?: Maybe<Dashboard_Section_Types_Mutation_Response>;
-  /** update single row of the table: "dashboard_section_types" */
-  update_dashboard_section_types_by_pk?: Maybe<Dashboard_Section_Types>;
-  /** update data of the table: "data_source_versions" */
-  update_data_source_versions?: Maybe<Data_Source_Versions_Mutation_Response>;
-  /** update single row of the table: "data_source_versions" */
-  update_data_source_versions_by_pk?: Maybe<Data_Source_Versions>;
-  /** update data of the table: "dw_engines" */
-  update_dw_engines?: Maybe<Dw_Engines_Mutation_Response>;
-  /** update single row of the table: "dw_engines" */
-  update_dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** update data of the table: "metric_approvals" */
-  update_metric_approvals?: Maybe<Metric_Approvals_Mutation_Response>;
-  /** update single row of the table: "metric_approvals" */
-  update_metric_approvals_by_pk?: Maybe<Metric_Approvals>;
-  /** update data of the table: "metric_collection_metrics" */
-  update_metric_collection_metrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
-  /** update single row of the table: "metric_collection_metrics" */
-  update_metric_collection_metrics_by_pk?: Maybe<Metric_Collection_Metrics>;
-  /** update data of the table: "metric_collection_view" */
-  update_metric_collection_view?: Maybe<Metric_Collection_View_Mutation_Response>;
-  /** update single row of the table: "metric_collection_view" */
-  update_metric_collection_view_by_pk?: Maybe<Metric_Collection_View>;
-  /** update data of the table: "metric_current_description" */
-  update_metric_current_description?: Maybe<Metric_Current_Description_Mutation_Response>;
-  /** update data of the table: "metric_descriptions" */
-  update_metric_descriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
-  /** update single row of the table: "metric_descriptions" */
-  update_metric_descriptions_by_pk?: Maybe<Metric_Descriptions>;
-  /** update data of the table: "metric_lineage_data_sources" */
-  update_metric_lineage_data_sources?: Maybe<Metric_Lineage_Data_Sources_Mutation_Response>;
-  /** update single row of the table: "metric_lineage_data_sources" */
-  update_metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** update data of the table: "metric_team_owners" */
-  update_metric_team_owners?: Maybe<Metric_Team_Owners_Mutation_Response>;
-  /** update single row of the table: "metric_team_owners" */
-  update_metric_team_owners_by_pk?: Maybe<Metric_Team_Owners>;
-  /** update data of the table: "metric_user_owners" */
-  update_metric_user_owners?: Maybe<Metric_User_Owners_Mutation_Response>;
-  /** update single row of the table: "metric_user_owners" */
-  update_metric_user_owners_by_pk?: Maybe<Metric_User_Owners>;
-  /** update data of the table: "metric_versions" */
-  update_metric_versions?: Maybe<Metric_Versions_Mutation_Response>;
-  /** update single row of the table: "metric_versions" */
-  update_metric_versions_by_pk?: Maybe<Metric_Versions>;
-  /** update data of the table: "metric_view" */
-  update_metric_view?: Maybe<Metric_View_Mutation_Response>;
-  /** update data of the table: "model_data_sources" */
-  update_model_data_sources?: Maybe<Model_Data_Sources_Mutation_Response>;
-  /** update single row of the table: "model_data_sources" */
-  update_model_data_sources_by_pk?: Maybe<Model_Data_Sources>;
-  /** update data of the table: "model_metrics" */
-  update_model_metrics?: Maybe<Model_Metrics_Mutation_Response>;
-  /** update single row of the table: "model_metrics" */
-  update_model_metrics_by_pk?: Maybe<Model_Metrics>;
-  /** update data of the table: "models" */
-  update_models?: Maybe<Models_Mutation_Response>;
-  /** update single row of the table: "models" */
-  update_models_by_pk?: Maybe<Models>;
-  /** update data of the table: "mql_heartbeats" */
-  update_mql_heartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
-  /** update single row of the table: "mql_heartbeats" */
-  update_mql_heartbeats_by_pk?: Maybe<Mql_Heartbeats>;
-  /** update data of the table: "org_data_sources" */
-  update_org_data_sources?: Maybe<Org_Data_Sources_Mutation_Response>;
-  /** update single row of the table: "org_data_sources" */
-  update_org_data_sources_by_pk?: Maybe<Org_Data_Sources>;
-  /** update data of the table: "org_metrics_current_view" */
-  update_org_metrics_current_view?: Maybe<Org_Metrics_Current_View_Mutation_Response>;
-  /** update single row of the table: "org_metrics_current_view" */
-  update_org_metrics_current_view_by_pk?: Maybe<Org_Metrics_Current_View>;
-  /** update data of the table: "org_mql_server_logs_types" */
-  update_org_mql_server_logs_types?: Maybe<Org_Mql_Server_Logs_Types_Mutation_Response>;
-  /** update single row of the table: "org_mql_server_logs_types" */
-  update_org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** update data of the table: "priorities" */
-  update_priorities?: Maybe<Priorities_Mutation_Response>;
-  /** update single row of the table: "priorities" */
-  update_priorities_by_pk?: Maybe<Priorities>;
-  /** update data of the table: "question_directed_to" */
-  update_question_directed_to?: Maybe<Question_Directed_To_Mutation_Response>;
-  /** update single row of the table: "question_directed_to" */
-  update_question_directed_to_by_pk?: Maybe<Question_Directed_To>;
-  /** update data of the table: "question_likes" */
-  update_question_likes?: Maybe<Question_Likes_Mutation_Response>;
-  /** update single row of the table: "question_likes" */
-  update_question_likes_by_pk?: Maybe<Question_Likes>;
-  /** update data of the table: "saved_query_metrics" */
-  update_saved_query_metrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
-  /** update single row of the table: "saved_query_metrics" */
-  update_saved_query_metrics_by_pk?: Maybe<Saved_Query_Metrics>;
-  /** update data of the table: "team_page_theme_colors" */
-  update_team_page_theme_colors?: Maybe<Team_Page_Theme_Colors_Mutation_Response>;
-  /** update single row of the table: "team_page_theme_colors" */
-  update_team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** update data of the table: "team_views" */
-  update_team_views?: Maybe<Team_Views_Mutation_Response>;
-  /** update single row of the table: "team_views" */
-  update_team_views_by_pk?: Maybe<Team_Views>;
-  /** update data of the table: "unsubscribes" */
-  update_unsubscribes?: Maybe<Unsubscribes_Mutation_Response>;
-  /** update single row of the table: "unsubscribes" */
-  update_unsubscribes_by_pk?: Maybe<Unsubscribes>;
-  /** update data of the table: "user_role_types" */
-  update_user_role_types?: Maybe<User_Role_Types_Mutation_Response>;
-  /** update single row of the table: "user_role_types" */
-  update_user_role_types_by_pk?: Maybe<User_Role_Types>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddMetricCollectionMetricArgs = {
-  object: Metric_Collection_Metrics_Insert_Input;
-  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddMetricCollectionMetricsArgs = {
-  objects: Array<Metric_Collection_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddTeamMemberArgs = {
-  object: Team_Members_Insert_Input;
-  on_conflict?: Maybe<Team_Members_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddTeamMembersArgs = {
-  objects: Array<Team_Members_Insert_Input>;
-  on_conflict?: Maybe<Team_Members_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddUserRoleArgs = {
-  input: AddUserRoleInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootApproveMetricArgs = {
-  object: Metric_Approvals_Insert_Input;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootApproveMetricsArgs = {
-  objects: Array<Metric_Approvals_Insert_Input>;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAssignUserRoleArgs = {
-  object: User_Roles_Insert_Input;
-  on_conflict?: Maybe<User_Roles_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAssignUserRolesArgs = {
-  objects: Array<User_Roles_Insert_Input>;
-  on_conflict?: Maybe<User_Roles_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateAnnotationArgs = {
-  object: Annotations_Insert_Input;
-  on_conflict?: Maybe<Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateAnnotationsArgs = {
-  objects: Array<Annotations_Insert_Input>;
-  on_conflict?: Maybe<Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateApiKeyForUserArgs = {
-  input: CreateApiKeyForUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardArgs = {
-  object: Dashboards_Insert_Input;
-  on_conflict?: Maybe<Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardItemArgs = {
-  object: Dashboard_Item_Configs_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardItemsArgs = {
-  objects: Array<Dashboard_Item_Configs_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardSectionArgs = {
-  object: Dashboard_Sections_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardSectionsArgs = {
-  objects: Array<Dashboard_Sections_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardsArgs = {
-  objects: Array<Dashboards_Insert_Input>;
-  on_conflict?: Maybe<Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateFeatureArgs = {
-  object: Features_Insert_Input;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateFeaturesArgs = {
-  objects: Array<Features_Insert_Input>;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricAnnotationArgs = {
-  object: Metric_Annotations_Insert_Input;
-  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricAnnotationsArgs = {
-  objects: Array<Metric_Annotations_Insert_Input>;
-  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionArgs = {
-  object: Metric_Collections_Insert_Input;
-  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionViewArgs = {
-  object: Metric_Collection_View_Insert_Input;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionViewsArgs = {
-  objects: Array<Metric_Collection_View_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionsArgs = {
-  objects: Array<Metric_Collections_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricDescriptionArgs = {
-  object: Metric_Descriptions_Insert_Input;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricDescriptionsArgs = {
-  objects: Array<Metric_Descriptions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricTeamOwnerArgs = {
-  object: Metric_Team_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricTeamOwnersArgs = {
-  objects: Array<Metric_Team_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricUserOwnerArgs = {
-  object: Metric_User_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricUserOwnersArgs = {
-  objects: Array<Metric_User_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricViewArgs = {
-  object: Metric_View_Insert_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricViewsArgs = {
-  objects: Array<Metric_View_Insert_Input>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMqlHeartbeatArgs = {
-  object: Mql_Heartbeats_Insert_Input;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMqlHeartbeatsArgs = {
-  objects: Array<Mql_Heartbeats_Insert_Input>;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrgMqlServerArgs = {
-  object: Org_Mql_Servers_Insert_Input;
-  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrgMqlServersArgs = {
-  objects: Array<Org_Mql_Servers_Insert_Input>;
-  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationArgs = {
-  object: Organizations_Insert_Input;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationFeatureArgs = {
-  object: Organization_Features_Insert_Input;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationFeaturesArgs = {
-  objects: Array<Organization_Features_Insert_Input>;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationsArgs = {
-  objects: Array<Organizations_Insert_Input>;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionArgs = {
-  object: Questions_Insert_Input;
-  on_conflict?: Maybe<Questions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionRepliesArgs = {
-  objects: Array<Question_Replies_Insert_Input>;
-  on_conflict?: Maybe<Question_Replies_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionReplyArgs = {
-  object: Question_Replies_Insert_Input;
-  on_conflict?: Maybe<Question_Replies_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionsArgs = {
-  objects: Array<Questions_Insert_Input>;
-  on_conflict?: Maybe<Questions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateSavedQueriesArgs = {
-  objects: Array<Saved_Queries_Insert_Input>;
-  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateSavedQueryArgs = {
-  object: Saved_Queries_Insert_Input;
-  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamArgs = {
-  object: Teams_Insert_Input;
-  on_conflict?: Maybe<Teams_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamDashboardArgs = {
-  object: Team_Dashboards_Insert_Input;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamDashboardsArgs = {
-  objects: Array<Team_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamViewArgs = {
-  object: Team_Views_Insert_Input;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamViewsArgs = {
-  objects: Array<Team_Views_Insert_Input>;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamsArgs = {
-  objects: Array<Teams_Insert_Input>;
-  on_conflict?: Maybe<Teams_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUnsubscribeArgs = {
-  object: Unsubscribes_Insert_Input;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUnsubscribesArgs = {
-  objects: Array<Unsubscribes_Insert_Input>;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserArgs = {
-  input: CreateUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserDashboardArgs = {
-  object: User_Dashboards_Insert_Input;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserDashboardsArgs = {
-  objects: Array<User_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserFeatureArgs = {
-  object: User_Features_Insert_Input;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserFeaturesArgs = {
-  objects: Array<User_Features_Insert_Input>;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserForOrgArgs = {
-  input: CreateUserForOrgInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserPreferenceArgs = {
-  object: User_Prefs_Insert_Input;
-  on_conflict?: Maybe<User_Prefs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserPreferencesArgs = {
-  objects: Array<User_Prefs_Insert_Input>;
-  on_conflict?: Maybe<User_Prefs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreatedSavedQueryMetricArgs = {
-  object: Saved_Query_Metrics_Insert_Input;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreatedSavedQueryMetricsArgs = {
-  objects: Array<Saved_Query_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeactivateUserArgs = {
-  input: DeactivateUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteAnnotationsArgs = {
-  where: Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardItemArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardItemsArgs = {
-  where: Dashboard_Item_Configs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardSectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardSectionsArgs = {
-  where: Dashboard_Sections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteFeatureArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteFeaturesArgs = {
-  where: Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricAnnotationsArgs = {
-  where: Metric_Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricCollectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricCollectionsArgs = {
-  where: Metric_Collections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricDescriptionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricDescriptionsArgs = {
-  where: Metric_Descriptions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricTeamOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricTeamOwnersArgs = {
-  where: Metric_Team_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricUserOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricUserOwnersArgs = {
-  where: Metric_User_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrgMqlServerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrgMqlServersArgs = {
-  where: Org_Mql_Servers_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationFeatureArgs = {
-  featureId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationFeaturesArgs = {
-  where: Organization_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationsArgs = {
-  where: Organizations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteQuestionRepliesArgs = {
-  where: Question_Replies_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteQuestionReplyArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteSavedQueryMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteSavedQueryMetricsArgs = {
-  where: Saved_Query_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteTeamDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  team_id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteTeamDashboardsArgs = {
-  where: Team_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUnsubscribeArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUnsubscribesArgs = {
-  where: Unsubscribes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserDashboardsArgs = {
-  where: User_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserFeatureArgs = {
-  featureId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserFeaturesArgs = {
-  where: User_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserPreferenceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserPreferencesArgs = {
-  where: User_Prefs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserRoleArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserRolesArgs = {
-  where: User_Roles_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Api_KeysArgs = {
-  where: Api_Keys_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Api_Keys_By_PkArgs = {
-  prefix: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Branch_MetadatasArgs = {
-  where: Branch_Metadatas_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Branch_Metadatas_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_LayoutsArgs = {
-  where: Dashboard_Layouts_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Layouts_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Renderable_TypesArgs = {
-  where: Dashboard_Renderable_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Renderable_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Section_TypesArgs = {
-  where: Dashboard_Section_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Section_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_DashboardsArgs = {
-  where: Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboards_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Data_Source_VersionsArgs = {
-  where: Data_Source_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Data_Source_Versions_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dw_EnginesArgs = {
-  where: Dw_Engines_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dw_Engines_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Collection_ViewArgs = {
-  where: Metric_Collection_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Collection_View_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Current_DescriptionArgs = {
-  where: Metric_Current_Description_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Lineage_Data_SourcesArgs = {
-  where: Metric_Lineage_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Lineage_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_VersionsArgs = {
-  where: Metric_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Versions_By_PkArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_ViewArgs = {
-  where: Metric_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_Data_SourcesArgs = {
-  where: Model_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_Data_Sources_By_PkArgs = {
-  dataSourceVersionId: Scalars['Int'];
-  modelId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_MetricsArgs = {
-  where: Model_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_Metrics_By_PkArgs = {
-  metricId: Scalars['bigint'];
-  metricVersionId: Scalars['bigint'];
-  modelId: Scalars['bigint'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_ModelsArgs = {
-  where: Models_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Models_By_PkArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Mql_HeartbeatsArgs = {
-  where: Mql_Heartbeats_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Mql_Heartbeats_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Data_SourcesArgs = {
-  where: Org_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Metrics_Current_ViewArgs = {
-  where: Org_Metrics_Current_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Metrics_Current_View_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Mql_Server_Logs_TypesArgs = {
-  where: Org_Mql_Server_Logs_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Mql_Server_Logs_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_PrioritiesArgs = {
-  where: Priorities_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Priorities_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_QuestionsArgs = {
-  where: Questions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Questions_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Saved_QueriesArgs = {
-  where: Saved_Queries_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Saved_Queries_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_Page_Theme_ColorsArgs = {
-  where: Team_Page_Theme_Colors_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_Page_Theme_Colors_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_ViewsArgs = {
-  where: Team_Views_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_Views_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_TeamsArgs = {
-  where: Teams_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Teams_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_User_Role_TypesArgs = {
-  where: User_Role_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_User_Role_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_UsersArgs = {
-  where: Users_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Users_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDirectQuestionToArgs = {
-  object: Question_Directed_To_Insert_Input;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootDirectQuestionToMultipleArgs = {
-  objects: Array<Question_Directed_To_Insert_Input>;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Api_KeysArgs = {
-  objects: Array<Api_Keys_Insert_Input>;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Api_Keys_OneArgs = {
-  object: Api_Keys_Insert_Input;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Branch_MetadatasArgs = {
-  objects: Array<Branch_Metadatas_Insert_Input>;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Branch_Metadatas_OneArgs = {
-  object: Branch_Metadatas_Insert_Input;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_LayoutsArgs = {
-  objects: Array<Dashboard_Layouts_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Layouts_OneArgs = {
-  object: Dashboard_Layouts_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Renderable_TypesArgs = {
-  objects: Array<Dashboard_Renderable_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Renderable_Types_OneArgs = {
-  object: Dashboard_Renderable_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Section_TypesArgs = {
-  objects: Array<Dashboard_Section_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Section_Types_OneArgs = {
-  object: Dashboard_Section_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Data_Source_VersionsArgs = {
-  objects: Array<Data_Source_Versions_Insert_Input>;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Data_Source_Versions_OneArgs = {
-  object: Data_Source_Versions_Insert_Input;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dw_EnginesArgs = {
-  objects: Array<Dw_Engines_Insert_Input>;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dw_Engines_OneArgs = {
-  object: Dw_Engines_Insert_Input;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Current_DescriptionArgs = {
-  objects: Array<Metric_Current_Description_Insert_Input>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Current_Description_OneArgs = {
-  object: Metric_Current_Description_Insert_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Lineage_Data_SourcesArgs = {
-  objects: Array<Metric_Lineage_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Lineage_Data_Sources_OneArgs = {
-  object: Metric_Lineage_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_VersionsArgs = {
-  objects: Array<Metric_Versions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Versions_OneArgs = {
-  object: Metric_Versions_Insert_Input;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_Data_SourcesArgs = {
-  objects: Array<Model_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_Data_Sources_OneArgs = {
-  object: Model_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_MetricsArgs = {
-  objects: Array<Model_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_Metrics_OneArgs = {
-  object: Model_Metrics_Insert_Input;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_ModelsArgs = {
-  objects: Array<Models_Insert_Input>;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Models_OneArgs = {
-  object: Models_Insert_Input;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Data_SourcesArgs = {
-  objects: Array<Org_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Data_Sources_OneArgs = {
-  object: Org_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Metrics_Current_ViewArgs = {
-  objects: Array<Org_Metrics_Current_View_Insert_Input>;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Metrics_Current_View_OneArgs = {
-  object: Org_Metrics_Current_View_Insert_Input;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Mql_Server_Logs_TypesArgs = {
-  objects: Array<Org_Mql_Server_Logs_Types_Insert_Input>;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Mql_Server_Logs_Types_OneArgs = {
-  object: Org_Mql_Server_Logs_Types_Insert_Input;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_PrioritiesArgs = {
-  objects: Array<Priorities_Insert_Input>;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Priorities_OneArgs = {
-  object: Priorities_Insert_Input;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Team_Page_Theme_ColorsArgs = {
-  objects: Array<Team_Page_Theme_Colors_Insert_Input>;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Team_Page_Theme_Colors_OneArgs = {
-  object: Team_Page_Theme_Colors_Insert_Input;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_User_Role_TypesArgs = {
-  objects: Array<User_Role_Types_Insert_Input>;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_User_Role_Types_OneArgs = {
-  object: User_Role_Types_Insert_Input;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_UsersArgs = {
-  objects: Array<Users_Insert_Input>;
-  on_conflict?: Maybe<Users_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Users_OneArgs = {
-  object: Users_Insert_Input;
-  on_conflict?: Maybe<Users_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootLikeQuestionArgs = {
-  object: Question_Likes_Insert_Input;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootLikeQuestionsArgs = {
-  objects: Array<Question_Likes_Insert_Input>;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootLogMqlLogArgs = {
-  level?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<Scalars['String']>>;
-};
-
-
-/** mutation root */
-export type Mutation_RootReactivateUserArgs = {
-  input: ReactivateUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveDirectQuestionToArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveDirectQuestionToMultipleArgs = {
-  where: Question_Directed_To_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricApprovalArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricApprovalsArgs = {
-  where: Metric_Approvals_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricCollectionMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricCollectionMetricsArgs = {
-  where: Metric_Collection_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveTeamMemberArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveTeamMembersArgs = {
-  where: Team_Members_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveUserRoleArgs = {
-  input: RemoveUserRoleInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootUnlikeQuestionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootUnlikeQuestionsArgs = {
-  where: Question_Likes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateAnnotationArgs = {
-  _inc?: Maybe<Annotations_Inc_Input>;
-  _set?: Maybe<Annotations_Set_Input>;
-  pk_columns: Annotations_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateAnnotationsArgs = {
-  _inc?: Maybe<Annotations_Inc_Input>;
-  _set?: Maybe<Annotations_Set_Input>;
-  where: Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateApiKeyArgs = {
-  _inc?: Maybe<Api_Keys_Inc_Input>;
-  _set?: Maybe<Api_Keys_Set_Input>;
-  pk_columns: Api_Keys_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateApiKeysArgs = {
-  _inc?: Maybe<Api_Keys_Inc_Input>;
-  _set?: Maybe<Api_Keys_Set_Input>;
-  where: Api_Keys_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardArgs = {
-  _inc?: Maybe<Dashboards_Inc_Input>;
-  _set?: Maybe<Dashboards_Set_Input>;
-  pk_columns: Dashboards_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardItemArgs = {
-  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
-  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
-  pk_columns: Dashboard_Item_Configs_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardItemsArgs = {
-  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
-  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
-  where: Dashboard_Item_Configs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardSectionArgs = {
-  _inc?: Maybe<Dashboard_Sections_Inc_Input>;
-  _set?: Maybe<Dashboard_Sections_Set_Input>;
-  pk_columns: Dashboard_Sections_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardSectionsArgs = {
-  _inc?: Maybe<Dashboard_Sections_Inc_Input>;
-  _set?: Maybe<Dashboard_Sections_Set_Input>;
-  where: Dashboard_Sections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardsArgs = {
-  _inc?: Maybe<Dashboards_Inc_Input>;
-  _set?: Maybe<Dashboards_Set_Input>;
-  where: Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateFeatureArgs = {
-  _inc?: Maybe<Features_Inc_Input>;
-  _set?: Maybe<Features_Set_Input>;
-  pk_columns: Features_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateFeaturesArgs = {
-  _inc?: Maybe<Features_Inc_Input>;
-  _set?: Maybe<Features_Set_Input>;
-  where: Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricAnnotationArgs = {
-  _inc?: Maybe<Metric_Annotations_Inc_Input>;
-  _set?: Maybe<Metric_Annotations_Set_Input>;
-  pk_columns: Metric_Annotations_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricAnnotationsArgs = {
-  _inc?: Maybe<Metric_Annotations_Inc_Input>;
-  _set?: Maybe<Metric_Annotations_Set_Input>;
-  where: Metric_Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricCollectionArgs = {
-  _inc?: Maybe<Metric_Collections_Inc_Input>;
-  _set?: Maybe<Metric_Collections_Set_Input>;
-  pk_columns: Metric_Collections_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricCollectionsArgs = {
-  _inc?: Maybe<Metric_Collections_Inc_Input>;
-  _set?: Maybe<Metric_Collections_Set_Input>;
-  where: Metric_Collections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMyEmailArgs = {
-  input: UpdateMyEmailInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrgMqlServerArgs = {
-  _inc?: Maybe<Org_Mql_Servers_Inc_Input>;
-  _set?: Maybe<Org_Mql_Servers_Set_Input>;
-  pk_columns: Org_Mql_Servers_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrgMqlServersArgs = {
-  _inc?: Maybe<Org_Mql_Servers_Inc_Input>;
-  _set?: Maybe<Org_Mql_Servers_Set_Input>;
-  where: Org_Mql_Servers_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationArgs = {
-  _inc?: Maybe<Organizations_Inc_Input>;
-  _set?: Maybe<Organizations_Set_Input>;
-  pk_columns: Organizations_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationFeatureArgs = {
-  _inc?: Maybe<Organization_Features_Inc_Input>;
-  _set?: Maybe<Organization_Features_Set_Input>;
-  pk_columns: Organization_Features_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationFeaturesArgs = {
-  _inc?: Maybe<Organization_Features_Inc_Input>;
-  _set?: Maybe<Organization_Features_Set_Input>;
-  where: Organization_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationsArgs = {
-  _inc?: Maybe<Organizations_Inc_Input>;
-  _set?: Maybe<Organizations_Set_Input>;
-  where: Organizations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionArgs = {
-  _inc?: Maybe<Questions_Inc_Input>;
-  _set?: Maybe<Questions_Set_Input>;
-  pk_columns: Questions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionRepliesArgs = {
-  _inc?: Maybe<Question_Replies_Inc_Input>;
-  _set?: Maybe<Question_Replies_Set_Input>;
-  where: Question_Replies_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionReplyArgs = {
-  _inc?: Maybe<Question_Replies_Inc_Input>;
-  _set?: Maybe<Question_Replies_Set_Input>;
-  pk_columns: Question_Replies_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionsArgs = {
-  _inc?: Maybe<Questions_Inc_Input>;
-  _set?: Maybe<Questions_Set_Input>;
-  where: Questions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateSavedQueriesArgs = {
-  _inc?: Maybe<Saved_Queries_Inc_Input>;
-  _set?: Maybe<Saved_Queries_Set_Input>;
-  where: Saved_Queries_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateSavedQueryArgs = {
-  _inc?: Maybe<Saved_Queries_Inc_Input>;
-  _set?: Maybe<Saved_Queries_Set_Input>;
-  pk_columns: Saved_Queries_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamArgs = {
-  _inc?: Maybe<Teams_Inc_Input>;
-  _set?: Maybe<Teams_Set_Input>;
-  pk_columns: Teams_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamDashboardArgs = {
-  _inc?: Maybe<Team_Dashboards_Inc_Input>;
-  _set?: Maybe<Team_Dashboards_Set_Input>;
-  pk_columns: Team_Dashboards_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamDashboardsArgs = {
-  _inc?: Maybe<Team_Dashboards_Inc_Input>;
-  _set?: Maybe<Team_Dashboards_Set_Input>;
-  where: Team_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamMemberArgs = {
-  _inc?: Maybe<Team_Members_Inc_Input>;
-  _set?: Maybe<Team_Members_Set_Input>;
-  pk_columns: Team_Members_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamMembersArgs = {
-  _inc?: Maybe<Team_Members_Inc_Input>;
-  _set?: Maybe<Team_Members_Set_Input>;
-  where: Team_Members_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamsArgs = {
-  _inc?: Maybe<Teams_Inc_Input>;
-  _set?: Maybe<Teams_Set_Input>;
-  where: Teams_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserArgs = {
-  _inc?: Maybe<Users_Inc_Input>;
-  _set?: Maybe<Users_Set_Input>;
-  pk_columns: Users_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserDashboardArgs = {
-  _inc?: Maybe<User_Dashboards_Inc_Input>;
-  _set?: Maybe<User_Dashboards_Set_Input>;
-  pk_columns: User_Dashboards_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserDashboardsArgs = {
-  _inc?: Maybe<User_Dashboards_Inc_Input>;
-  _set?: Maybe<User_Dashboards_Set_Input>;
-  where: User_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserEmailForOrgArgs = {
-  input: UpdateUserEmailForOrgInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserFeatureArgs = {
-  _inc?: Maybe<User_Features_Inc_Input>;
-  _set?: Maybe<User_Features_Set_Input>;
-  pk_columns: User_Features_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserFeaturesArgs = {
-  _inc?: Maybe<User_Features_Inc_Input>;
-  _set?: Maybe<User_Features_Set_Input>;
-  where: User_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserPreferenceArgs = {
-  _inc?: Maybe<User_Prefs_Inc_Input>;
-  _set?: Maybe<User_Prefs_Set_Input>;
-  pk_columns: User_Prefs_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserPreferencesArgs = {
-  _inc?: Maybe<User_Prefs_Inc_Input>;
-  _set?: Maybe<User_Prefs_Set_Input>;
-  where: User_Prefs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserRoleArgs = {
-  _inc?: Maybe<User_Roles_Inc_Input>;
-  _set?: Maybe<User_Roles_Set_Input>;
-  pk_columns: User_Roles_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserRolesArgs = {
-  _inc?: Maybe<User_Roles_Inc_Input>;
-  _set?: Maybe<User_Roles_Set_Input>;
-  where: User_Roles_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUsersArgs = {
-  _inc?: Maybe<Users_Inc_Input>;
-  _set?: Maybe<Users_Set_Input>;
-  where: Users_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Branch_MetadatasArgs = {
-  _inc?: Maybe<Branch_Metadatas_Inc_Input>;
-  _set?: Maybe<Branch_Metadatas_Set_Input>;
-  where: Branch_Metadatas_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Branch_Metadatas_By_PkArgs = {
-  _inc?: Maybe<Branch_Metadatas_Inc_Input>;
-  _set?: Maybe<Branch_Metadatas_Set_Input>;
-  pk_columns: Branch_Metadatas_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_LayoutsArgs = {
-  _set?: Maybe<Dashboard_Layouts_Set_Input>;
-  where: Dashboard_Layouts_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Layouts_By_PkArgs = {
-  _set?: Maybe<Dashboard_Layouts_Set_Input>;
-  pk_columns: Dashboard_Layouts_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Renderable_TypesArgs = {
-  _set?: Maybe<Dashboard_Renderable_Types_Set_Input>;
-  where: Dashboard_Renderable_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Renderable_Types_By_PkArgs = {
-  _set?: Maybe<Dashboard_Renderable_Types_Set_Input>;
-  pk_columns: Dashboard_Renderable_Types_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Section_TypesArgs = {
-  _set?: Maybe<Dashboard_Section_Types_Set_Input>;
-  where: Dashboard_Section_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Section_Types_By_PkArgs = {
-  _set?: Maybe<Dashboard_Section_Types_Set_Input>;
-  pk_columns: Dashboard_Section_Types_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Data_Source_VersionsArgs = {
-  _inc?: Maybe<Data_Source_Versions_Inc_Input>;
-  _set?: Maybe<Data_Source_Versions_Set_Input>;
-  where: Data_Source_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Data_Source_Versions_By_PkArgs = {
-  _inc?: Maybe<Data_Source_Versions_Inc_Input>;
-  _set?: Maybe<Data_Source_Versions_Set_Input>;
-  pk_columns: Data_Source_Versions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dw_EnginesArgs = {
-  _set?: Maybe<Dw_Engines_Set_Input>;
-  where: Dw_Engines_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dw_Engines_By_PkArgs = {
-  _set?: Maybe<Dw_Engines_Set_Input>;
-  pk_columns: Dw_Engines_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_ApprovalsArgs = {
-  _inc?: Maybe<Metric_Approvals_Inc_Input>;
-  _set?: Maybe<Metric_Approvals_Set_Input>;
-  where: Metric_Approvals_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Approvals_By_PkArgs = {
-  _inc?: Maybe<Metric_Approvals_Inc_Input>;
-  _set?: Maybe<Metric_Approvals_Set_Input>;
-  pk_columns: Metric_Approvals_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_MetricsArgs = {
-  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
-  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
-  where: Metric_Collection_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_Metrics_By_PkArgs = {
-  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
-  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
-  pk_columns: Metric_Collection_Metrics_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_ViewArgs = {
-  _inc?: Maybe<Metric_Collection_View_Inc_Input>;
-  _set?: Maybe<Metric_Collection_View_Set_Input>;
-  where: Metric_Collection_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_View_By_PkArgs = {
-  _inc?: Maybe<Metric_Collection_View_Inc_Input>;
-  _set?: Maybe<Metric_Collection_View_Set_Input>;
-  pk_columns: Metric_Collection_View_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Current_DescriptionArgs = {
-  _inc?: Maybe<Metric_Current_Description_Inc_Input>;
-  _set?: Maybe<Metric_Current_Description_Set_Input>;
-  where: Metric_Current_Description_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_DescriptionsArgs = {
-  _inc?: Maybe<Metric_Descriptions_Inc_Input>;
-  _set?: Maybe<Metric_Descriptions_Set_Input>;
-  where: Metric_Descriptions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Descriptions_By_PkArgs = {
-  _inc?: Maybe<Metric_Descriptions_Inc_Input>;
-  _set?: Maybe<Metric_Descriptions_Set_Input>;
-  pk_columns: Metric_Descriptions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Lineage_Data_SourcesArgs = {
-  _inc?: Maybe<Metric_Lineage_Data_Sources_Inc_Input>;
-  _set?: Maybe<Metric_Lineage_Data_Sources_Set_Input>;
-  where: Metric_Lineage_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Lineage_Data_Sources_By_PkArgs = {
-  _inc?: Maybe<Metric_Lineage_Data_Sources_Inc_Input>;
-  _set?: Maybe<Metric_Lineage_Data_Sources_Set_Input>;
-  pk_columns: Metric_Lineage_Data_Sources_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Team_OwnersArgs = {
-  _inc?: Maybe<Metric_Team_Owners_Inc_Input>;
-  _set?: Maybe<Metric_Team_Owners_Set_Input>;
-  where: Metric_Team_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Team_Owners_By_PkArgs = {
-  _inc?: Maybe<Metric_Team_Owners_Inc_Input>;
-  _set?: Maybe<Metric_Team_Owners_Set_Input>;
-  pk_columns: Metric_Team_Owners_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_User_OwnersArgs = {
-  _inc?: Maybe<Metric_User_Owners_Inc_Input>;
-  _set?: Maybe<Metric_User_Owners_Set_Input>;
-  where: Metric_User_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_User_Owners_By_PkArgs = {
-  _inc?: Maybe<Metric_User_Owners_Inc_Input>;
-  _set?: Maybe<Metric_User_Owners_Set_Input>;
-  pk_columns: Metric_User_Owners_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_VersionsArgs = {
-  _append?: Maybe<Metric_Versions_Append_Input>;
-  _delete_at_path?: Maybe<Metric_Versions_Delete_At_Path_Input>;
-  _delete_elem?: Maybe<Metric_Versions_Delete_Elem_Input>;
-  _delete_key?: Maybe<Metric_Versions_Delete_Key_Input>;
-  _inc?: Maybe<Metric_Versions_Inc_Input>;
-  _prepend?: Maybe<Metric_Versions_Prepend_Input>;
-  _set?: Maybe<Metric_Versions_Set_Input>;
-  where: Metric_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Versions_By_PkArgs = {
-  _append?: Maybe<Metric_Versions_Append_Input>;
-  _delete_at_path?: Maybe<Metric_Versions_Delete_At_Path_Input>;
-  _delete_elem?: Maybe<Metric_Versions_Delete_Elem_Input>;
-  _delete_key?: Maybe<Metric_Versions_Delete_Key_Input>;
-  _inc?: Maybe<Metric_Versions_Inc_Input>;
-  _prepend?: Maybe<Metric_Versions_Prepend_Input>;
-  _set?: Maybe<Metric_Versions_Set_Input>;
-  pk_columns: Metric_Versions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_ViewArgs = {
-  _inc?: Maybe<Metric_View_Inc_Input>;
-  _set?: Maybe<Metric_View_Set_Input>;
-  where: Metric_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_Data_SourcesArgs = {
-  _inc?: Maybe<Model_Data_Sources_Inc_Input>;
-  _set?: Maybe<Model_Data_Sources_Set_Input>;
-  where: Model_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_Data_Sources_By_PkArgs = {
-  _inc?: Maybe<Model_Data_Sources_Inc_Input>;
-  _set?: Maybe<Model_Data_Sources_Set_Input>;
-  pk_columns: Model_Data_Sources_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_MetricsArgs = {
-  _inc?: Maybe<Model_Metrics_Inc_Input>;
-  _set?: Maybe<Model_Metrics_Set_Input>;
-  where: Model_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_Metrics_By_PkArgs = {
-  _inc?: Maybe<Model_Metrics_Inc_Input>;
-  _set?: Maybe<Model_Metrics_Set_Input>;
-  pk_columns: Model_Metrics_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_ModelsArgs = {
-  _inc?: Maybe<Models_Inc_Input>;
-  _set?: Maybe<Models_Set_Input>;
-  where: Models_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Models_By_PkArgs = {
-  _inc?: Maybe<Models_Inc_Input>;
-  _set?: Maybe<Models_Set_Input>;
-  pk_columns: Models_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Mql_HeartbeatsArgs = {
-  _inc?: Maybe<Mql_Heartbeats_Inc_Input>;
-  _set?: Maybe<Mql_Heartbeats_Set_Input>;
-  where: Mql_Heartbeats_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Mql_Heartbeats_By_PkArgs = {
-  _inc?: Maybe<Mql_Heartbeats_Inc_Input>;
-  _set?: Maybe<Mql_Heartbeats_Set_Input>;
-  pk_columns: Mql_Heartbeats_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Data_SourcesArgs = {
-  _inc?: Maybe<Org_Data_Sources_Inc_Input>;
-  _set?: Maybe<Org_Data_Sources_Set_Input>;
-  where: Org_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Data_Sources_By_PkArgs = {
-  _inc?: Maybe<Org_Data_Sources_Inc_Input>;
-  _set?: Maybe<Org_Data_Sources_Set_Input>;
-  pk_columns: Org_Data_Sources_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Metrics_Current_ViewArgs = {
-  _inc?: Maybe<Org_Metrics_Current_View_Inc_Input>;
-  _set?: Maybe<Org_Metrics_Current_View_Set_Input>;
-  where: Org_Metrics_Current_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Metrics_Current_View_By_PkArgs = {
-  _inc?: Maybe<Org_Metrics_Current_View_Inc_Input>;
-  _set?: Maybe<Org_Metrics_Current_View_Set_Input>;
-  pk_columns: Org_Metrics_Current_View_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Mql_Server_Logs_TypesArgs = {
-  _set?: Maybe<Org_Mql_Server_Logs_Types_Set_Input>;
-  where: Org_Mql_Server_Logs_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Mql_Server_Logs_Types_By_PkArgs = {
-  _set?: Maybe<Org_Mql_Server_Logs_Types_Set_Input>;
-  pk_columns: Org_Mql_Server_Logs_Types_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_PrioritiesArgs = {
-  _set?: Maybe<Priorities_Set_Input>;
-  where: Priorities_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Priorities_By_PkArgs = {
-  _set?: Maybe<Priorities_Set_Input>;
-  pk_columns: Priorities_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_Directed_ToArgs = {
-  _inc?: Maybe<Question_Directed_To_Inc_Input>;
-  _set?: Maybe<Question_Directed_To_Set_Input>;
-  where: Question_Directed_To_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_Directed_To_By_PkArgs = {
-  _inc?: Maybe<Question_Directed_To_Inc_Input>;
-  _set?: Maybe<Question_Directed_To_Set_Input>;
-  pk_columns: Question_Directed_To_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_LikesArgs = {
-  _inc?: Maybe<Question_Likes_Inc_Input>;
-  _set?: Maybe<Question_Likes_Set_Input>;
-  where: Question_Likes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_Likes_By_PkArgs = {
-  _inc?: Maybe<Question_Likes_Inc_Input>;
-  _set?: Maybe<Question_Likes_Set_Input>;
-  pk_columns: Question_Likes_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Saved_Query_MetricsArgs = {
-  _inc?: Maybe<Saved_Query_Metrics_Inc_Input>;
-  _set?: Maybe<Saved_Query_Metrics_Set_Input>;
-  where: Saved_Query_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Saved_Query_Metrics_By_PkArgs = {
-  _inc?: Maybe<Saved_Query_Metrics_Inc_Input>;
-  _set?: Maybe<Saved_Query_Metrics_Set_Input>;
-  pk_columns: Saved_Query_Metrics_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_Page_Theme_ColorsArgs = {
-  _set?: Maybe<Team_Page_Theme_Colors_Set_Input>;
-  where: Team_Page_Theme_Colors_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_Page_Theme_Colors_By_PkArgs = {
-  _set?: Maybe<Team_Page_Theme_Colors_Set_Input>;
-  pk_columns: Team_Page_Theme_Colors_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_ViewsArgs = {
-  _inc?: Maybe<Team_Views_Inc_Input>;
-  _set?: Maybe<Team_Views_Set_Input>;
-  where: Team_Views_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_Views_By_PkArgs = {
-  _inc?: Maybe<Team_Views_Inc_Input>;
-  _set?: Maybe<Team_Views_Set_Input>;
-  pk_columns: Team_Views_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_UnsubscribesArgs = {
-  _inc?: Maybe<Unsubscribes_Inc_Input>;
-  _set?: Maybe<Unsubscribes_Set_Input>;
-  where: Unsubscribes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Unsubscribes_By_PkArgs = {
-  _inc?: Maybe<Unsubscribes_Inc_Input>;
-  _set?: Maybe<Unsubscribes_Set_Input>;
-  pk_columns: Unsubscribes_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_User_Role_TypesArgs = {
-  _set?: Maybe<User_Role_Types_Set_Input>;
-  where: User_Role_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_User_Role_Types_By_PkArgs = {
-  _set?: Maybe<User_Role_Types_Set_Input>;
-  pk_columns: User_Role_Types_Pk_Columns_Input;
-};
 
 /** column ordering options */
 export enum Order_By {
@@ -14249,12 +11080,6 @@ export type Org_Data_Sources_Aggregate_Order_By = {
   variance?: Maybe<Org_Data_Sources_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "org_data_sources" */
-export type Org_Data_Sources_Arr_Rel_Insert_Input = {
-  data: Array<Org_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Org_Data_Sources_Avg_Fields = {
   __typename?: 'org_data_sources_avg_fields';
@@ -14280,29 +11105,6 @@ export type Org_Data_Sources_Bool_Exp = {
   name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "org_data_sources" */
-export enum Org_Data_Sources_Constraint {
-  /** unique or primary key constraint */
-  OrgDataSourcesPkey = 'org_data_sources_pkey'
-}
-
-/** input type for incrementing integer column in table "org_data_sources" */
-export type Org_Data_Sources_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "org_data_sources" */
-export type Org_Data_Sources_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metricVersions?: Maybe<Metric_Versions_Arr_Rel_Insert_Input>;
-  modelDataSources?: Maybe<Model_Data_Sources_Arr_Rel_Insert_Input>;
-  name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -14339,28 +11141,6 @@ export type Org_Data_Sources_Min_Order_By = {
   organizationId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "org_data_sources" */
-export type Org_Data_Sources_Mutation_Response = {
-  __typename?: 'org_data_sources_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Org_Data_Sources>;
-};
-
-/** input type for inserting object relation for remote table "org_data_sources" */
-export type Org_Data_Sources_Obj_Rel_Insert_Input = {
-  data: Org_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
-/** on conflict condition type for table "org_data_sources" */
-export type Org_Data_Sources_On_Conflict = {
-  constraint: Org_Data_Sources_Constraint;
-  update_columns: Array<Org_Data_Sources_Update_Column>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "org_data_sources" */
 export type Org_Data_Sources_Order_By = {
   createdAt?: Maybe<Order_By>;
@@ -14388,14 +11168,6 @@ export enum Org_Data_Sources_Select_Column {
   /** column name */
   OrganizationId = 'organizationId'
 }
-
-/** input type for updating data in table "org_data_sources" */
-export type Org_Data_Sources_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Org_Data_Sources_Stddev_Fields = {
@@ -14448,18 +11220,6 @@ export type Org_Data_Sources_Sum_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "org_data_sources" */
-export enum Org_Data_Sources_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Org_Data_Sources_Var_Pop_Fields = {
@@ -14546,7 +11306,6 @@ export type Org_Metrics_Current_View = {
   questions: Array<Questions>;
   /** An aggregated array relationship */
   questions_aggregate: Questions_Aggregate;
-  removedAt?: Maybe<Scalars['timestamptz']>;
   /** An array relationship */
   savedQueries: Array<Saved_Query_Metrics>;
   /** An aggregated array relationship */
@@ -14904,12 +11663,6 @@ export type Org_Metrics_Current_View_Aggregate_Order_By = {
   variance?: Maybe<Org_Metrics_Current_View_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Arr_Rel_Insert_Input = {
-  data: Array<Org_Metrics_Current_View_Insert_Input>;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Org_Metrics_Current_View_Avg_Fields = {
   __typename?: 'org_metrics_current_view_avg_fields';
@@ -14953,60 +11706,12 @@ export type Org_Metrics_Current_View_Bool_Exp = {
   organizationId?: Maybe<Int_Comparison_Exp>;
   params?: Maybe<Json_Comparison_Exp>;
   questions?: Maybe<Questions_Bool_Exp>;
-  removedAt?: Maybe<Timestamptz_Comparison_Exp>;
   savedQueries?: Maybe<Saved_Query_Metrics_Bool_Exp>;
   teamOwners?: Maybe<Metric_Team_Owners_Bool_Exp>;
   tier?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   userOwners?: Maybe<Metric_User_Owners_Bool_Exp>;
   views?: Maybe<Metric_View_Bool_Exp>;
-};
-
-/** unique or primary key constraints on table "org_metrics_current_view" */
-export enum Org_Metrics_Current_View_Constraint {
-  /** unique or primary key constraint */
-  OrgMetricsCurrentViewOrganizationIdNameKey = 'org_metrics_current_view_organization_id_name_key',
-  /** unique or primary key constraint */
-  OrgMetricsCurrentViewPkey = 'org_metrics_current_view_pkey'
-}
-
-/** input type for incrementing integer column in table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metricType?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  tier?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Insert_Input = {
-  annotations?: Maybe<Metric_Annotations_Arr_Rel_Insert_Input>;
-  approvals?: Maybe<Metric_Approvals_Arr_Rel_Insert_Input>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  currentDescription?: Maybe<Metric_Current_Description_Obj_Rel_Insert_Input>;
-  currentModelMetric?: Maybe<Model_Metrics_Obj_Rel_Insert_Input>;
-  definition?: Maybe<Scalars['String']>;
-  descriptions?: Maybe<Metric_Descriptions_Arr_Rel_Insert_Input>;
-  displayName?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metadata?: Maybe<Scalars['json']>;
-  metricCollections?: Maybe<Metric_Collection_Metrics_Arr_Rel_Insert_Input>;
-  metricType?: Maybe<Scalars['Int']>;
-  model?: Maybe<Models_Obj_Rel_Insert_Input>;
-  modelId?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['json']>;
-  questions?: Maybe<Questions_Arr_Rel_Insert_Input>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
-  savedQueries?: Maybe<Saved_Query_Metrics_Arr_Rel_Insert_Input>;
-  teamOwners?: Maybe<Metric_Team_Owners_Arr_Rel_Insert_Input>;
-  tier?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userOwners?: Maybe<Metric_User_Owners_Arr_Rel_Insert_Input>;
-  views?: Maybe<Metric_View_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -15020,7 +11725,6 @@ export type Org_Metrics_Current_View_Max_Fields = {
   modelId?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
   tier?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -15035,7 +11739,6 @@ export type Org_Metrics_Current_View_Max_Order_By = {
   modelId?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  removedAt?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -15051,7 +11754,6 @@ export type Org_Metrics_Current_View_Min_Fields = {
   modelId?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
   tier?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -15066,31 +11768,8 @@ export type Org_Metrics_Current_View_Min_Order_By = {
   modelId?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  removedAt?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Mutation_Response = {
-  __typename?: 'org_metrics_current_view_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Org_Metrics_Current_View>;
-};
-
-/** input type for inserting object relation for remote table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Obj_Rel_Insert_Input = {
-  data: Org_Metrics_Current_View_Insert_Input;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
-/** on conflict condition type for table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_On_Conflict = {
-  constraint: Org_Metrics_Current_View_Constraint;
-  update_columns: Array<Org_Metrics_Current_View_Update_Column>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "org_metrics_current_view" */
@@ -15114,7 +11793,6 @@ export type Org_Metrics_Current_View_Order_By = {
   organizationId?: Maybe<Order_By>;
   params?: Maybe<Order_By>;
   questions_aggregate?: Maybe<Questions_Aggregate_Order_By>;
-  removedAt?: Maybe<Order_By>;
   savedQueries_aggregate?: Maybe<Saved_Query_Metrics_Aggregate_Order_By>;
   teamOwners_aggregate?: Maybe<Metric_Team_Owners_Aggregate_Order_By>;
   tier?: Maybe<Order_By>;
@@ -15151,29 +11829,10 @@ export enum Org_Metrics_Current_View_Select_Column {
   /** column name */
   Params = 'params',
   /** column name */
-  RemovedAt = 'removedAt',
-  /** column name */
   Tier = 'tier',
   /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  definition?: Maybe<Scalars['String']>;
-  displayName?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metadata?: Maybe<Scalars['json']>;
-  metricType?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['json']>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
-  tier?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Org_Metrics_Current_View_Stddev_Fields = {
@@ -15251,36 +11910,6 @@ export type Org_Metrics_Current_View_Sum_Order_By = {
   tier?: Maybe<Order_By>;
 };
 
-/** update columns of table "org_metrics_current_view" */
-export enum Org_Metrics_Current_View_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Definition = 'definition',
-  /** column name */
-  DisplayName = 'displayName',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Metadata = 'metadata',
-  /** column name */
-  MetricType = 'metricType',
-  /** column name */
-  ModelId = 'modelId',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Params = 'params',
-  /** column name */
-  RemovedAt = 'removedAt',
-  /** column name */
-  Tier = 'tier',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
-
 /** aggregate var_pop on columns */
 export type Org_Metrics_Current_View_Var_Pop_Fields = {
   __typename?: 'org_metrics_current_view_var_pop_fields';
@@ -15338,68 +11967,6 @@ export type Org_Metrics_Current_View_Variance_Order_By = {
   tier?: Maybe<Order_By>;
 };
 
-/**
- * Contains options what we do with an org's MQL server logs
- *
- *
- * columns and relationships of "org_mql_server_logs_types"
- */
-export type Org_Mql_Server_Logs_Types = {
-  __typename?: 'org_mql_server_logs_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate = {
-  __typename?: 'org_mql_server_logs_types_aggregate';
-  aggregate?: Maybe<Org_Mql_Server_Logs_Types_Aggregate_Fields>;
-  nodes: Array<Org_Mql_Server_Logs_Types>;
-};
-
-/** aggregate fields of "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate_Fields = {
-  __typename?: 'org_mql_server_logs_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Org_Mql_Server_Logs_Types_Max_Fields>;
-  min?: Maybe<Org_Mql_Server_Logs_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Org_Mql_Server_Logs_Types_Max_Order_By>;
-  min?: Maybe<Org_Mql_Server_Logs_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Arr_Rel_Insert_Input = {
-  data: Array<Org_Mql_Server_Logs_Types_Insert_Input>;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "org_mql_server_logs_types". All fields are combined with a logical 'AND'. */
-export type Org_Mql_Server_Logs_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>>>;
-  _not?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "org_mql_server_logs_types" */
-export enum Org_Mql_Server_Logs_Types_Constraint {
-  /** unique or primary key constraint */
-  OrgMqlServerLogsTypesPkey = 'org_mql_server_logs_types_pkey'
-}
-
 export enum Org_Mql_Server_Logs_Types_Enum {
   /** stream MQL logs back to transform backend */
   Always = 'ALWAYS',
@@ -15418,93 +11985,6 @@ export type Org_Mql_Server_Logs_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Org_Mql_Server_Logs_Types_Enum>>;
 };
 
-/** input type for inserting data into table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Org_Mql_Server_Logs_Types_Max_Fields = {
-  __typename?: 'org_mql_server_logs_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Org_Mql_Server_Logs_Types_Min_Fields = {
-  __typename?: 'org_mql_server_logs_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Mutation_Response = {
-  __typename?: 'org_mql_server_logs_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Org_Mql_Server_Logs_Types>;
-};
-
-/** input type for inserting object relation for remote table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Obj_Rel_Insert_Input = {
-  data: Org_Mql_Server_Logs_Types_Insert_Input;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_On_Conflict = {
-  constraint: Org_Mql_Server_Logs_Types_Constraint;
-  update_columns: Array<Org_Mql_Server_Logs_Types_Update_Column>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "org_mql_server_logs_types" */
-export enum Org_Mql_Server_Logs_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "org_mql_server_logs_types" */
-export enum Org_Mql_Server_Logs_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
 /**
  * Allowing for multiple MQL Servers for an Organization enables the use of development environments and other non-production applications.
  *
@@ -15515,11 +11995,8 @@ export type Org_Mql_Servers = {
   __typename?: 'org_mql_servers';
   configSecret?: Maybe<Scalars['String']>;
   createdAt: Scalars['timestamptz'];
-  dw_engine?: Maybe<Dw_Engines_Enum>;
   /** An array relationship */
   heartbeats: Array<Mql_Heartbeats>;
-  /** An aggregated array relationship */
-  heartbeats_aggregate: Mql_Heartbeats_Aggregate;
   id: Scalars['Int'];
   isOrgDefault: Scalars['Boolean'];
   name: Scalars['String'];
@@ -15538,21 +12015,6 @@ export type Org_Mql_Servers = {
  * columns and relationships of "org_mql_servers"
  */
 export type Org_Mql_ServersHeartbeatsArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/**
- * Allowing for multiple MQL Servers for an Organization enables the use of development environments and other non-production applications.
- *
- *
- * columns and relationships of "org_mql_servers"
- */
-export type Org_Mql_ServersHeartbeats_AggregateArgs = {
   distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
   limit?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
@@ -15631,7 +12093,6 @@ export type Org_Mql_Servers_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Org_Mql_Servers_Bool_Exp>>>;
   configSecret?: Maybe<String_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dw_engine?: Maybe<Dw_Engines_Enum_Comparison_Exp>;
   heartbeats?: Maybe<Mql_Heartbeats_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   isOrgDefault?: Maybe<Boolean_Comparison_Exp>;
@@ -15650,24 +12111,12 @@ export enum Org_Mql_Servers_Constraint {
   OrgMqlServersPkey = 'org_mql_servers_pkey'
 }
 
-/** input type for incrementing integer column in table "org_mql_servers" */
-export type Org_Mql_Servers_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "org_mql_servers" */
 export type Org_Mql_Servers_Insert_Input = {
   configSecret?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dw_engine?: Maybe<Dw_Engines_Enum>;
   heartbeats?: Maybe<Mql_Heartbeats_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars['Int']>;
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   url?: Maybe<Scalars['String']>;
 };
 
@@ -15743,8 +12192,6 @@ export type Org_Mql_Servers_On_Conflict = {
 export type Org_Mql_Servers_Order_By = {
   configSecret?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  dw_engine?: Maybe<Order_By>;
-  heartbeats_aggregate?: Maybe<Mql_Heartbeats_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
   isOrgDefault?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
@@ -15766,8 +12213,6 @@ export enum Org_Mql_Servers_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DwEngine = 'dw_engine',
-  /** column name */
   Id = 'id',
   /** column name */
   IsOrgDefault = 'isOrgDefault',
@@ -15784,13 +12229,8 @@ export enum Org_Mql_Servers_Select_Column {
 /** input type for updating data in table "org_mql_servers" */
 export type Org_Mql_Servers_Set_Input = {
   configSecret?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dw_engine?: Maybe<Dw_Engines_Enum>;
-  id?: Maybe<Scalars['Int']>;
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   url?: Maybe<Scalars['String']>;
 };
 
@@ -15851,19 +12291,9 @@ export enum Org_Mql_Servers_Update_Column {
   /** column name */
   ConfigSecret = 'configSecret',
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DwEngine = 'dw_engine',
-  /** column name */
-  Id = 'id',
-  /** column name */
   IsOrgDefault = 'isOrgDefault',
   /** column name */
   Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
   /** column name */
   Url = 'url'
 }
@@ -15963,12 +12393,6 @@ export type Organization_Features_Aggregate_Order_By = {
   variance?: Maybe<Organization_Features_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "organization_features" */
-export type Organization_Features_Arr_Rel_Insert_Input = {
-  data: Array<Organization_Features_Insert_Input>;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Organization_Features_Avg_Fields = {
   __typename?: 'organization_features_avg_fields';
@@ -15991,26 +12415,6 @@ export type Organization_Features_Bool_Exp = {
   featureId?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "organization_features" */
-export enum Organization_Features_Constraint {
-  /** unique or primary key constraint */
-  OrganizationFeaturesPkey = 'organization_features_pkey'
-}
-
-/** input type for incrementing integer column in table "organization_features" */
-export type Organization_Features_Inc_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "organization_features" */
-export type Organization_Features_Insert_Input = {
-  feature?: Maybe<Features_Obj_Rel_Insert_Input>;
-  featureId?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -16039,28 +12443,6 @@ export type Organization_Features_Min_Order_By = {
   organizationId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "organization_features" */
-export type Organization_Features_Mutation_Response = {
-  __typename?: 'organization_features_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Organization_Features>;
-};
-
-/** input type for inserting object relation for remote table "organization_features" */
-export type Organization_Features_Obj_Rel_Insert_Input = {
-  data: Organization_Features_Insert_Input;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
-/** on conflict condition type for table "organization_features" */
-export type Organization_Features_On_Conflict = {
-  constraint: Organization_Features_Constraint;
-  update_columns: Array<Organization_Features_Update_Column>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "organization_features" */
 export type Organization_Features_Order_By = {
   feature?: Maybe<Features_Order_By>;
@@ -16082,12 +12464,6 @@ export enum Organization_Features_Select_Column {
   /** column name */
   OrganizationId = 'organizationId'
 }
-
-/** input type for updating data in table "organization_features" */
-export type Organization_Features_Set_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Organization_Features_Stddev_Fields = {
@@ -16140,14 +12516,6 @@ export type Organization_Features_Sum_Order_By = {
   featureId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "organization_features" */
-export enum Organization_Features_Update_Column {
-  /** column name */
-  FeatureId = 'featureId',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Organization_Features_Var_Pop_Fields = {
@@ -16216,11 +12584,8 @@ export type Organizations = {
   dataSources: Array<Org_Data_Sources>;
   /** An aggregated array relationship */
   dataSources_aggregate: Org_Data_Sources_Aggregate;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
   /** This is a soft delete for the Organization model. If the Organization has been deactivated, this value will reflect the timestamp of that operation. If the Organization is active, this value will be null. */
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
   /** An array relationship */
   features: Array<Organization_Features>;
   /** An aggregated array relationship */
@@ -16260,8 +12625,6 @@ export type Organizations = {
   models_aggregate: Models_Aggregate;
   /** An array relationship */
   mqlHeartbeats: Array<Mql_Heartbeats>;
-  /** An aggregated array relationship */
-  mqlHeartbeats_aggregate: Mql_Heartbeats_Aggregate;
   mqlServerLogs?: Maybe<Org_Mql_Server_Logs_Types_Enum>;
   /** The URL of your MQL Server */
   mqlServerUrl?: Maybe<Scalars['String']>;
@@ -16296,8 +12659,6 @@ export type Organizations = {
   /** An aggregated array relationship */
   savedQueries_aggregate: Saved_Queries_Aggregate;
   shardId?: Maybe<Scalars['Int']>;
-  /** The slug is a URL-friendly string used to identify an organization in the App */
-  slug?: Maybe<Scalars['String']>;
   /** The URL of your source control system, used for generating links to config files */
   sourceControlUrl?: Maybe<Scalars['String']>;
   /** An array relationship */
@@ -16708,21 +13069,6 @@ export type OrganizationsMqlHeartbeatsArgs = {
  *
  * columns and relationships of "organizations"
  */
-export type OrganizationsMqlHeartbeats_AggregateArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/**
- * An Organization is a company that is a customer of Transform
- *
- *
- * columns and relationships of "organizations"
- */
 export type OrganizationsMqlServersArgs = {
   distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
   limit?: Maybe<Scalars['Int']>;
@@ -17046,74 +13392,6 @@ export type OrganizationsUsers_AggregateArgs = {
   where?: Maybe<Users_Bool_Exp>;
 };
 
-/** aggregated selection of "organizations" */
-export type Organizations_Aggregate = {
-  __typename?: 'organizations_aggregate';
-  aggregate?: Maybe<Organizations_Aggregate_Fields>;
-  nodes: Array<Organizations>;
-};
-
-/** aggregate fields of "organizations" */
-export type Organizations_Aggregate_Fields = {
-  __typename?: 'organizations_aggregate_fields';
-  avg?: Maybe<Organizations_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Organizations_Max_Fields>;
-  min?: Maybe<Organizations_Min_Fields>;
-  stddev?: Maybe<Organizations_Stddev_Fields>;
-  stddev_pop?: Maybe<Organizations_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Organizations_Stddev_Samp_Fields>;
-  sum?: Maybe<Organizations_Sum_Fields>;
-  var_pop?: Maybe<Organizations_Var_Pop_Fields>;
-  var_samp?: Maybe<Organizations_Var_Samp_Fields>;
-  variance?: Maybe<Organizations_Variance_Fields>;
-};
-
-
-/** aggregate fields of "organizations" */
-export type Organizations_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Organizations_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "organizations" */
-export type Organizations_Aggregate_Order_By = {
-  avg?: Maybe<Organizations_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Organizations_Max_Order_By>;
-  min?: Maybe<Organizations_Min_Order_By>;
-  stddev?: Maybe<Organizations_Stddev_Order_By>;
-  stddev_pop?: Maybe<Organizations_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Organizations_Stddev_Samp_Order_By>;
-  sum?: Maybe<Organizations_Sum_Order_By>;
-  var_pop?: Maybe<Organizations_Var_Pop_Order_By>;
-  var_samp?: Maybe<Organizations_Var_Samp_Order_By>;
-  variance?: Maybe<Organizations_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "organizations" */
-export type Organizations_Arr_Rel_Insert_Input = {
-  data: Array<Organizations_Insert_Input>;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Organizations_Avg_Fields = {
-  __typename?: 'organizations_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "organizations" */
-export type Organizations_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
 /** Boolean expression to filter rows from the table "organizations". All fields are combined with a logical 'AND'. */
 export type Organizations_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Organizations_Bool_Exp>>>;
@@ -17125,10 +13403,7 @@ export type Organizations_Bool_Exp = {
   currentModel?: Maybe<Model_Current_Bool_Exp>;
   dashboards?: Maybe<Dashboards_Bool_Exp>;
   dataSources?: Maybe<Org_Data_Sources_Bool_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
-  date_delete?: Maybe<Int_Comparison_Exp>;
   deactivatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  domain?: Maybe<String_Comparison_Exp>;
   features?: Maybe<Organization_Features_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   isHosted?: Maybe<Boolean_Comparison_Exp>;
@@ -17153,7 +13428,6 @@ export type Organizations_Bool_Exp = {
   questions?: Maybe<Questions_Bool_Exp>;
   savedQueries?: Maybe<Saved_Queries_Bool_Exp>;
   shardId?: Maybe<Int_Comparison_Exp>;
-  slug?: Maybe<String_Comparison_Exp>;
   sourceControlUrl?: Maybe<String_Comparison_Exp>;
   team_members?: Maybe<Team_Members_Bool_Exp>;
   teams?: Maybe<Teams_Bool_Exp>;
@@ -17169,137 +13443,6 @@ export enum Organizations_Constraint {
   OrganizationsPkey = 'organizations_pkey'
 }
 
-/** input type for incrementing integer column in table "organizations" */
-export type Organizations_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  shardId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "organizations" */
-export type Organizations_Insert_Input = {
-  annotations?: Maybe<Annotations_Arr_Rel_Insert_Input>;
-  api_keys?: Maybe<Api_Keys_Arr_Rel_Insert_Input>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboards?: Maybe<Dashboards_Arr_Rel_Insert_Input>;
-  dataSources?: Maybe<Org_Data_Sources_Arr_Rel_Insert_Input>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  features?: Maybe<Organization_Features_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars['Int']>;
-  isHosted?: Maybe<Scalars['Boolean']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  metricCollections?: Maybe<Metric_Collections_Arr_Rel_Insert_Input>;
-  metric_annotations?: Maybe<Metric_Annotations_Arr_Rel_Insert_Input>;
-  metric_approvals?: Maybe<Metric_Approvals_Arr_Rel_Insert_Input>;
-  metric_team_owners?: Maybe<Metric_Team_Owners_Arr_Rel_Insert_Input>;
-  metric_views?: Maybe<Metric_View_Arr_Rel_Insert_Input>;
-  metrics?: Maybe<Org_Metrics_Current_View_Arr_Rel_Insert_Input>;
-  models?: Maybe<Models_Arr_Rel_Insert_Input>;
-  mqlHeartbeats?: Maybe<Mql_Heartbeats_Arr_Rel_Insert_Input>;
-  mqlServerLogs?: Maybe<Org_Mql_Server_Logs_Types_Enum>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  mqlServers?: Maybe<Org_Mql_Servers_Arr_Rel_Insert_Input>;
-  name?: Maybe<Scalars['String']>;
-  primaryConfigBranch?: Maybe<Scalars['String']>;
-  primaryConfigRepo?: Maybe<Scalars['String']>;
-  question_directed_tos?: Maybe<Question_Directed_To_Arr_Rel_Insert_Input>;
-  question_likes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
-  question_replies?: Maybe<Question_Replies_Arr_Rel_Insert_Input>;
-  questions?: Maybe<Questions_Arr_Rel_Insert_Input>;
-  savedQueries?: Maybe<Saved_Queries_Arr_Rel_Insert_Input>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
-  sourceControlUrl?: Maybe<Scalars['String']>;
-  team_members?: Maybe<Team_Members_Arr_Rel_Insert_Input>;
-  teams?: Maybe<Teams_Arr_Rel_Insert_Input>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  user_prefs?: Maybe<User_Prefs_Arr_Rel_Insert_Input>;
-  user_roles?: Maybe<User_Roles_Arr_Rel_Insert_Input>;
-  users?: Maybe<Users_Arr_Rel_Insert_Input>;
-};
-
-/** aggregate max on columns */
-export type Organizations_Max_Fields = {
-  __typename?: 'organizations_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  primaryConfigBranch?: Maybe<Scalars['String']>;
-  primaryConfigRepo?: Maybe<Scalars['String']>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
-  sourceControlUrl?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** order by max() on columns of table "organizations" */
-export type Organizations_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  domain?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  logoUrl?: Maybe<Order_By>;
-  mqlServerUrl?: Maybe<Order_By>;
-  name?: Maybe<Order_By>;
-  primaryConfigBranch?: Maybe<Order_By>;
-  primaryConfigRepo?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-  slug?: Maybe<Order_By>;
-  sourceControlUrl?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Organizations_Min_Fields = {
-  __typename?: 'organizations_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  primaryConfigBranch?: Maybe<Scalars['String']>;
-  primaryConfigRepo?: Maybe<Scalars['String']>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
-  sourceControlUrl?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** order by min() on columns of table "organizations" */
-export type Organizations_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  domain?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  logoUrl?: Maybe<Order_By>;
-  mqlServerUrl?: Maybe<Order_By>;
-  name?: Maybe<Order_By>;
-  primaryConfigBranch?: Maybe<Order_By>;
-  primaryConfigRepo?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-  slug?: Maybe<Order_By>;
-  sourceControlUrl?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-};
-
 /** response of any mutation on the table "organizations" */
 export type Organizations_Mutation_Response = {
   __typename?: 'organizations_mutation_response';
@@ -17307,12 +13450,6 @@ export type Organizations_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Organizations>;
-};
-
-/** input type for inserting object relation for remote table "organizations" */
-export type Organizations_Obj_Rel_Insert_Input = {
-  data: Organizations_Insert_Input;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
 };
 
 /** on conflict condition type for table "organizations" */
@@ -17330,10 +13467,7 @@ export type Organizations_Order_By = {
   currentModel?: Maybe<Model_Current_Order_By>;
   dashboards_aggregate?: Maybe<Dashboards_Aggregate_Order_By>;
   dataSources_aggregate?: Maybe<Org_Data_Sources_Aggregate_Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
-  domain?: Maybe<Order_By>;
   features_aggregate?: Maybe<Organization_Features_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
   isHosted?: Maybe<Order_By>;
@@ -17345,7 +13479,6 @@ export type Organizations_Order_By = {
   metric_views_aggregate?: Maybe<Metric_View_Aggregate_Order_By>;
   metrics_aggregate?: Maybe<Org_Metrics_Current_View_Aggregate_Order_By>;
   models_aggregate?: Maybe<Models_Aggregate_Order_By>;
-  mqlHeartbeats_aggregate?: Maybe<Mql_Heartbeats_Aggregate_Order_By>;
   mqlServerLogs?: Maybe<Order_By>;
   mqlServerUrl?: Maybe<Order_By>;
   mqlServers_aggregate?: Maybe<Org_Mql_Servers_Aggregate_Order_By>;
@@ -17358,7 +13491,6 @@ export type Organizations_Order_By = {
   questions_aggregate?: Maybe<Questions_Aggregate_Order_By>;
   savedQueries_aggregate?: Maybe<Saved_Queries_Aggregate_Order_By>;
   shardId?: Maybe<Order_By>;
-  slug?: Maybe<Order_By>;
   sourceControlUrl?: Maybe<Order_By>;
   team_members_aggregate?: Maybe<Team_Members_Aggregate_Order_By>;
   teams_aggregate?: Maybe<Teams_Aggregate_Order_By>;
@@ -17379,13 +13511,7 @@ export enum Organizations_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDelete = 'date_delete',
-  /** column name */
   DeactivatedAt = 'deactivatedAt',
-  /** column name */
-  Domain = 'domain',
   /** column name */
   Id = 'id',
   /** column name */
@@ -17404,8 +13530,6 @@ export enum Organizations_Select_Column {
   PrimaryConfigRepo = 'primaryConfigRepo',
   /** column name */
   ShardId = 'shardId',
-  /** column name */
-  Slug = 'slug',
   /** column name */
   SourceControlUrl = 'sourceControlUrl',
   /** column name */
@@ -17414,113 +13538,18 @@ export enum Organizations_Select_Column {
 
 /** input type for updating data in table "organizations" */
 export type Organizations_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  isHosted?: Maybe<Scalars['Boolean']>;
   logoUrl?: Maybe<Scalars['String']>;
-  mqlServerLogs?: Maybe<Org_Mql_Server_Logs_Types_Enum>;
   mqlServerUrl?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   primaryConfigBranch?: Maybe<Scalars['String']>;
   primaryConfigRepo?: Maybe<Scalars['String']>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
   sourceControlUrl?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** aggregate stddev on columns */
-export type Organizations_Stddev_Fields = {
-  __typename?: 'organizations_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "organizations" */
-export type Organizations_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Organizations_Stddev_Pop_Fields = {
-  __typename?: 'organizations_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "organizations" */
-export type Organizations_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Organizations_Stddev_Samp_Fields = {
-  __typename?: 'organizations_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "organizations" */
-export type Organizations_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Organizations_Sum_Fields = {
-  __typename?: 'organizations_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  shardId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "organizations" */
-export type Organizations_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
 };
 
 /** update columns of table "organizations" */
 export enum Organizations_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDelete = 'date_delete',
-  /** column name */
-  DeactivatedAt = 'deactivatedAt',
-  /** column name */
-  Domain = 'domain',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  IsHosted = 'isHosted',
-  /** column name */
   LogoUrl = 'logoUrl',
-  /** column name */
-  MqlServerLogs = 'mqlServerLogs',
   /** column name */
   MqlServerUrl = 'mqlServerUrl',
   /** column name */
@@ -17530,106 +13559,13 @@ export enum Organizations_Update_Column {
   /** column name */
   PrimaryConfigRepo = 'primaryConfigRepo',
   /** column name */
-  ShardId = 'shardId',
-  /** column name */
-  Slug = 'slug',
-  /** column name */
-  SourceControlUrl = 'sourceControlUrl',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  SourceControlUrl = 'sourceControlUrl'
 }
-
-/** aggregate var_pop on columns */
-export type Organizations_Var_Pop_Fields = {
-  __typename?: 'organizations_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "organizations" */
-export type Organizations_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Organizations_Var_Samp_Fields = {
-  __typename?: 'organizations_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "organizations" */
-export type Organizations_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Organizations_Variance_Fields = {
-  __typename?: 'organizations_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "organizations" */
-export type Organizations_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
 
 /** columns and relationships of "priorities" */
 export type Priorities = {
   __typename?: 'priorities';
-  comment?: Maybe<Scalars['String']>;
   value: Scalars['String'];
-};
-
-/** aggregated selection of "priorities" */
-export type Priorities_Aggregate = {
-  __typename?: 'priorities_aggregate';
-  aggregate?: Maybe<Priorities_Aggregate_Fields>;
-  nodes: Array<Priorities>;
-};
-
-/** aggregate fields of "priorities" */
-export type Priorities_Aggregate_Fields = {
-  __typename?: 'priorities_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Priorities_Max_Fields>;
-  min?: Maybe<Priorities_Min_Fields>;
-};
-
-
-/** aggregate fields of "priorities" */
-export type Priorities_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Priorities_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "priorities" */
-export type Priorities_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Priorities_Max_Order_By>;
-  min?: Maybe<Priorities_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "priorities" */
-export type Priorities_Arr_Rel_Insert_Input = {
-  data: Array<Priorities_Insert_Input>;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
 };
 
 /** Boolean expression to filter rows from the table "priorities". All fields are combined with a logical 'AND'. */
@@ -17637,17 +13573,8 @@ export type Priorities_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Priorities_Bool_Exp>>>;
   _not?: Maybe<Priorities_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Priorities_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
   value?: Maybe<String_Comparison_Exp>;
 };
-
-/** unique or primary key constraints on table "priorities" */
-export enum Priorities_Constraint {
-  /** unique or primary key constraint */
-  PrioritiesNameKey = 'priorities_name_key',
-  /** unique or primary key constraint */
-  PrioritiesPkey = 'priorities_pkey'
-}
 
 export enum Priorities_Enum {
   Critical = 'CRITICAL',
@@ -17666,63 +13593,8 @@ export type Priorities_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Priorities_Enum>>;
 };
 
-/** input type for inserting data into table "priorities" */
-export type Priorities_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Priorities_Max_Fields = {
-  __typename?: 'priorities_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "priorities" */
-export type Priorities_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Priorities_Min_Fields = {
-  __typename?: 'priorities_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "priorities" */
-export type Priorities_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "priorities" */
-export type Priorities_Mutation_Response = {
-  __typename?: 'priorities_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Priorities>;
-};
-
-/** input type for inserting object relation for remote table "priorities" */
-export type Priorities_Obj_Rel_Insert_Input = {
-  data: Priorities_Insert_Input;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
-};
-
-/** on conflict condition type for table "priorities" */
-export type Priorities_On_Conflict = {
-  constraint: Priorities_Constraint;
-  update_columns: Array<Priorities_Update_Column>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "priorities" */
 export type Priorities_Order_By = {
-  comment?: Maybe<Order_By>;
   value?: Maybe<Order_By>;
 };
 
@@ -17734,1821 +13606,8 @@ export type Priorities_Pk_Columns_Input = {
 /** select columns of table "priorities" */
 export enum Priorities_Select_Column {
   /** column name */
-  Comment = 'comment',
-  /** column name */
   Value = 'value'
 }
-
-/** input type for updating data in table "priorities" */
-export type Priorities_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "priorities" */
-export enum Priorities_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** query root */
-export type Query_Root = {
-  __typename?: 'query_root';
-  /** fetch data from the table: "annotations" using primary key columns */
-  annotation?: Maybe<Annotations>;
-  /** fetch data from the table: "annotations" */
-  annotations: Array<Annotations>;
-  /** fetch aggregated fields from the table: "annotations" */
-  annotationsAggregate: Annotations_Aggregate;
-  /** fetch data from the table: "api_keys" using primary key columns */
-  apiKey?: Maybe<Api_Keys>;
-  /** fetch data from the table: "api_keys" */
-  apiKeys: Array<Api_Keys>;
-  /** fetch aggregated fields from the table: "api_keys" */
-  apiKeysAggregate: Api_Keys_Aggregate;
-  auth0Profile?: Maybe<Auth0Profile>;
-  /** fetch data from the table: "branch_metadatas" */
-  branch_metadatas: Array<Branch_Metadatas>;
-  /** fetch aggregated fields from the table: "branch_metadatas" */
-  branch_metadatas_aggregate: Branch_Metadatas_Aggregate;
-  /** fetch data from the table: "branch_metadatas" using primary key columns */
-  branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** fetch data from the table: "dashboards" using primary key columns */
-  dashboard?: Maybe<Dashboards>;
-  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
-  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
-  /** fetch data from the table: "dashboard_item_configs" */
-  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
-  /** fetch aggregated fields from the table: "dashboard_item_configs" */
-  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
-  /** fetch data from the table: "dashboard_layouts" using primary key columns */
-  dashboardLayout?: Maybe<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_layouts" */
-  dashboardLayouts: Array<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_renderable_types" using primary key columns */
-  dashboardRenderableType?: Maybe<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_renderable_types" */
-  dashboardRenderableTypes: Array<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_sections" using primary key columns */
-  dashboardSection?: Maybe<Dashboard_Sections>;
-  /** fetch data from the table: "dashboard_section_types" using primary key columns */
-  dashboardSectionType?: Maybe<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_section_types" */
-  dashboardSectionTypes: Array<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_sections" */
-  dashboardSections: Array<Dashboard_Sections>;
-  /** fetch aggregated fields from the table: "dashboard_sections" */
-  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_layouts" */
-  dashboard_layouts_aggregate: Dashboard_Layouts_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_renderable_types" */
-  dashboard_renderable_types_aggregate: Dashboard_Renderable_Types_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_section_types" */
-  dashboard_section_types_aggregate: Dashboard_Section_Types_Aggregate;
-  /** fetch data from the table: "dashboards" */
-  dashboards: Array<Dashboards>;
-  /** fetch aggregated fields from the table: "dashboards" */
-  dashboardsAggregate: Dashboards_Aggregate;
-  /** fetch data from the table: "org_data_sources" using primary key columns */
-  dataSource?: Maybe<Org_Data_Sources>;
-  /** fetch data from the table: "data_source_versions" using primary key columns */
-  dataSourceVersion?: Maybe<Data_Source_Versions>;
-  /** fetch data from the table: "data_source_versions" */
-  dataSourceVersions: Array<Data_Source_Versions>;
-  /** fetch aggregated fields from the table: "data_source_versions" */
-  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
-  /** fetch data from the table: "org_data_sources" */
-  dataSources: Array<Org_Data_Sources>;
-  /** fetch aggregated fields from the table: "org_data_sources" */
-  dataSourcesAggregate: Org_Data_Sources_Aggregate;
-  /** fetch data from the table: "dw_engines" */
-  dw_engines: Array<Dw_Engines>;
-  /** fetch aggregated fields from the table: "dw_engines" */
-  dw_engines_aggregate: Dw_Engines_Aggregate;
-  /** fetch data from the table: "dw_engines" using primary key columns */
-  dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** fetch data from the table: "features" using primary key columns */
-  feature?: Maybe<Features>;
-  /** fetch data from the table: "features" */
-  features: Array<Features>;
-  /** fetch aggregated fields from the table: "features" */
-  featuresAggregate: Features_Aggregate;
-  latestMqlServer?: Maybe<MqlServerVersion>;
-  /** execute function "me" which returns "users" */
-  me: Array<Users>;
-  /** execute function "me" and query aggregates on result of table type "users" */
-  me_aggregate: Users_Aggregate;
-  /** fetch data from the table: "metric_annotations" using primary key columns */
-  metricAnnotation?: Maybe<Metric_Annotations>;
-  /** fetch data from the table: "metric_annotations" */
-  metricAnnotations: Array<Metric_Annotations>;
-  /** fetch aggregated fields from the table: "metric_annotations" */
-  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
-  /** fetch data from the table: "metric_approvals" using primary key columns */
-  metricApproval?: Maybe<Metric_Approvals>;
-  /** fetch data from the table: "metric_approvals" */
-  metricApprovals: Array<Metric_Approvals>;
-  /** fetch aggregated fields from the table: "metric_approvals" */
-  metricApprovalsAggregate: Metric_Approvals_Aggregate;
-  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
-  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
-  /** fetch data from the table: "metric_collections" using primary key columns */
-  metricCollection?: Maybe<Metric_Collections>;
-  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
-  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** fetch data from the table: "metric_collection_metrics" */
-  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
-  /** fetch aggregated fields from the table: "metric_collection_metrics" */
-  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
-  /** fetch data from the table: "metric_collection_view" using primary key columns */
-  metricCollectionView?: Maybe<Metric_Collection_View>;
-  /** fetch aggregated fields from the table: "metric_collection_view" */
-  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
-  /** fetch data from the table: "metric_collection_view" */
-  metricCollectionViews: Array<Metric_Collection_View>;
-  /** fetch data from the table: "metric_collections" */
-  metricCollections: Array<Metric_Collections>;
-  /** fetch aggregated fields from the table: "metric_collections" */
-  metricCollectionsAggregate: Metric_Collections_Aggregate;
-  /** fetch data from the table: "metric_current_description" */
-  metricCurrentDescriptions: Array<Metric_Current_Description>;
-  /** fetch data from the table: "metric_descriptions" using primary key columns */
-  metricDescription?: Maybe<Metric_Descriptions>;
-  /** fetch data from the table: "metric_descriptions" */
-  metricDescriptions: Array<Metric_Descriptions>;
-  /** fetch aggregated fields from the table: "metric_descriptions" */
-  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
-  /** fetch data from the table: "metric_team_owners" using primary key columns */
-  metricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** fetch data from the table: "metric_team_owners" */
-  metricTeamOwners: Array<Metric_Team_Owners>;
-  /** fetch aggregated fields from the table: "metric_team_owners" */
-  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
-  /** fetch data from the table: "metric_user_owners" using primary key columns */
-  metricUserOwner?: Maybe<Metric_User_Owners>;
-  /** fetch data from the table: "metric_user_owners" */
-  metricUserOwners: Array<Metric_User_Owners>;
-  /** fetch aggregated fields from the table: "metric_user_owners" */
-  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
-  /** fetch data from the table: "metric_versions" using primary key columns */
-  metricVersion?: Maybe<Metric_Versions>;
-  /** fetch data from the table: "metric_versions" */
-  metricVersions: Array<Metric_Versions>;
-  /** fetch aggregated fields from the table: "metric_versions" */
-  metricVersionsAggregate: Metric_Versions_Aggregate;
-  /** fetch data from the table: "metric_view" */
-  metricViews: Array<Metric_View>;
-  /** fetch aggregated fields from the table: "metric_view" */
-  metricViewsAggregate: Metric_View_Aggregate;
-  /** fetch aggregated fields from the table: "metric_current_description" */
-  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
-  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
-  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** fetch data from the table: "org_metrics_current_view" */
-  metrics: Array<Org_Metrics_Current_View>;
-  /** fetch aggregated fields from the table: "org_metrics_current_view" */
-  metricsAggregate: Org_Metrics_Current_View_Aggregate;
-  /** fetch data from the table: "models" using primary key columns */
-  model?: Maybe<Models>;
-  /** fetch data from the table: "model_data_sources" using primary key columns */
-  modelDataSource?: Maybe<Model_Data_Sources>;
-  /** fetch data from the table: "model_data_sources" */
-  modelDataSources: Array<Model_Data_Sources>;
-  /** fetch aggregated fields from the table: "model_data_sources" */
-  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
-  /** fetch data from the table: "model_metrics" using primary key columns */
-  modelMetric?: Maybe<Model_Metrics>;
-  /** fetch data from the table: "model_metrics" */
-  modelMetrics: Array<Model_Metrics>;
-  /** fetch aggregated fields from the table: "model_metrics" */
-  modelMetricsAggregate: Model_Metrics_Aggregate;
-  /** fetch data from the table: "model_current" */
-  model_current: Array<Model_Current>;
-  /** fetch aggregated fields from the table: "model_current" */
-  model_current_aggregate: Model_Current_Aggregate;
-  /** fetch data from the table: "models" */
-  models: Array<Models>;
-  /** fetch aggregated fields from the table: "models" */
-  modelsAggregate: Models_Aggregate;
-  /** fetch data from the table: "mql_heartbeats" using primary key columns */
-  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
-  /** fetch data from the table: "mql_heartbeats" */
-  mqlHeartbeats: Array<Mql_Heartbeats>;
-  /** fetch aggregated fields from the table: "mql_heartbeats" */
-  mqlHeartbeatsAggregate: Mql_Heartbeats_Aggregate;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
-  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
-  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
-  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
-  /** execute function "my_org" which returns "organizations" */
-  my_org: Array<Organizations>;
-  /** execute function "my_org" and query aggregates on result of table type "organizations" */
-  my_org_aggregate: Organizations_Aggregate;
-  /** fetch data from the table: "org_mql_servers" using primary key columns */
-  orgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** fetch data from the table: "org_mql_servers" */
-  orgMqlServers: Array<Org_Mql_Servers>;
-  /** fetch aggregated fields from the table: "org_mql_servers" */
-  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types: Array<Org_Mql_Server_Logs_Types>;
-  /** fetch aggregated fields from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types_aggregate: Org_Mql_Server_Logs_Types_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" using primary key columns */
-  org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** fetch data from the table: "organizations" using primary key columns */
-  organization?: Maybe<Organizations>;
-  /** fetch data from the table: "organization_features" using primary key columns */
-  organizationFeature?: Maybe<Organization_Features>;
-  /** fetch data from the table: "organization_features" */
-  organizationFeatures: Array<Organization_Features>;
-  /** fetch aggregated fields from the table: "organization_features" */
-  organizationFeaturesAggregate: Organization_Features_Aggregate;
-  /** fetch data from the table: "organizations" */
-  organizations: Array<Organizations>;
-  /** fetch aggregated fields from the table: "organizations" */
-  organizationsAggregate: Organizations_Aggregate;
-  /** fetch data from the table: "priorities" */
-  priorities: Array<Priorities>;
-  /** fetch aggregated fields from the table: "priorities" */
-  priorities_aggregate: Priorities_Aggregate;
-  /** fetch data from the table: "priorities" using primary key columns */
-  priorities_by_pk?: Maybe<Priorities>;
-  /** fetch data from the table: "questions" using primary key columns */
-  question?: Maybe<Questions>;
-  /** fetch data from the table: "question_directed_to" */
-  questionDirectedTo: Array<Question_Directed_To>;
-  /** fetch aggregated fields from the table: "question_directed_to" */
-  questionDirectedToAggregate: Question_Directed_To_Aggregate;
-  /** fetch data from the table: "question_directed_to" using primary key columns */
-  questionDirectedToByPK?: Maybe<Question_Directed_To>;
-  /** fetch data from the table: "question_likes" using primary key columns */
-  questionLike?: Maybe<Question_Likes>;
-  /** fetch data from the table: "question_likes" */
-  questionLikes: Array<Question_Likes>;
-  /** fetch aggregated fields from the table: "question_likes" */
-  questionLikesAggregate: Question_Likes_Aggregate;
-  /** fetch data from the table: "question_replies" */
-  questionReplies: Array<Question_Replies>;
-  /** fetch aggregated fields from the table: "question_replies" */
-  questionRepliesAggregate: Question_Replies_Aggregate;
-  /** fetch data from the table: "question_replies" using primary key columns */
-  questionReply?: Maybe<Question_Replies>;
-  /** fetch data from the table: "questions" */
-  questions: Array<Questions>;
-  /** fetch aggregated fields from the table: "questions" */
-  questionsAggregate: Questions_Aggregate;
-  /** fetch data from the table: "saved_queries" */
-  savedQueries: Array<Saved_Queries>;
-  /** fetch aggregated fields from the table: "saved_queries" */
-  savedQueriesAggregate: Saved_Queries_Aggregate;
-  /** fetch data from the table: "saved_queries" using primary key columns */
-  savedQuery?: Maybe<Saved_Queries>;
-  /** fetch data from the table: "saved_query_metrics" using primary key columns */
-  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** fetch data from the table: "saved_query_metrics" */
-  savedQueryMetrics: Array<Saved_Query_Metrics>;
-  /** fetch aggregated fields from the table: "saved_query_metrics" */
-  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
-  /** fetch data from the table: "teams" using primary key columns */
-  team?: Maybe<Teams>;
-  /** fetch data from the table: "team_dashboards" using primary key columns */
-  teamDashboard?: Maybe<Team_Dashboards>;
-  /** fetch data from the table: "team_dashboards" */
-  teamDashboards: Array<Team_Dashboards>;
-  /** fetch aggregated fields from the table: "team_dashboards" */
-  teamDashboardsAggregate: Team_Dashboards_Aggregate;
-  /** fetch data from the table: "team_members" using primary key columns */
-  teamMember?: Maybe<Team_Members>;
-  /** fetch data from the table: "team_members" */
-  teamMembers: Array<Team_Members>;
-  /** fetch aggregated fields from the table: "team_members" */
-  teamMembersAggregate: Team_Members_Aggregate;
-  /** fetch aggregated fields from the table: "team_views" */
-  teamViewsAggregate: Team_Views_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" */
-  team_page_theme_colors: Array<Team_Page_Theme_Colors>;
-  /** fetch aggregated fields from the table: "team_page_theme_colors" */
-  team_page_theme_colors_aggregate: Team_Page_Theme_Colors_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" using primary key columns */
-  team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** fetch data from the table: "team_views" */
-  team_views: Array<Team_Views>;
-  /** fetch data from the table: "team_views" using primary key columns */
-  team_views_by_pk?: Maybe<Team_Views>;
-  /** fetch data from the table: "teams" */
-  teams: Array<Teams>;
-  /** fetch aggregated fields from the table: "teams" */
-  teamsAggregate: Teams_Aggregate;
-  /** fetch data from the table: "unsubscribes" */
-  unsubscribes: Array<Unsubscribes>;
-  /** fetch aggregated fields from the table: "unsubscribes" */
-  unsubscribes_aggregate: Unsubscribes_Aggregate;
-  /** fetch data from the table: "unsubscribes" using primary key columns */
-  unsubscribes_by_pk?: Maybe<Unsubscribes>;
-  /** fetch data from the table: "users" using primary key columns */
-  user?: Maybe<Users>;
-  /** fetch data from the table: "user_dashboards" using primary key columns */
-  userDashboard?: Maybe<User_Dashboards>;
-  /** fetch data from the table: "user_dashboards" */
-  userDashboards: Array<User_Dashboards>;
-  /** fetch aggregated fields from the table: "user_dashboards" */
-  userDashboardsAggregate: User_Dashboards_Aggregate;
-  /** fetch data from the table: "user_features" using primary key columns */
-  userFeature?: Maybe<User_Features>;
-  /** fetch data from the table: "user_features" */
-  userFeatures: Array<User_Features>;
-  /** fetch aggregated fields from the table: "user_features" */
-  userFeaturesAggregate: User_Features_Aggregate;
-  /** fetch data from the table: "user_prefs" using primary key columns */
-  userPreference?: Maybe<User_Prefs>;
-  /** fetch data from the table: "user_prefs" */
-  userPreferences: Array<User_Prefs>;
-  /** fetch aggregated fields from the table: "user_prefs" */
-  userPreferencesAggregate: User_Prefs_Aggregate;
-  /** fetch data from the table: "user_roles" using primary key columns */
-  userRole?: Maybe<User_Roles>;
-  /** fetch data from the table: "user_roles" */
-  userRoles: Array<User_Roles>;
-  /** fetch aggregated fields from the table: "user_roles" */
-  userRolesAggregate: User_Roles_Aggregate;
-  /** fetch data from the table: "user_role_types" */
-  user_role_types: Array<User_Role_Types>;
-  /** fetch aggregated fields from the table: "user_role_types" */
-  user_role_types_aggregate: User_Role_Types_Aggregate;
-  /** fetch data from the table: "user_role_types" using primary key columns */
-  user_role_types_by_pk?: Maybe<User_Role_Types>;
-  /** fetch data from the table: "users" */
-  users: Array<Users>;
-  /** fetch aggregated fields from the table: "users" */
-  usersAggregate: Users_Aggregate;
-};
-
-
-/** query root */
-export type Query_RootAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootApiKeyArgs = {
-  prefix: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootApiKeysArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootApiKeysAggregateArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootAuth0ProfileArgs = {
-  auth0Id: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootBranch_MetadatasArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootBranch_Metadatas_AggregateArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootBranch_Metadatas_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardItemConfigArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardItemConfigsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardItemConfigsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardLayoutArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootDashboardLayoutsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardRenderableTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootDashboardRenderableTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboard_Layouts_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboard_Renderable_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboard_Section_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardsArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDataSourceVersionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDataSourceVersionsArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourceVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDw_EnginesArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDw_Engines_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDw_Engines_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootFeatureArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootFeaturesArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMeArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMe_AggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricApprovalArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricApprovalsArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricApprovalsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricByIdTempArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionMetricsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionViewArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionViewAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCurrentDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricDescriptionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricDescriptionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricTeamOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricTeamOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricTeamOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricUserOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricUserOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricUserOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricVersionArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** query root */
-export type Query_RootMetricVersionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Current_Description_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Lineage_Data_SourcesArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Lineage_Data_Sources_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Lineage_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** query root */
-export type Query_RootModelDataSourceArgs = {
-  dataSourceVersionId: Scalars['Int'];
-  modelId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootModelDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelMetricArgs = {
-  metricId: Scalars['bigint'];
-  metricVersionId: Scalars['bigint'];
-  modelId: Scalars['bigint'];
-};
-
-
-/** query root */
-export type Query_RootModelMetricsArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModel_CurrentArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModel_Current_AggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelsArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelsAggregateArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMqlHeartbeatArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMqlHeartbeatsArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMqlHeartbeatsAggregateArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_Most_Viewed_MetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_Most_Viewed_Metrics_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_OrgArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_Org_AggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrgMqlServerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootOrgMqlServersArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrgMqlServersAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrg_Mql_Server_Logs_TypesArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrg_Mql_Server_Logs_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrg_Mql_Server_Logs_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootOrganizationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootOrganizationFeatureArgs = {
-  featureId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootOrganizationFeaturesArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrganizationFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrganizationsArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrganizationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootPrioritiesArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootPriorities_AggregateArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootPriorities_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootQuestionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionDirectedToArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionDirectedToAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionDirectedToByPkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionLikeArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionLikesArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionLikesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionRepliesArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionRepliesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionReplyArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionsArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueriesArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueriesAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueryArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootSavedQueryMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootSavedQueryMetricsArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueryMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  team_id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamDashboardsArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamMemberArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamMembersArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamMembersAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Page_Theme_ColorsArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Page_Theme_Colors_AggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Page_Theme_Colors_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootTeam_ViewsArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Views_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamsArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamsAggregateArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUnsubscribesArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUnsubscribes_AggregateArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUnsubscribes_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserDashboardsArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserFeatureArgs = {
-  featureId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserFeaturesArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserPreferenceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserPreferencesArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserPreferencesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserRoleArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserRolesArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserRolesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUser_Role_TypesArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUser_Role_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUser_Role_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootUsersArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUsersAggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
 
 /**
  * Indicates to which User or Team a Question is directed.
@@ -19560,22 +13619,16 @@ export type Question_Directed_To = {
   __typename?: 'question_directed_to';
   /** Timestamp indicated when a Question Directed To entry was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
-  entity_type?: Maybe<Scalars['entity']>;
   /** Unique identifier for a target to whom the Question is directed */
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   question: Questions;
-  questionid: Scalars['Int'];
   /** An object relationship */
   team?: Maybe<Teams>;
-  teamId?: Maybe<Scalars['Int']>;
   /** An object relationship */
   user?: Maybe<Users>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "question_directed_to" */
@@ -19626,28 +13679,17 @@ export type Question_Directed_To_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "question_directed_to" */
 export type Question_Directed_To_Arr_Rel_Insert_Input = {
   data: Array<Question_Directed_To_Insert_Input>;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Question_Directed_To_Avg_Fields = {
   __typename?: 'question_directed_to_avg_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "question_directed_to" */
 export type Question_Directed_To_Avg_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "question_directed_to". All fields are combined with a logical 'AND'. */
@@ -19656,45 +13698,15 @@ export type Question_Directed_To_Bool_Exp = {
   _not?: Maybe<Question_Directed_To_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Question_Directed_To_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  entity_id?: Maybe<Int_Comparison_Exp>;
-  entity_type?: Maybe<Entity_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<Questions_Bool_Exp>;
-  questionid?: Maybe<Int_Comparison_Exp>;
   team?: Maybe<Teams_Bool_Exp>;
-  teamId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "question_directed_to" */
-export enum Question_Directed_To_Constraint {
-  /** unique or primary key constraint */
-  QuestionDirectedToIdKey = 'question_directed_to_id_key',
-  /** unique or primary key constraint */
-  QuestionDirectedToPkey = 'question_directed_to_pkey'
-}
-
-/** input type for incrementing integer column in table "question_directed_to" */
-export type Question_Directed_To_Inc_Input = {
-  entity_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "question_directed_to" */
 export type Question_Directed_To_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
-  entity_type?: Maybe<Scalars['entity']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   question?: Maybe<Questions_Obj_Rel_Insert_Input>;
   questionid?: Maybe<Scalars['Int']>;
   team?: Maybe<Teams_Obj_Rel_Insert_Input>;
@@ -19707,46 +13719,26 @@ export type Question_Directed_To_Insert_Input = {
 export type Question_Directed_To_Max_Fields = {
   __typename?: 'question_directed_to_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "question_directed_to" */
 export type Question_Directed_To_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Question_Directed_To_Min_Fields = {
   __typename?: 'question_directed_to_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "question_directed_to" */
 export type Question_Directed_To_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "question_directed_to" */
@@ -19761,30 +13753,16 @@ export type Question_Directed_To_Mutation_Response = {
 /** input type for inserting object relation for remote table "question_directed_to" */
 export type Question_Directed_To_Obj_Rel_Insert_Input = {
   data: Question_Directed_To_Insert_Input;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
-};
-
-/** on conflict condition type for table "question_directed_to" */
-export type Question_Directed_To_On_Conflict = {
-  constraint: Question_Directed_To_Constraint;
-  update_columns: Array<Question_Directed_To_Update_Column>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "question_directed_to" */
 export type Question_Directed_To_Order_By = {
   createdAt?: Maybe<Order_By>;
-  entity_id?: Maybe<Order_By>;
-  entity_type?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   question?: Maybe<Questions_Order_By>;
-  questionid?: Maybe<Order_By>;
   team?: Maybe<Teams_Order_By>;
-  teamId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "question_directed_to" */
@@ -19798,198 +13776,84 @@ export enum Question_Directed_To_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  EntityId = 'entity_id',
-  /** column name */
-  EntityType = 'entity_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Questionid = 'questionid',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'userId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "question_directed_to" */
-export type Question_Directed_To_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
-  entity_type?: Maybe<Scalars['entity']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Question_Directed_To_Stddev_Fields = {
   __typename?: 'question_directed_to_stddev_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "question_directed_to" */
 export type Question_Directed_To_Stddev_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Question_Directed_To_Stddev_Pop_Fields = {
   __typename?: 'question_directed_to_stddev_pop_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "question_directed_to" */
 export type Question_Directed_To_Stddev_Pop_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Question_Directed_To_Stddev_Samp_Fields = {
   __typename?: 'question_directed_to_stddev_samp_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "question_directed_to" */
 export type Question_Directed_To_Stddev_Samp_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Question_Directed_To_Sum_Fields = {
   __typename?: 'question_directed_to_sum_fields';
-  entity_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "question_directed_to" */
 export type Question_Directed_To_Sum_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
-
-/** update columns of table "question_directed_to" */
-export enum Question_Directed_To_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  EntityId = 'entity_id',
-  /** column name */
-  EntityType = 'entity_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Questionid = 'questionid',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'userId'
-}
 
 /** aggregate var_pop on columns */
 export type Question_Directed_To_Var_Pop_Fields = {
   __typename?: 'question_directed_to_var_pop_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "question_directed_to" */
 export type Question_Directed_To_Var_Pop_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Question_Directed_To_Var_Samp_Fields = {
   __typename?: 'question_directed_to_var_samp_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "question_directed_to" */
 export type Question_Directed_To_Var_Samp_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Question_Directed_To_Variance_Fields = {
   __typename?: 'question_directed_to_variance_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "question_directed_to" */
 export type Question_Directed_To_Variance_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /**
@@ -20000,24 +13864,16 @@ export type Question_Directed_To_Variance_Order_By = {
  */
 export type Question_Likes = {
   __typename?: 'question_likes';
-  /** Timestamp indicating when the Question was liked */
-  createdAt?: Maybe<Scalars['timestamptz']>;
   /** A primary identifier for the Question Like */
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   question?: Maybe<Questions>;
-  questionId?: Maybe<Scalars['Int']>;
   /** An object relationship */
   questionReply?: Maybe<Question_Replies>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply?: Maybe<Scalars['questionorreply']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
   /** An object relationship */
   user: Users;
-  userId: Scalars['Int'];
 };
 
 /** aggregated selection of "question_likes" */
@@ -20068,28 +13924,17 @@ export type Question_Likes_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "question_likes" */
 export type Question_Likes_Arr_Rel_Insert_Input = {
   data: Array<Question_Likes_Insert_Input>;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Question_Likes_Avg_Fields = {
   __typename?: 'question_likes_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "question_likes" */
 export type Question_Likes_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "question_likes". All fields are combined with a logical 'AND'. */
@@ -20097,102 +13942,42 @@ export type Question_Likes_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Question_Likes_Bool_Exp>>>;
   _not?: Maybe<Question_Likes_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Question_Likes_Bool_Exp>>>;
-  createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<Questions_Bool_Exp>;
-  questionId?: Maybe<Int_Comparison_Exp>;
   questionReply?: Maybe<Question_Replies_Bool_Exp>;
-  questionReplyId?: Maybe<Int_Comparison_Exp>;
-  question_or_reply?: Maybe<Questionorreply_Comparison_Exp>;
-  question_or_reply_id?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "question_likes" */
-export enum Question_Likes_Constraint {
-  /** unique or primary key constraint */
-  QuestionLikesIdKey = 'question_likes_id_key',
-  /** unique or primary key constraint */
-  QuestionLikesPkey = 'question_likes_pkey',
-  /** unique or primary key constraint */
-  QuestionLikesUserIdQuestionIdKey = 'question_likes_user_id_question_id_key',
-  /** unique or primary key constraint */
-  QuestionLikesUserIdQuestionReplyIdKey = 'question_likes_user_id_question_reply_id_key'
-}
-
-/** input type for incrementing integer column in table "question_likes" */
-export type Question_Likes_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "question_likes" */
 export type Question_Likes_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   question?: Maybe<Questions_Obj_Rel_Insert_Input>;
   questionId?: Maybe<Scalars['Int']>;
   questionReply?: Maybe<Question_Replies_Obj_Rel_Insert_Input>;
   questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply?: Maybe<Scalars['questionorreply']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Question_Likes_Max_Fields = {
   __typename?: 'question_likes_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "question_likes" */
 export type Question_Likes_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Question_Likes_Min_Fields = {
   __typename?: 'question_likes_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "question_likes" */
 export type Question_Likes_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "question_likes" */
@@ -20207,30 +13992,15 @@ export type Question_Likes_Mutation_Response = {
 /** input type for inserting object relation for remote table "question_likes" */
 export type Question_Likes_Obj_Rel_Insert_Input = {
   data: Question_Likes_Insert_Input;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
-};
-
-/** on conflict condition type for table "question_likes" */
-export type Question_Likes_On_Conflict = {
-  constraint: Question_Likes_Constraint;
-  update_columns: Array<Question_Likes_Update_Column>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "question_likes" */
 export type Question_Likes_Order_By = {
-  createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   question?: Maybe<Questions_Order_By>;
-  questionId?: Maybe<Order_By>;
   questionReply?: Maybe<Question_Replies_Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "question_likes" */
@@ -20242,200 +14012,84 @@ export type Question_Likes_Pk_Columns_Input = {
 /** select columns of table "question_likes" */
 export enum Question_Likes_Select_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
-  /** column name */
-  QuestionReplyId = 'questionReplyId',
-  /** column name */
-  QuestionOrReply = 'question_or_reply',
-  /** column name */
-  QuestionOrReplyId = 'question_or_reply_id',
-  /** column name */
-  UserId = 'userId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "question_likes" */
-export type Question_Likes_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply?: Maybe<Scalars['questionorreply']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Question_Likes_Stddev_Fields = {
   __typename?: 'question_likes_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "question_likes" */
 export type Question_Likes_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Question_Likes_Stddev_Pop_Fields = {
   __typename?: 'question_likes_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "question_likes" */
 export type Question_Likes_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Question_Likes_Stddev_Samp_Fields = {
   __typename?: 'question_likes_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "question_likes" */
 export type Question_Likes_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Question_Likes_Sum_Fields = {
   __typename?: 'question_likes_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "question_likes" */
 export type Question_Likes_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
-
-/** update columns of table "question_likes" */
-export enum Question_Likes_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
-  /** column name */
-  QuestionReplyId = 'questionReplyId',
-  /** column name */
-  QuestionOrReply = 'question_or_reply',
-  /** column name */
-  QuestionOrReplyId = 'question_or_reply_id',
-  /** column name */
-  UserId = 'userId'
-}
 
 /** aggregate var_pop on columns */
 export type Question_Likes_Var_Pop_Fields = {
   __typename?: 'question_likes_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "question_likes" */
 export type Question_Likes_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Question_Likes_Var_Samp_Fields = {
   __typename?: 'question_likes_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "question_likes" */
 export type Question_Likes_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Question_Likes_Variance_Fields = {
   __typename?: 'question_likes_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "question_likes" */
 export type Question_Likes_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /**
@@ -20448,18 +14102,14 @@ export type Question_Replies = {
   __typename?: 'question_replies';
   /** An object relationship */
   author: Users;
-  authorId: Scalars['Int'];
   /** Timestamp indicating when the Question Reply was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   /** A unique identifier for the Question Reply */
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   question: Questions;
-  questionId: Scalars['Int'];
   /** An array relationship */
   questionLikes: Array<Question_Likes>;
   /** An aggregated array relationship */
@@ -20556,20 +14206,12 @@ export type Question_Replies_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Question_Replies_Avg_Fields = {
   __typename?: 'question_replies_avg_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "question_replies" */
 export type Question_Replies_Avg_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "question_replies". All fields are combined with a logical 'AND'. */
@@ -20578,14 +14220,10 @@ export type Question_Replies_Bool_Exp = {
   _not?: Maybe<Question_Replies_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Question_Replies_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<Questions_Bool_Exp>;
-  questionId?: Maybe<Int_Comparison_Exp>;
   questionLikes?: Maybe<Question_Likes_Bool_Exp>;
   text?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -20597,52 +14235,28 @@ export enum Question_Replies_Constraint {
   QuestionRepliesPkey = 'question_replies_pkey'
 }
 
-/** input type for incrementing integer column in table "question_replies" */
-export type Question_Replies_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "question_replies" */
 export type Question_Replies_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   question?: Maybe<Questions_Obj_Rel_Insert_Input>;
   questionId?: Maybe<Scalars['Int']>;
   questionLikes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Question_Replies_Max_Fields = {
   __typename?: 'question_replies_max_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "question_replies" */
 export type Question_Replies_Max_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -20650,24 +14264,16 @@ export type Question_Replies_Max_Order_By = {
 /** aggregate min on columns */
 export type Question_Replies_Min_Fields = {
   __typename?: 'question_replies_min_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "question_replies" */
 export type Question_Replies_Min_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -20697,14 +14303,10 @@ export type Question_Replies_On_Conflict = {
 /** ordering options when selecting data from "question_replies" */
 export type Question_Replies_Order_By = {
   author?: Maybe<Users_Order_By>;
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   question?: Maybe<Questions_Order_By>;
-  questionId?: Maybe<Order_By>;
   questionLikes_aggregate?: Maybe<Question_Likes_Aggregate_Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -20719,17 +14321,9 @@ export type Question_Replies_Pk_Columns_Input = {
 /** select columns of table "question_replies" */
 export enum Question_Replies_Select_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
   /** column name */
   Text = 'text',
   /** column name */
@@ -20738,181 +14332,90 @@ export enum Question_Replies_Select_Column {
 
 /** input type for updating data in table "question_replies" */
 export type Question_Replies_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Question_Replies_Stddev_Fields = {
   __typename?: 'question_replies_stddev_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "question_replies" */
 export type Question_Replies_Stddev_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Question_Replies_Stddev_Pop_Fields = {
   __typename?: 'question_replies_stddev_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "question_replies" */
 export type Question_Replies_Stddev_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Question_Replies_Stddev_Samp_Fields = {
   __typename?: 'question_replies_stddev_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "question_replies" */
 export type Question_Replies_Stddev_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Question_Replies_Sum_Fields = {
   __typename?: 'question_replies_sum_fields';
-  authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "question_replies" */
 export type Question_Replies_Sum_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** update columns of table "question_replies" */
 export enum Question_Replies_Update_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
-  /** column name */
-  Text = 'text',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Text = 'text'
 }
 
 /** aggregate var_pop on columns */
 export type Question_Replies_Var_Pop_Fields = {
   __typename?: 'question_replies_var_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "question_replies" */
 export type Question_Replies_Var_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Question_Replies_Var_Samp_Fields = {
   __typename?: 'question_replies_var_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "question_replies" */
 export type Question_Replies_Var_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Question_Replies_Variance_Fields = {
   __typename?: 'question_replies_variance_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "question_replies" */
 export type Question_Replies_Variance_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-};
-
-
-/** expression to compare columns of type questionorreply. All fields are combined with logical 'AND'. */
-export type Questionorreply_Comparison_Exp = {
-  _eq?: Maybe<Scalars['questionorreply']>;
-  _gt?: Maybe<Scalars['questionorreply']>;
-  _gte?: Maybe<Scalars['questionorreply']>;
-  _in?: Maybe<Array<Scalars['questionorreply']>>;
-  _is_null?: Maybe<Scalars['Boolean']>;
-  _lt?: Maybe<Scalars['questionorreply']>;
-  _lte?: Maybe<Scalars['questionorreply']>;
-  _neq?: Maybe<Scalars['questionorreply']>;
-  _nin?: Maybe<Array<Scalars['questionorreply']>>;
 };
 
 /**
@@ -20928,14 +14431,12 @@ export type Questions = {
   authorId: Scalars['Int'];
   /** Timestamp indicating when the `Question` was created. */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   /** The primary key for the `Question` */
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
   metricId?: Maybe<Scalars['Int']>;
   metricName: Scalars['String'];
-  notified_at?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
@@ -20952,11 +14453,9 @@ export type Questions = {
   questionReplies: Array<Question_Replies>;
   /** An aggregated array relationship */
   questionReplies_aggregate: Question_Replies_Aggregate;
-  resolved?: Maybe<Scalars['Boolean']>;
   /** Timestamp indicating when the `Question` was resolved. */
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text: Scalars['String'];
   /** Timestamp indicating the last time the `Question` was updated */
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -21111,23 +14610,19 @@ export type Questions_Arr_Rel_Insert_Input = {
 export type Questions_Avg_Fields = {
   __typename?: 'questions_avg_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "questions" */
 export type Questions_Avg_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "questions". All fields are combined with a logical 'AND'. */
@@ -21138,22 +14633,18 @@ export type Questions_Bool_Exp = {
   author?: Maybe<Users_Bool_Exp>;
   authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
   metricId?: Maybe<Int_Comparison_Exp>;
   metricName?: Maybe<String_Comparison_Exp>;
-  notified_at?: Maybe<Timestamptz_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   priority?: Maybe<Priorities_Enum_Comparison_Exp>;
   questionDirectedTos?: Maybe<Question_Directed_To_Bool_Exp>;
   questionLikes?: Maybe<Question_Likes_Bool_Exp>;
   questionReplies?: Maybe<Question_Replies_Bool_Exp>;
-  resolved?: Maybe<Boolean_Comparison_Exp>;
   resolvedAt?: Maybe<Timestamptz_Comparison_Exp>;
   resolvedBy?: Maybe<Int_Comparison_Exp>;
-  resolved_ts?: Maybe<Int_Comparison_Exp>;
   text?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   userByResolvedBy?: Maybe<Users_Bool_Exp>;
@@ -21169,38 +14660,20 @@ export enum Questions_Constraint {
 
 /** input type for incrementing integer column in table "questions" */
 export type Questions_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "questions" */
 export type Questions_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
   metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
   questionDirectedTos?: Maybe<Question_Directed_To_Arr_Rel_Insert_Input>;
   questionLikes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
   questionReplies?: Maybe<Question_Replies_Arr_Rel_Insert_Input>;
-  resolved?: Maybe<Scalars['Boolean']>;
-  resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   userByResolvedBy?: Maybe<Users_Obj_Rel_Insert_Input>;
 };
 
@@ -21209,15 +14682,12 @@ export type Questions_Max_Fields = {
   __typename?: 'questions_max_fields';
   authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
   organizationId?: Maybe<Scalars['Int']>;
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21226,15 +14696,12 @@ export type Questions_Max_Fields = {
 export type Questions_Max_Order_By = {
   authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   metricName?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedAt?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21244,15 +14711,12 @@ export type Questions_Min_Fields = {
   __typename?: 'questions_min_fields';
   authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
   organizationId?: Maybe<Scalars['Int']>;
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21261,15 +14725,12 @@ export type Questions_Min_Fields = {
 export type Questions_Min_Order_By = {
   authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   metricName?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedAt?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21301,22 +14762,18 @@ export type Questions_Order_By = {
   author?: Maybe<Users_Order_By>;
   authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
   metricId?: Maybe<Order_By>;
   metricName?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   priority?: Maybe<Order_By>;
   questionDirectedTos_aggregate?: Maybe<Question_Directed_To_Aggregate_Order_By>;
   questionLikes_aggregate?: Maybe<Question_Likes_Aggregate_Order_By>;
   questionReplies_aggregate?: Maybe<Question_Replies_Aggregate_Order_By>;
-  resolved?: Maybe<Order_By>;
   resolvedAt?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userByResolvedBy?: Maybe<Users_Order_By>;
@@ -21335,27 +14792,19 @@ export enum Questions_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
   Id = 'id',
   /** column name */
   MetricId = 'metricId',
   /** column name */
   MetricName = 'metricName',
   /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
   OrganizationId = 'organizationId',
   /** column name */
   Priority = 'priority',
   /** column name */
-  Resolved = 'resolved',
-  /** column name */
   ResolvedAt = 'resolvedAt',
   /** column name */
   ResolvedBy = 'resolvedBy',
-  /** column name */
-  ResolvedTs = 'resolved_ts',
   /** column name */
   Text = 'text',
   /** column name */
@@ -21364,216 +14813,155 @@ export enum Questions_Select_Column {
 
 /** input type for updating data in table "questions" */
 export type Questions_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
-  resolved?: Maybe<Scalars['Boolean']>;
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Questions_Stddev_Fields = {
   __typename?: 'questions_stddev_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "questions" */
 export type Questions_Stddev_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Questions_Stddev_Pop_Fields = {
   __typename?: 'questions_stddev_pop_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "questions" */
 export type Questions_Stddev_Pop_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Questions_Stddev_Samp_Fields = {
   __typename?: 'questions_stddev_samp_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "questions" */
 export type Questions_Stddev_Samp_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Questions_Sum_Fields = {
   __typename?: 'questions_sum_fields';
   authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "questions" */
 export type Questions_Sum_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** update columns of table "questions" */
 export enum Questions_Update_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metricName',
-  /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   Priority = 'priority',
-  /** column name */
-  Resolved = 'resolved',
   /** column name */
   ResolvedAt = 'resolvedAt',
   /** column name */
   ResolvedBy = 'resolvedBy',
   /** column name */
-  ResolvedTs = 'resolved_ts',
-  /** column name */
-  Text = 'text',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Text = 'text'
 }
 
 /** aggregate var_pop on columns */
 export type Questions_Var_Pop_Fields = {
   __typename?: 'questions_var_pop_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "questions" */
 export type Questions_Var_Pop_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Questions_Var_Samp_Fields = {
   __typename?: 'questions_var_samp_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "questions" */
 export type Questions_Var_Samp_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Questions_Variance_Fields = {
   __typename?: 'questions_variance_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "questions" */
 export type Questions_Variance_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /**
@@ -21585,11 +14973,8 @@ export type Questions_Variance_Order_By = {
 export type Saved_Queries = {
   __typename?: 'saved_queries';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  /** User ID for the creator of the query */
-  createdBy: Scalars['Int'];
   /** An object relationship */
   createdByUser: Users;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id: Scalars['Int'];
   /** An array relationship */
   metrics: Array<Saved_Query_Metrics>;
@@ -21597,11 +14982,8 @@ export type Saved_Queries = {
   metrics_aggregate: Saved_Query_Metrics_Aggregate;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   ownerTeam?: Maybe<Teams>;
-  /** Team ID for the team that owns the query if a team owns the query */
-  ownerTeamId?: Maybe<Scalars['Int']>;
   /** JSON representative of the full query */
   serializedQuery: Scalars['json'];
   title: Scalars['String'];
@@ -21703,18 +15085,12 @@ export type Saved_Queries_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Saved_Queries_Avg_Fields = {
   __typename?: 'saved_queries_avg_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "saved_queries" */
 export type Saved_Queries_Avg_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "saved_queries". All fields are combined with a logical 'AND'. */
@@ -21723,15 +15099,11 @@ export type Saved_Queries_Bool_Exp = {
   _not?: Maybe<Saved_Queries_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Saved_Queries_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  createdBy?: Maybe<Int_Comparison_Exp>;
   createdByUser?: Maybe<Users_Bool_Exp>;
-  deletedAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metrics?: Maybe<Saved_Query_Metrics_Bool_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   ownerTeam?: Maybe<Teams_Bool_Exp>;
-  ownerTeamId?: Maybe<Int_Comparison_Exp>;
   serializedQuery?: Maybe<Json_Comparison_Exp>;
   title?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -21745,38 +15117,24 @@ export enum Saved_Queries_Constraint {
 
 /** input type for incrementing integer column in table "saved_queries" */
 export type Saved_Queries_Inc_Input = {
-  createdBy?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "saved_queries" */
 export type Saved_Queries_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   createdByUser?: Maybe<Users_Obj_Rel_Insert_Input>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
   metrics?: Maybe<Saved_Query_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeam?: Maybe<Teams_Obj_Rel_Insert_Input>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   serializedQuery?: Maybe<Scalars['json']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Saved_Queries_Max_Fields = {
   __typename?: 'saved_queries_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  ownerTeamId?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21784,11 +15142,7 @@ export type Saved_Queries_Max_Fields = {
 /** order by max() on columns of table "saved_queries" */
 export type Saved_Queries_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  createdBy?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21797,11 +15151,7 @@ export type Saved_Queries_Max_Order_By = {
 export type Saved_Queries_Min_Fields = {
   __typename?: 'saved_queries_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  ownerTeamId?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21809,11 +15159,7 @@ export type Saved_Queries_Min_Fields = {
 /** order by min() on columns of table "saved_queries" */
 export type Saved_Queries_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  createdBy?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21843,15 +15189,11 @@ export type Saved_Queries_On_Conflict = {
 /** ordering options when selecting data from "saved_queries" */
 export type Saved_Queries_Order_By = {
   createdAt?: Maybe<Order_By>;
-  createdBy?: Maybe<Order_By>;
   createdByUser?: Maybe<Users_Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metrics_aggregate?: Maybe<Saved_Query_Metrics_Aggregate_Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   ownerTeam?: Maybe<Teams_Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
   serializedQuery?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -21867,15 +15209,7 @@ export enum Saved_Queries_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedBy = 'createdBy',
-  /** column name */
-  DeletedAt = 'deletedAt',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  OwnerTeamId = 'ownerTeamId',
   /** column name */
   SerializedQuery = 'serializedQuery',
   /** column name */
@@ -21886,156 +15220,99 @@ export enum Saved_Queries_Select_Column {
 
 /** input type for updating data in table "saved_queries" */
 export type Saved_Queries_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   serializedQuery?: Maybe<Scalars['json']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Saved_Queries_Stddev_Fields = {
   __typename?: 'saved_queries_stddev_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "saved_queries" */
 export type Saved_Queries_Stddev_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Saved_Queries_Stddev_Pop_Fields = {
   __typename?: 'saved_queries_stddev_pop_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "saved_queries" */
 export type Saved_Queries_Stddev_Pop_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Saved_Queries_Stddev_Samp_Fields = {
   __typename?: 'saved_queries_stddev_samp_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "saved_queries" */
 export type Saved_Queries_Stddev_Samp_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Saved_Queries_Sum_Fields = {
   __typename?: 'saved_queries_sum_fields';
-  createdBy?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  ownerTeamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "saved_queries" */
 export type Saved_Queries_Sum_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** update columns of table "saved_queries" */
 export enum Saved_Queries_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedBy = 'createdBy',
-  /** column name */
   DeletedAt = 'deletedAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   OwnerTeamId = 'ownerTeamId',
   /** column name */
   SerializedQuery = 'serializedQuery',
   /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
 export type Saved_Queries_Var_Pop_Fields = {
   __typename?: 'saved_queries_var_pop_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "saved_queries" */
 export type Saved_Queries_Var_Pop_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Saved_Queries_Var_Samp_Fields = {
   __typename?: 'saved_queries_var_samp_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "saved_queries" */
 export type Saved_Queries_Var_Samp_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Saved_Queries_Variance_Fields = {
   __typename?: 'saved_queries_variance_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "saved_queries" */
 export type Saved_Queries_Variance_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /**
@@ -22050,10 +15327,8 @@ export type Saved_Query_Metrics = {
   id: Scalars['Int'];
   /** An object relationship */
   metric: Org_Metrics_Current_View;
-  metricId: Scalars['Int'];
   /** An object relationship */
   savedQuery: Saved_Queries;
-  savedQueryId: Scalars['Int'];
   updatedAt: Scalars['timestamptz'];
 };
 
@@ -22105,22 +15380,17 @@ export type Saved_Query_Metrics_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "saved_query_metrics" */
 export type Saved_Query_Metrics_Arr_Rel_Insert_Input = {
   data: Array<Saved_Query_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Saved_Query_Metrics_Avg_Fields = {
   __typename?: 'saved_query_metrics_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "saved_query_metrics". All fields are combined with a logical 'AND'. */
@@ -22131,36 +15401,15 @@ export type Saved_Query_Metrics_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   savedQuery?: Maybe<Saved_Queries_Bool_Exp>;
-  savedQueryId?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "saved_query_metrics" */
-export enum Saved_Query_Metrics_Constraint {
-  /** unique or primary key constraint */
-  SavedQueryMetricsMetricIdSavedQueryIdKey = 'saved_query_metrics_metric_id_saved_query_id_key',
-  /** unique or primary key constraint */
-  SavedQueryMetricsPkey = 'saved_query_metrics_pkey'
-}
-
-/** input type for incrementing integer column in table "saved_query_metrics" */
-export type Saved_Query_Metrics_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "saved_query_metrics" */
 export type Saved_Query_Metrics_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
   savedQuery?: Maybe<Saved_Queries_Obj_Rel_Insert_Input>;
   savedQueryId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -22168,8 +15417,6 @@ export type Saved_Query_Metrics_Max_Fields = {
   __typename?: 'saved_query_metrics_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
@@ -22177,8 +15424,6 @@ export type Saved_Query_Metrics_Max_Fields = {
 export type Saved_Query_Metrics_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -22187,8 +15432,6 @@ export type Saved_Query_Metrics_Min_Fields = {
   __typename?: 'saved_query_metrics_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
@@ -22196,8 +15439,6 @@ export type Saved_Query_Metrics_Min_Fields = {
 export type Saved_Query_Metrics_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -22213,14 +15454,6 @@ export type Saved_Query_Metrics_Mutation_Response = {
 /** input type for inserting object relation for remote table "saved_query_metrics" */
 export type Saved_Query_Metrics_Obj_Rel_Insert_Input = {
   data: Saved_Query_Metrics_Insert_Input;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
-};
-
-/** on conflict condition type for table "saved_query_metrics" */
-export type Saved_Query_Metrics_On_Conflict = {
-  constraint: Saved_Query_Metrics_Constraint;
-  update_columns: Array<Saved_Query_Metrics_Update_Column>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "saved_query_metrics" */
@@ -22228,9 +15461,7 @@ export type Saved_Query_Metrics_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
   savedQuery?: Maybe<Saved_Queries_Order_By>;
-  savedQueryId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -22246,1936 +15477,90 @@ export enum Saved_Query_Metrics_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  SavedQueryId = 'savedQueryId',
-  /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "saved_query_metrics" */
-export type Saved_Query_Metrics_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Saved_Query_Metrics_Stddev_Fields = {
   __typename?: 'saved_query_metrics_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Saved_Query_Metrics_Stddev_Pop_Fields = {
   __typename?: 'saved_query_metrics_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Saved_Query_Metrics_Stddev_Samp_Fields = {
   __typename?: 'saved_query_metrics_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Saved_Query_Metrics_Sum_Fields = {
   __typename?: 'saved_query_metrics_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
-
-/** update columns of table "saved_query_metrics" */
-export enum Saved_Query_Metrics_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  SavedQueryId = 'savedQueryId',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
 
 /** aggregate var_pop on columns */
 export type Saved_Query_Metrics_Var_Pop_Fields = {
   __typename?: 'saved_query_metrics_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Saved_Query_Metrics_Var_Samp_Fields = {
   __typename?: 'saved_query_metrics_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Saved_Query_Metrics_Variance_Fields = {
   __typename?: 'saved_query_metrics_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
-};
-
-/** subscription root */
-export type Subscription_Root = {
-  __typename?: 'subscription_root';
-  /** fetch data from the table: "annotations" using primary key columns */
-  annotation?: Maybe<Annotations>;
-  /** fetch data from the table: "annotations" */
-  annotations: Array<Annotations>;
-  /** fetch aggregated fields from the table: "annotations" */
-  annotationsAggregate: Annotations_Aggregate;
-  /** fetch data from the table: "api_keys" using primary key columns */
-  apiKey?: Maybe<Api_Keys>;
-  /** fetch data from the table: "api_keys" */
-  apiKeys: Array<Api_Keys>;
-  /** fetch aggregated fields from the table: "api_keys" */
-  apiKeysAggregate: Api_Keys_Aggregate;
-  /** fetch data from the table: "branch_metadatas" */
-  branch_metadatas: Array<Branch_Metadatas>;
-  /** fetch aggregated fields from the table: "branch_metadatas" */
-  branch_metadatas_aggregate: Branch_Metadatas_Aggregate;
-  /** fetch data from the table: "branch_metadatas" using primary key columns */
-  branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** fetch data from the table: "dashboards" using primary key columns */
-  dashboard?: Maybe<Dashboards>;
-  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
-  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
-  /** fetch data from the table: "dashboard_item_configs" */
-  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
-  /** fetch aggregated fields from the table: "dashboard_item_configs" */
-  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
-  /** fetch data from the table: "dashboard_layouts" using primary key columns */
-  dashboardLayout?: Maybe<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_layouts" */
-  dashboardLayouts: Array<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_renderable_types" using primary key columns */
-  dashboardRenderableType?: Maybe<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_renderable_types" */
-  dashboardRenderableTypes: Array<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_sections" using primary key columns */
-  dashboardSection?: Maybe<Dashboard_Sections>;
-  /** fetch data from the table: "dashboard_section_types" using primary key columns */
-  dashboardSectionType?: Maybe<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_section_types" */
-  dashboardSectionTypes: Array<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_sections" */
-  dashboardSections: Array<Dashboard_Sections>;
-  /** fetch aggregated fields from the table: "dashboard_sections" */
-  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_layouts" */
-  dashboard_layouts_aggregate: Dashboard_Layouts_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_renderable_types" */
-  dashboard_renderable_types_aggregate: Dashboard_Renderable_Types_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_section_types" */
-  dashboard_section_types_aggregate: Dashboard_Section_Types_Aggregate;
-  /** fetch data from the table: "dashboards" */
-  dashboards: Array<Dashboards>;
-  /** fetch aggregated fields from the table: "dashboards" */
-  dashboardsAggregate: Dashboards_Aggregate;
-  /** fetch data from the table: "org_data_sources" using primary key columns */
-  dataSource?: Maybe<Org_Data_Sources>;
-  /** fetch data from the table: "data_source_versions" using primary key columns */
-  dataSourceVersion?: Maybe<Data_Source_Versions>;
-  /** fetch data from the table: "data_source_versions" */
-  dataSourceVersions: Array<Data_Source_Versions>;
-  /** fetch aggregated fields from the table: "data_source_versions" */
-  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
-  /** fetch data from the table: "org_data_sources" */
-  dataSources: Array<Org_Data_Sources>;
-  /** fetch aggregated fields from the table: "org_data_sources" */
-  dataSourcesAggregate: Org_Data_Sources_Aggregate;
-  /** fetch data from the table: "dw_engines" */
-  dw_engines: Array<Dw_Engines>;
-  /** fetch aggregated fields from the table: "dw_engines" */
-  dw_engines_aggregate: Dw_Engines_Aggregate;
-  /** fetch data from the table: "dw_engines" using primary key columns */
-  dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** fetch data from the table: "features" using primary key columns */
-  feature?: Maybe<Features>;
-  /** fetch data from the table: "features" */
-  features: Array<Features>;
-  /** fetch aggregated fields from the table: "features" */
-  featuresAggregate: Features_Aggregate;
-  /** execute function "me" which returns "users" */
-  me: Array<Users>;
-  /** execute function "me" and query aggregates on result of table type "users" */
-  me_aggregate: Users_Aggregate;
-  /** fetch data from the table: "metric_annotations" using primary key columns */
-  metricAnnotation?: Maybe<Metric_Annotations>;
-  /** fetch data from the table: "metric_annotations" */
-  metricAnnotations: Array<Metric_Annotations>;
-  /** fetch aggregated fields from the table: "metric_annotations" */
-  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
-  /** fetch data from the table: "metric_approvals" using primary key columns */
-  metricApproval?: Maybe<Metric_Approvals>;
-  /** fetch data from the table: "metric_approvals" */
-  metricApprovals: Array<Metric_Approvals>;
-  /** fetch aggregated fields from the table: "metric_approvals" */
-  metricApprovalsAggregate: Metric_Approvals_Aggregate;
-  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
-  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
-  /** fetch data from the table: "metric_collections" using primary key columns */
-  metricCollection?: Maybe<Metric_Collections>;
-  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
-  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** fetch data from the table: "metric_collection_metrics" */
-  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
-  /** fetch aggregated fields from the table: "metric_collection_metrics" */
-  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
-  /** fetch data from the table: "metric_collection_view" using primary key columns */
-  metricCollectionView?: Maybe<Metric_Collection_View>;
-  /** fetch aggregated fields from the table: "metric_collection_view" */
-  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
-  /** fetch data from the table: "metric_collection_view" */
-  metricCollectionViews: Array<Metric_Collection_View>;
-  /** fetch data from the table: "metric_collections" */
-  metricCollections: Array<Metric_Collections>;
-  /** fetch aggregated fields from the table: "metric_collections" */
-  metricCollectionsAggregate: Metric_Collections_Aggregate;
-  /** fetch data from the table: "metric_current_description" */
-  metricCurrentDescriptions: Array<Metric_Current_Description>;
-  /** fetch data from the table: "metric_descriptions" using primary key columns */
-  metricDescription?: Maybe<Metric_Descriptions>;
-  /** fetch data from the table: "metric_descriptions" */
-  metricDescriptions: Array<Metric_Descriptions>;
-  /** fetch aggregated fields from the table: "metric_descriptions" */
-  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
-  /** fetch data from the table: "metric_team_owners" using primary key columns */
-  metricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** fetch data from the table: "metric_team_owners" */
-  metricTeamOwners: Array<Metric_Team_Owners>;
-  /** fetch aggregated fields from the table: "metric_team_owners" */
-  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
-  /** fetch data from the table: "metric_user_owners" using primary key columns */
-  metricUserOwner?: Maybe<Metric_User_Owners>;
-  /** fetch data from the table: "metric_user_owners" */
-  metricUserOwners: Array<Metric_User_Owners>;
-  /** fetch aggregated fields from the table: "metric_user_owners" */
-  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
-  /** fetch data from the table: "metric_versions" using primary key columns */
-  metricVersion?: Maybe<Metric_Versions>;
-  /** fetch data from the table: "metric_versions" */
-  metricVersions: Array<Metric_Versions>;
-  /** fetch aggregated fields from the table: "metric_versions" */
-  metricVersionsAggregate: Metric_Versions_Aggregate;
-  /** fetch data from the table: "metric_view" */
-  metricViews: Array<Metric_View>;
-  /** fetch aggregated fields from the table: "metric_view" */
-  metricViewsAggregate: Metric_View_Aggregate;
-  /** fetch aggregated fields from the table: "metric_current_description" */
-  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
-  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
-  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** fetch data from the table: "org_metrics_current_view" */
-  metrics: Array<Org_Metrics_Current_View>;
-  /** fetch aggregated fields from the table: "org_metrics_current_view" */
-  metricsAggregate: Org_Metrics_Current_View_Aggregate;
-  /** fetch data from the table: "models" using primary key columns */
-  model?: Maybe<Models>;
-  /** fetch data from the table: "model_data_sources" using primary key columns */
-  modelDataSource?: Maybe<Model_Data_Sources>;
-  /** fetch data from the table: "model_data_sources" */
-  modelDataSources: Array<Model_Data_Sources>;
-  /** fetch aggregated fields from the table: "model_data_sources" */
-  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
-  /** fetch data from the table: "model_metrics" using primary key columns */
-  modelMetric?: Maybe<Model_Metrics>;
-  /** fetch data from the table: "model_metrics" */
-  modelMetrics: Array<Model_Metrics>;
-  /** fetch aggregated fields from the table: "model_metrics" */
-  modelMetricsAggregate: Model_Metrics_Aggregate;
-  /** fetch data from the table: "model_current" */
-  model_current: Array<Model_Current>;
-  /** fetch aggregated fields from the table: "model_current" */
-  model_current_aggregate: Model_Current_Aggregate;
-  /** fetch data from the table: "models" */
-  models: Array<Models>;
-  /** fetch aggregated fields from the table: "models" */
-  modelsAggregate: Models_Aggregate;
-  /** fetch data from the table: "mql_heartbeats" using primary key columns */
-  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
-  /** fetch data from the table: "mql_heartbeats" */
-  mqlHeartbeats: Array<Mql_Heartbeats>;
-  /** fetch aggregated fields from the table: "mql_heartbeats" */
-  mqlHeartbeatsAggregate: Mql_Heartbeats_Aggregate;
-  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
-  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
-  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
-  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
-  /** execute function "my_org" which returns "organizations" */
-  my_org: Array<Organizations>;
-  /** execute function "my_org" and query aggregates on result of table type "organizations" */
-  my_org_aggregate: Organizations_Aggregate;
-  /** fetch data from the table: "org_mql_servers" using primary key columns */
-  orgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** fetch data from the table: "org_mql_servers" */
-  orgMqlServers: Array<Org_Mql_Servers>;
-  /** fetch aggregated fields from the table: "org_mql_servers" */
-  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types: Array<Org_Mql_Server_Logs_Types>;
-  /** fetch aggregated fields from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types_aggregate: Org_Mql_Server_Logs_Types_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" using primary key columns */
-  org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** fetch data from the table: "organizations" using primary key columns */
-  organization?: Maybe<Organizations>;
-  /** fetch data from the table: "organization_features" using primary key columns */
-  organizationFeature?: Maybe<Organization_Features>;
-  /** fetch data from the table: "organization_features" */
-  organizationFeatures: Array<Organization_Features>;
-  /** fetch aggregated fields from the table: "organization_features" */
-  organizationFeaturesAggregate: Organization_Features_Aggregate;
-  /** fetch data from the table: "organizations" */
-  organizations: Array<Organizations>;
-  /** fetch aggregated fields from the table: "organizations" */
-  organizationsAggregate: Organizations_Aggregate;
-  /** fetch data from the table: "priorities" */
-  priorities: Array<Priorities>;
-  /** fetch aggregated fields from the table: "priorities" */
-  priorities_aggregate: Priorities_Aggregate;
-  /** fetch data from the table: "priorities" using primary key columns */
-  priorities_by_pk?: Maybe<Priorities>;
-  /** fetch data from the table: "questions" using primary key columns */
-  question?: Maybe<Questions>;
-  /** fetch data from the table: "question_directed_to" */
-  questionDirectedTo: Array<Question_Directed_To>;
-  /** fetch aggregated fields from the table: "question_directed_to" */
-  questionDirectedToAggregate: Question_Directed_To_Aggregate;
-  /** fetch data from the table: "question_directed_to" using primary key columns */
-  questionDirectedToByPK?: Maybe<Question_Directed_To>;
-  /** fetch data from the table: "question_likes" using primary key columns */
-  questionLike?: Maybe<Question_Likes>;
-  /** fetch data from the table: "question_likes" */
-  questionLikes: Array<Question_Likes>;
-  /** fetch aggregated fields from the table: "question_likes" */
-  questionLikesAggregate: Question_Likes_Aggregate;
-  /** fetch data from the table: "question_replies" */
-  questionReplies: Array<Question_Replies>;
-  /** fetch aggregated fields from the table: "question_replies" */
-  questionRepliesAggregate: Question_Replies_Aggregate;
-  /** fetch data from the table: "question_replies" using primary key columns */
-  questionReply?: Maybe<Question_Replies>;
-  /** fetch data from the table: "questions" */
-  questions: Array<Questions>;
-  /** fetch aggregated fields from the table: "questions" */
-  questionsAggregate: Questions_Aggregate;
-  /** fetch data from the table: "saved_queries" */
-  savedQueries: Array<Saved_Queries>;
-  /** fetch aggregated fields from the table: "saved_queries" */
-  savedQueriesAggregate: Saved_Queries_Aggregate;
-  /** fetch data from the table: "saved_queries" using primary key columns */
-  savedQuery?: Maybe<Saved_Queries>;
-  /** fetch data from the table: "saved_query_metrics" using primary key columns */
-  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** fetch data from the table: "saved_query_metrics" */
-  savedQueryMetrics: Array<Saved_Query_Metrics>;
-  /** fetch aggregated fields from the table: "saved_query_metrics" */
-  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
-  /** fetch data from the table: "teams" using primary key columns */
-  team?: Maybe<Teams>;
-  /** fetch data from the table: "team_dashboards" using primary key columns */
-  teamDashboard?: Maybe<Team_Dashboards>;
-  /** fetch data from the table: "team_dashboards" */
-  teamDashboards: Array<Team_Dashboards>;
-  /** fetch aggregated fields from the table: "team_dashboards" */
-  teamDashboardsAggregate: Team_Dashboards_Aggregate;
-  /** fetch data from the table: "team_members" using primary key columns */
-  teamMember?: Maybe<Team_Members>;
-  /** fetch data from the table: "team_members" */
-  teamMembers: Array<Team_Members>;
-  /** fetch aggregated fields from the table: "team_members" */
-  teamMembersAggregate: Team_Members_Aggregate;
-  /** fetch aggregated fields from the table: "team_views" */
-  teamViewsAggregate: Team_Views_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" */
-  team_page_theme_colors: Array<Team_Page_Theme_Colors>;
-  /** fetch aggregated fields from the table: "team_page_theme_colors" */
-  team_page_theme_colors_aggregate: Team_Page_Theme_Colors_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" using primary key columns */
-  team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** fetch data from the table: "team_views" */
-  team_views: Array<Team_Views>;
-  /** fetch data from the table: "team_views" using primary key columns */
-  team_views_by_pk?: Maybe<Team_Views>;
-  /** fetch data from the table: "teams" */
-  teams: Array<Teams>;
-  /** fetch aggregated fields from the table: "teams" */
-  teamsAggregate: Teams_Aggregate;
-  /** fetch data from the table: "unsubscribes" */
-  unsubscribes: Array<Unsubscribes>;
-  /** fetch aggregated fields from the table: "unsubscribes" */
-  unsubscribes_aggregate: Unsubscribes_Aggregate;
-  /** fetch data from the table: "unsubscribes" using primary key columns */
-  unsubscribes_by_pk?: Maybe<Unsubscribes>;
-  /** fetch data from the table: "users" using primary key columns */
-  user?: Maybe<Users>;
-  /** fetch data from the table: "user_dashboards" using primary key columns */
-  userDashboard?: Maybe<User_Dashboards>;
-  /** fetch data from the table: "user_dashboards" */
-  userDashboards: Array<User_Dashboards>;
-  /** fetch aggregated fields from the table: "user_dashboards" */
-  userDashboardsAggregate: User_Dashboards_Aggregate;
-  /** fetch data from the table: "user_features" using primary key columns */
-  userFeature?: Maybe<User_Features>;
-  /** fetch data from the table: "user_features" */
-  userFeatures: Array<User_Features>;
-  /** fetch aggregated fields from the table: "user_features" */
-  userFeaturesAggregate: User_Features_Aggregate;
-  /** fetch data from the table: "user_prefs" using primary key columns */
-  userPreference?: Maybe<User_Prefs>;
-  /** fetch data from the table: "user_prefs" */
-  userPreferences: Array<User_Prefs>;
-  /** fetch aggregated fields from the table: "user_prefs" */
-  userPreferencesAggregate: User_Prefs_Aggregate;
-  /** fetch data from the table: "user_roles" using primary key columns */
-  userRole?: Maybe<User_Roles>;
-  /** fetch data from the table: "user_roles" */
-  userRoles: Array<User_Roles>;
-  /** fetch aggregated fields from the table: "user_roles" */
-  userRolesAggregate: User_Roles_Aggregate;
-  /** fetch data from the table: "user_role_types" */
-  user_role_types: Array<User_Role_Types>;
-  /** fetch aggregated fields from the table: "user_role_types" */
-  user_role_types_aggregate: User_Role_Types_Aggregate;
-  /** fetch data from the table: "user_role_types" using primary key columns */
-  user_role_types_by_pk?: Maybe<User_Role_Types>;
-  /** fetch data from the table: "users" */
-  users: Array<Users>;
-  /** fetch aggregated fields from the table: "users" */
-  usersAggregate: Users_Aggregate;
-};
-
-
-/** subscription root */
-export type Subscription_RootAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootApiKeyArgs = {
-  prefix: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootApiKeysArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootApiKeysAggregateArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootBranch_MetadatasArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootBranch_Metadatas_AggregateArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootBranch_Metadatas_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardItemConfigArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardItemConfigsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardItemConfigsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardLayoutArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardLayoutsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardRenderableTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardRenderableTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboard_Layouts_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboard_Renderable_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboard_Section_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardsArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceVersionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceVersionsArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDw_EnginesArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDw_Engines_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDw_Engines_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootFeatureArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootFeaturesArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMeArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMe_AggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricApprovalArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricApprovalsArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricApprovalsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricByIdTempArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionMetricsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionViewArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionViewAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCurrentDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricDescriptionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricDescriptionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricTeamOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricTeamOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricTeamOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricUserOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricUserOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricUserOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricVersionArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricVersionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Current_Description_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Lineage_Data_SourcesArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Lineage_Data_Sources_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Lineage_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** subscription root */
-export type Subscription_RootModelDataSourceArgs = {
-  dataSourceVersionId: Scalars['Int'];
-  modelId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootModelDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelMetricArgs = {
-  metricId: Scalars['bigint'];
-  metricVersionId: Scalars['bigint'];
-  modelId: Scalars['bigint'];
-};
-
-
-/** subscription root */
-export type Subscription_RootModelMetricsArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModel_CurrentArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModel_Current_AggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelsArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelsAggregateArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMqlHeartbeatArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMqlHeartbeatsArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMqlHeartbeatsAggregateArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_Most_Viewed_MetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_Most_Viewed_Metrics_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_OrgArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_Org_AggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrgMqlServerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrgMqlServersArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrgMqlServersAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrg_Mql_Server_Logs_TypesArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrg_Mql_Server_Logs_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrg_Mql_Server_Logs_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationFeatureArgs = {
-  featureId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationFeaturesArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationsArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootPrioritiesArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootPriorities_AggregateArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootPriorities_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionDirectedToArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionDirectedToAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionDirectedToByPkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionLikeArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionLikesArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionLikesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionRepliesArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionRepliesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionReplyArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionsArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueriesArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueriesAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryMetricsArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  team_id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamDashboardsArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamMemberArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamMembersArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamMembersAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Page_Theme_ColorsArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Page_Theme_Colors_AggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Page_Theme_Colors_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_ViewsArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Views_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamsArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamsAggregateArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUnsubscribesArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUnsubscribes_AggregateArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUnsubscribes_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserDashboardsArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserFeatureArgs = {
-  featureId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserFeaturesArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserPreferenceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserPreferencesArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserPreferencesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserRoleArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserRolesArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserRolesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUser_Role_TypesArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUser_Role_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUser_Role_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUsersArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUsersAggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
 };
 
 /** columns and relationships of "team_dashboards" */
 export type Team_Dashboards = {
   __typename?: 'team_dashboards';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-  team_id: Scalars['Int'];
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
@@ -24189,17 +15574,9 @@ export type Team_Dashboards_Aggregate = {
 /** aggregate fields of "team_dashboards" */
 export type Team_Dashboards_Aggregate_Fields = {
   __typename?: 'team_dashboards_aggregate_fields';
-  avg?: Maybe<Team_Dashboards_Avg_Fields>;
   count?: Maybe<Scalars['Int']>;
   max?: Maybe<Team_Dashboards_Max_Fields>;
   min?: Maybe<Team_Dashboards_Min_Fields>;
-  stddev?: Maybe<Team_Dashboards_Stddev_Fields>;
-  stddev_pop?: Maybe<Team_Dashboards_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Team_Dashboards_Stddev_Samp_Fields>;
-  sum?: Maybe<Team_Dashboards_Sum_Fields>;
-  var_pop?: Maybe<Team_Dashboards_Var_Pop_Fields>;
-  var_samp?: Maybe<Team_Dashboards_Var_Samp_Fields>;
-  variance?: Maybe<Team_Dashboards_Variance_Fields>;
 };
 
 
@@ -24211,38 +15588,14 @@ export type Team_Dashboards_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "team_dashboards" */
 export type Team_Dashboards_Aggregate_Order_By = {
-  avg?: Maybe<Team_Dashboards_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Team_Dashboards_Max_Order_By>;
   min?: Maybe<Team_Dashboards_Min_Order_By>;
-  stddev?: Maybe<Team_Dashboards_Stddev_Order_By>;
-  stddev_pop?: Maybe<Team_Dashboards_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Team_Dashboards_Stddev_Samp_Order_By>;
-  sum?: Maybe<Team_Dashboards_Sum_Order_By>;
-  var_pop?: Maybe<Team_Dashboards_Var_Pop_Order_By>;
-  var_samp?: Maybe<Team_Dashboards_Var_Samp_Order_By>;
-  variance?: Maybe<Team_Dashboards_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "team_dashboards" */
 export type Team_Dashboards_Arr_Rel_Insert_Input = {
   data: Array<Team_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Team_Dashboards_Avg_Fields = {
-  __typename?: 'team_dashboards_avg_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "team_dashboards" */
-export type Team_Dashboards_Avg_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "team_dashboards". All fields are combined with a logical 'AND'. */
@@ -24251,50 +15604,25 @@ export type Team_Dashboards_Bool_Exp = {
   _not?: Maybe<Team_Dashboards_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Team_Dashboards_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dashboardId?: Maybe<Int_Comparison_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-  team_id?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "team_dashboards" */
-export enum Team_Dashboards_Constraint {
-  /** unique or primary key constraint */
-  TeamDashboardsPkey = 'team_dashboards_pkey'
-}
-
-/** input type for incrementing integer column in table "team_dashboards" */
-export type Team_Dashboards_Inc_Input = {
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "team_dashboards" */
 export type Team_Dashboards_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   team_id?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Team_Dashboards_Max_Fields = {
   __typename?: 'team_dashboards_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "team_dashboards" */
 export type Team_Dashboards_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -24302,18 +15630,12 @@ export type Team_Dashboards_Max_Order_By = {
 export type Team_Dashboards_Min_Fields = {
   __typename?: 'team_dashboards_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "team_dashboards" */
 export type Team_Dashboards_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -24329,22 +15651,11 @@ export type Team_Dashboards_Mutation_Response = {
 /** input type for inserting object relation for remote table "team_dashboards" */
 export type Team_Dashboards_Obj_Rel_Insert_Input = {
   data: Team_Dashboards_Insert_Input;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-/** on conflict condition type for table "team_dashboards" */
-export type Team_Dashboards_On_Conflict = {
-  constraint: Team_Dashboards_Constraint;
-  update_columns: Array<Team_Dashboards_Update_Column>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "team_dashboards" */
 export type Team_Dashboards_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -24359,142 +15670,8 @@ export enum Team_Dashboards_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "team_dashboards" */
-export type Team_Dashboards_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** aggregate stddev on columns */
-export type Team_Dashboards_Stddev_Fields = {
-  __typename?: 'team_dashboards_stddev_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "team_dashboards" */
-export type Team_Dashboards_Stddev_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Team_Dashboards_Stddev_Pop_Fields = {
-  __typename?: 'team_dashboards_stddev_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "team_dashboards" */
-export type Team_Dashboards_Stddev_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Team_Dashboards_Stddev_Samp_Fields = {
-  __typename?: 'team_dashboards_stddev_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "team_dashboards" */
-export type Team_Dashboards_Stddev_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Team_Dashboards_Sum_Fields = {
-  __typename?: 'team_dashboards_sum_fields';
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "team_dashboards" */
-export type Team_Dashboards_Sum_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "team_dashboards" */
-export enum Team_Dashboards_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
-
-/** aggregate var_pop on columns */
-export type Team_Dashboards_Var_Pop_Fields = {
-  __typename?: 'team_dashboards_var_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "team_dashboards" */
-export type Team_Dashboards_Var_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Team_Dashboards_Var_Samp_Fields = {
-  __typename?: 'team_dashboards_var_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "team_dashboards" */
-export type Team_Dashboards_Var_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Team_Dashboards_Variance_Fields = {
-  __typename?: 'team_dashboards_variance_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "team_dashboards" */
-export type Team_Dashboards_Variance_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
 
 /**
  * Users belonging to a Team
@@ -24509,16 +15686,12 @@ export type Team_Members = {
   isTeamAdmin: Scalars['Boolean'];
   /** Indicates when the User was added to the Team */
   joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   team: Teams;
-  teamId: Scalars['Int'];
   /** An object relationship */
   user: Users;
-  user_id: Scalars['Int'];
 };
 
 /** aggregated selection of "team_members" */
@@ -24576,19 +15749,11 @@ export type Team_Members_Arr_Rel_Insert_Input = {
 export type Team_Members_Avg_Fields = {
   __typename?: 'team_members_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "team_members" */
 export type Team_Members_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "team_members". All fields are combined with a logical 'AND'. */
@@ -24599,13 +15764,9 @@ export type Team_Members_Bool_Exp = {
   id?: Maybe<Int_Comparison_Exp>;
   isTeamAdmin?: Maybe<Boolean_Comparison_Exp>;
   joinedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  joined_ts?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   team?: Maybe<Teams_Bool_Exp>;
-  teamId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "team_members" */
@@ -24614,23 +15775,9 @@ export enum Team_Members_Constraint {
   TeamMembersPkey = 'team_members_pkey'
 }
 
-/** input type for incrementing integer column in table "team_members" */
-export type Team_Members_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "team_members" */
 export type Team_Members_Insert_Input = {
-  id?: Maybe<Scalars['Int']>;
   isTeamAdmin?: Maybe<Scalars['Boolean']>;
-  joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   team?: Maybe<Teams_Obj_Rel_Insert_Input>;
   teamId?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
@@ -24642,20 +15789,12 @@ export type Team_Members_Max_Fields = {
   __typename?: 'team_members_max_fields';
   id?: Maybe<Scalars['Int']>;
   joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "team_members" */
 export type Team_Members_Max_Order_By = {
   id?: Maybe<Order_By>;
   joinedAt?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -24663,20 +15802,12 @@ export type Team_Members_Min_Fields = {
   __typename?: 'team_members_min_fields';
   id?: Maybe<Scalars['Int']>;
   joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "team_members" */
 export type Team_Members_Min_Order_By = {
   id?: Maybe<Order_By>;
   joinedAt?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "team_members" */
@@ -24706,13 +15837,9 @@ export type Team_Members_Order_By = {
   id?: Maybe<Order_By>;
   isTeamAdmin?: Maybe<Order_By>;
   joinedAt?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   team?: Maybe<Teams_Order_By>;
-  teamId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "team_members" */
@@ -24727,399 +15854,106 @@ export enum Team_Members_Select_Column {
   /** column name */
   IsTeamAdmin = 'isTeamAdmin',
   /** column name */
-  JoinedAt = 'joinedAt',
-  /** column name */
-  JoinedTs = 'joined_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'user_id'
+  JoinedAt = 'joinedAt'
 }
 
 /** input type for updating data in table "team_members" */
 export type Team_Members_Set_Input = {
-  id?: Maybe<Scalars['Int']>;
   isTeamAdmin?: Maybe<Scalars['Boolean']>;
-  joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type Team_Members_Stddev_Fields = {
   __typename?: 'team_members_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "team_members" */
 export type Team_Members_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Team_Members_Stddev_Pop_Fields = {
   __typename?: 'team_members_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "team_members" */
 export type Team_Members_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Team_Members_Stddev_Samp_Fields = {
   __typename?: 'team_members_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "team_members" */
 export type Team_Members_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Team_Members_Sum_Fields = {
   __typename?: 'team_members_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "team_members" */
 export type Team_Members_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** update columns of table "team_members" */
 export enum Team_Members_Update_Column {
   /** column name */
-  Id = 'id',
-  /** column name */
-  IsTeamAdmin = 'isTeamAdmin',
-  /** column name */
-  JoinedAt = 'joinedAt',
-  /** column name */
-  JoinedTs = 'joined_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'user_id'
+  IsTeamAdmin = 'isTeamAdmin'
 }
 
 /** aggregate var_pop on columns */
 export type Team_Members_Var_Pop_Fields = {
   __typename?: 'team_members_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "team_members" */
 export type Team_Members_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Team_Members_Var_Samp_Fields = {
   __typename?: 'team_members_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "team_members" */
 export type Team_Members_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Team_Members_Variance_Fields = {
   __typename?: 'team_members_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "team_members" */
 export type Team_Members_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
-
-/** columns and relationships of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors = {
-  __typename?: 'team_page_theme_colors';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate = {
-  __typename?: 'team_page_theme_colors_aggregate';
-  aggregate?: Maybe<Team_Page_Theme_Colors_Aggregate_Fields>;
-  nodes: Array<Team_Page_Theme_Colors>;
-};
-
-/** aggregate fields of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate_Fields = {
-  __typename?: 'team_page_theme_colors_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Team_Page_Theme_Colors_Max_Fields>;
-  min?: Maybe<Team_Page_Theme_Colors_Min_Fields>;
-};
-
-
-/** aggregate fields of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Team_Page_Theme_Colors_Max_Order_By>;
-  min?: Maybe<Team_Page_Theme_Colors_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Arr_Rel_Insert_Input = {
-  data: Array<Team_Page_Theme_Colors_Insert_Input>;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "team_page_theme_colors". All fields are combined with a logical 'AND'. */
-export type Team_Page_Theme_Colors_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Team_Page_Theme_Colors_Bool_Exp>>>;
-  _not?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Team_Page_Theme_Colors_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "team_page_theme_colors" */
-export enum Team_Page_Theme_Colors_Constraint {
-  /** unique or primary key constraint */
-  TeamPageThemeColorsPkey = 'team_page_theme_colors_pkey'
-}
-
-/** input type for inserting data into table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Team_Page_Theme_Colors_Max_Fields = {
-  __typename?: 'team_page_theme_colors_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Team_Page_Theme_Colors_Min_Fields = {
-  __typename?: 'team_page_theme_colors_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Mutation_Response = {
-  __typename?: 'team_page_theme_colors_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Team_Page_Theme_Colors>;
-};
-
-/** input type for inserting object relation for remote table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Obj_Rel_Insert_Input = {
-  data: Team_Page_Theme_Colors_Insert_Input;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-/** on conflict condition type for table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_On_Conflict = {
-  constraint: Team_Page_Theme_Colors_Constraint;
-  update_columns: Array<Team_Page_Theme_Colors_Update_Column>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "team_page_theme_colors" */
-export enum Team_Page_Theme_Colors_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "team_page_theme_colors" */
-export enum Team_Page_Theme_Colors_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
 
 /** columns and relationships of "team_views" */
 export type Team_Views = {
   __typename?: 'team_views';
   created_at: Scalars['timestamptz'];
-  id: Scalars['Int'];
-  organization_id: Scalars['Int'];
-  team_id: Scalars['Int'];
-  user_id: Scalars['Int'];
-};
-
-/** aggregated selection of "team_views" */
-export type Team_Views_Aggregate = {
-  __typename?: 'team_views_aggregate';
-  aggregate?: Maybe<Team_Views_Aggregate_Fields>;
-  nodes: Array<Team_Views>;
-};
-
-/** aggregate fields of "team_views" */
-export type Team_Views_Aggregate_Fields = {
-  __typename?: 'team_views_aggregate_fields';
-  avg?: Maybe<Team_Views_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Team_Views_Max_Fields>;
-  min?: Maybe<Team_Views_Min_Fields>;
-  stddev?: Maybe<Team_Views_Stddev_Fields>;
-  stddev_pop?: Maybe<Team_Views_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Team_Views_Stddev_Samp_Fields>;
-  sum?: Maybe<Team_Views_Sum_Fields>;
-  var_pop?: Maybe<Team_Views_Var_Pop_Fields>;
-  var_samp?: Maybe<Team_Views_Var_Samp_Fields>;
-  variance?: Maybe<Team_Views_Variance_Fields>;
-};
-
-
-/** aggregate fields of "team_views" */
-export type Team_Views_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Team_Views_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "team_views" */
-export type Team_Views_Aggregate_Order_By = {
-  avg?: Maybe<Team_Views_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Team_Views_Max_Order_By>;
-  min?: Maybe<Team_Views_Min_Order_By>;
-  stddev?: Maybe<Team_Views_Stddev_Order_By>;
-  stddev_pop?: Maybe<Team_Views_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Team_Views_Stddev_Samp_Order_By>;
-  sum?: Maybe<Team_Views_Sum_Order_By>;
-  var_pop?: Maybe<Team_Views_Var_Pop_Order_By>;
-  var_samp?: Maybe<Team_Views_Var_Samp_Order_By>;
-  variance?: Maybe<Team_Views_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "team_views" */
 export type Team_Views_Arr_Rel_Insert_Input = {
   data: Array<Team_Views_Insert_Input>;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Team_Views_Avg_Fields = {
-  __typename?: 'team_views_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "team_views" */
-export type Team_Views_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "team_views". All fields are combined with a logical 'AND'. */
@@ -25128,71 +15962,11 @@ export type Team_Views_Bool_Exp = {
   _not?: Maybe<Team_Views_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Team_Views_Bool_Exp>>>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
-  team_id?: Maybe<Int_Comparison_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "team_views" */
-export enum Team_Views_Constraint {
-  /** unique or primary key constraint */
-  TeamViewsPkey = 'team_views_pkey'
-}
-
-/** input type for incrementing integer column in table "team_views" */
-export type Team_Views_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "team_views" */
 export type Team_Views_Insert_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type Team_Views_Max_Fields = {
-  __typename?: 'team_views_max_fields';
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "team_views" */
-export type Team_Views_Max_Order_By = {
-  created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Team_Views_Min_Fields = {
-  __typename?: 'team_views_min_fields';
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "team_views" */
-export type Team_Views_Min_Order_By = {
-  created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "team_views" */
@@ -25207,23 +15981,11 @@ export type Team_Views_Mutation_Response = {
 /** input type for inserting object relation for remote table "team_views" */
 export type Team_Views_Obj_Rel_Insert_Input = {
   data: Team_Views_Insert_Input;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-/** on conflict condition type for table "team_views" */
-export type Team_Views_On_Conflict = {
-  constraint: Team_Views_Constraint;
-  update_columns: Array<Team_Views_Update_Column>;
-  where?: Maybe<Team_Views_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "team_views" */
 export type Team_Views_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "team_views" */
@@ -25234,158 +15996,8 @@ export type Team_Views_Pk_Columns_Input = {
 /** select columns of table "team_views" */
 export enum Team_Views_Select_Column {
   /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
-  UserId = 'user_id'
+  CreatedAt = 'created_at'
 }
-
-/** input type for updating data in table "team_views" */
-export type Team_Views_Set_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Team_Views_Stddev_Fields = {
-  __typename?: 'team_views_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "team_views" */
-export type Team_Views_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Team_Views_Stddev_Pop_Fields = {
-  __typename?: 'team_views_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "team_views" */
-export type Team_Views_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Team_Views_Stddev_Samp_Fields = {
-  __typename?: 'team_views_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "team_views" */
-export type Team_Views_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Team_Views_Sum_Fields = {
-  __typename?: 'team_views_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "team_views" */
-export type Team_Views_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "team_views" */
-export enum Team_Views_Update_Column {
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** aggregate var_pop on columns */
-export type Team_Views_Var_Pop_Fields = {
-  __typename?: 'team_views_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "team_views" */
-export type Team_Views_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Team_Views_Var_Samp_Fields = {
-  __typename?: 'team_views_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "team_views" */
-export type Team_Views_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Team_Views_Variance_Fields = {
-  __typename?: 'team_views_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "team_views" */
-export type Team_Views_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
 
 /**
  * Teams are groups of Users within an Organization
@@ -25399,18 +16011,12 @@ export type Teams = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   createdBy?: Maybe<Users>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   /** An array relationship */
   dashboards: Array<Team_Dashboards>;
   /** An aggregated array relationship */
   dashboards_aggregate: Team_Dashboards_Aggregate;
-  deactivated?: Maybe<Scalars['Int']>;
-  /** A soft delete mechanism for removing a Team */
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   featuredMetricCollection?: Maybe<Metric_Collections>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   /** A unique identifier for a Team */
   id: Scalars['Int'];
   /** An array relationship */
@@ -25425,10 +16031,8 @@ export type Teams = {
   name: Scalars['String'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   primaryDashboard?: Maybe<Dashboards>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   /** An array relationship */
   questionsDirectedTo: Array<Question_Directed_To>;
   /** An aggregated array relationship */
@@ -25445,11 +16049,7 @@ export type Teams = {
   teamMembers_aggregate: Team_Members_Aggregate;
   /** An array relationship */
   teamViews: Array<Team_Views>;
-  /** An aggregated array relationship */
-  teamViews_aggregate: Team_Views_Aggregate;
   theme?: Maybe<Scalars['String']>;
-  /** An object relationship */
-  theme_color?: Maybe<Team_Page_Theme_Colors>;
   /** Timestamp indicating when the Team was last updated */
   updatedAt?: Maybe<Scalars['timestamptz']>;
   /** A computed field, executes function "user_is_team_admin" */
@@ -25651,21 +16251,6 @@ export type TeamsTeamViewsArgs = {
   where?: Maybe<Team_Views_Bool_Exp>;
 };
 
-
-/**
- * Teams are groups of Users within an Organization
- *
- *
- * columns and relationships of "teams"
- */
-export type TeamsTeamViews_AggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
 /** aggregated selection of "teams" */
 export type Teams_Aggregate = {
   __typename?: 'teams_aggregate';
@@ -25720,24 +16305,12 @@ export type Teams_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Teams_Avg_Fields = {
   __typename?: 'teams_avg_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "teams" */
 export type Teams_Avg_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "teams". All fields are combined with a logical 'AND'. */
@@ -25747,28 +16320,20 @@ export type Teams_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Teams_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   createdBy?: Maybe<Users_Bool_Exp>;
-  created_by?: Maybe<Int_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   dashboards?: Maybe<Team_Dashboards_Bool_Exp>;
-  deactivated?: Maybe<Int_Comparison_Exp>;
-  deactivatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   featuredMetricCollection?: Maybe<Metric_Collections_Bool_Exp>;
-  featuredMetricCollectionId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metricCollections?: Maybe<Metric_Collections_Bool_Exp>;
   metricTeamOwners?: Maybe<Metric_Team_Owners_Bool_Exp>;
   name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   primaryDashboard?: Maybe<Dashboards_Bool_Exp>;
-  primaryDashboardId?: Maybe<Int_Comparison_Exp>;
   questionsDirectedTo?: Maybe<Question_Directed_To_Bool_Exp>;
   savedQueries?: Maybe<Saved_Queries_Bool_Exp>;
   slug?: Maybe<String_Comparison_Exp>;
   teamMembers?: Maybe<Team_Members_Bool_Exp>;
   teamViews?: Maybe<Team_Views_Bool_Exp>;
   theme?: Maybe<String_Comparison_Exp>;
-  theme_color?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
 };
 
@@ -25782,57 +16347,32 @@ export enum Teams_Constraint {
 
 /** input type for incrementing integer column in table "teams" */
 export type Teams_Inc_Input = {
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
   featuredMetricCollectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "teams" */
 export type Teams_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   createdBy?: Maybe<Users_Obj_Rel_Insert_Input>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   dashboards?: Maybe<Team_Dashboards_Arr_Rel_Insert_Input>;
-  deactivated?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
   featuredMetricCollection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollections?: Maybe<Metric_Collections_Arr_Rel_Insert_Input>;
   metricTeamOwners?: Maybe<Metric_Team_Owners_Arr_Rel_Insert_Input>;
   name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   primaryDashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   questionsDirectedTo?: Maybe<Question_Directed_To_Arr_Rel_Insert_Input>;
   savedQueries?: Maybe<Saved_Queries_Arr_Rel_Insert_Input>;
   slug?: Maybe<Scalars['String']>;
   teamMembers?: Maybe<Team_Members_Arr_Rel_Insert_Input>;
   teamViews?: Maybe<Team_Views_Arr_Rel_Insert_Input>;
   theme?: Maybe<Scalars['String']>;
-  theme_color?: Maybe<Team_Page_Theme_Colors_Obj_Rel_Insert_Input>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Teams_Max_Fields = {
   __typename?: 'teams_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   theme?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -25841,15 +16381,8 @@ export type Teams_Max_Fields = {
 /** order by max() on columns of table "teams" */
 export type Teams_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   slug?: Maybe<Order_By>;
   theme?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -25859,15 +16392,8 @@ export type Teams_Max_Order_By = {
 export type Teams_Min_Fields = {
   __typename?: 'teams_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   theme?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -25876,15 +16402,8 @@ export type Teams_Min_Fields = {
 /** order by min() on columns of table "teams" */
 export type Teams_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   slug?: Maybe<Order_By>;
   theme?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -25916,28 +16435,19 @@ export type Teams_On_Conflict = {
 export type Teams_Order_By = {
   createdAt?: Maybe<Order_By>;
   createdBy?: Maybe<Users_Order_By>;
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   dashboards_aggregate?: Maybe<Team_Dashboards_Aggregate_Order_By>;
-  deactivated?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
   featuredMetricCollection?: Maybe<Metric_Collections_Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollections_aggregate?: Maybe<Metric_Collections_Aggregate_Order_By>;
   metricTeamOwners_aggregate?: Maybe<Metric_Team_Owners_Aggregate_Order_By>;
   name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   primaryDashboard?: Maybe<Dashboards_Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   questionsDirectedTo_aggregate?: Maybe<Question_Directed_To_Aggregate_Order_By>;
   savedQueries_aggregate?: Maybe<Saved_Queries_Aggregate_Order_By>;
   slug?: Maybe<Order_By>;
   teamMembers_aggregate?: Maybe<Team_Members_Aggregate_Order_By>;
-  teamViews_aggregate?: Maybe<Team_Views_Aggregate_Order_By>;
   theme?: Maybe<Order_By>;
-  theme_color?: Maybe<Team_Page_Theme_Colors_Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -25952,23 +16462,9 @@ export enum Teams_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedBy = 'created_by',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Deactivated = 'deactivated',
-  /** column name */
-  DeactivatedAt = 'deactivatedAt',
-  /** column name */
-  FeaturedMetricCollectionId = 'featuredMetricCollectionId',
-  /** column name */
   Id = 'id',
   /** column name */
   Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
   /** column name */
   Slug = 'slug',
   /** column name */
@@ -25979,210 +16475,102 @@ export enum Teams_Select_Column {
 
 /** input type for updating data in table "teams" */
 export type Teams_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   featuredMetricCollectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   theme?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Teams_Stddev_Fields = {
   __typename?: 'teams_stddev_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "teams" */
 export type Teams_Stddev_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Teams_Stddev_Pop_Fields = {
   __typename?: 'teams_stddev_pop_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "teams" */
 export type Teams_Stddev_Pop_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Teams_Stddev_Samp_Fields = {
   __typename?: 'teams_stddev_samp_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "teams" */
 export type Teams_Stddev_Samp_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Teams_Sum_Fields = {
   __typename?: 'teams_sum_fields';
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "teams" */
 export type Teams_Sum_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** update columns of table "teams" */
 export enum Teams_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedBy = 'created_by',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Deactivated = 'deactivated',
-  /** column name */
   DeactivatedAt = 'deactivatedAt',
   /** column name */
   FeaturedMetricCollectionId = 'featuredMetricCollectionId',
   /** column name */
-  Id = 'id',
-  /** column name */
   Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
   /** column name */
   Slug = 'slug',
   /** column name */
-  Theme = 'theme',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Theme = 'theme'
 }
 
 /** aggregate var_pop on columns */
 export type Teams_Var_Pop_Fields = {
   __typename?: 'teams_var_pop_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "teams" */
 export type Teams_Var_Pop_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Teams_Var_Samp_Fields = {
   __typename?: 'teams_var_samp_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "teams" */
 export type Teams_Var_Samp_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Teams_Variance_Fields = {
   __typename?: 'teams_variance_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "teams" */
 export type Teams_Variance_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 
@@ -26197,628 +16585,6 @@ export type Timestamptz_Comparison_Exp = {
   _lte?: Maybe<Scalars['timestamptz']>;
   _neq?: Maybe<Scalars['timestamptz']>;
   _nin?: Maybe<Array<Scalars['timestamptz']>>;
-};
-
-/**
- * Tracks which users have unsubscribed from which transactional emails.
- *
- *
- * columns and relationships of "unsubscribes"
- */
-export type Unsubscribes = {
-  __typename?: 'unsubscribes';
-  email_type: Scalars['String'];
-  id: Scalars['Int'];
-  /** An object relationship */
-  user: Users;
-  user_id: Scalars['Int'];
-};
-
-/** aggregated selection of "unsubscribes" */
-export type Unsubscribes_Aggregate = {
-  __typename?: 'unsubscribes_aggregate';
-  aggregate?: Maybe<Unsubscribes_Aggregate_Fields>;
-  nodes: Array<Unsubscribes>;
-};
-
-/** aggregate fields of "unsubscribes" */
-export type Unsubscribes_Aggregate_Fields = {
-  __typename?: 'unsubscribes_aggregate_fields';
-  avg?: Maybe<Unsubscribes_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Unsubscribes_Max_Fields>;
-  min?: Maybe<Unsubscribes_Min_Fields>;
-  stddev?: Maybe<Unsubscribes_Stddev_Fields>;
-  stddev_pop?: Maybe<Unsubscribes_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Unsubscribes_Stddev_Samp_Fields>;
-  sum?: Maybe<Unsubscribes_Sum_Fields>;
-  var_pop?: Maybe<Unsubscribes_Var_Pop_Fields>;
-  var_samp?: Maybe<Unsubscribes_Var_Samp_Fields>;
-  variance?: Maybe<Unsubscribes_Variance_Fields>;
-};
-
-
-/** aggregate fields of "unsubscribes" */
-export type Unsubscribes_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Unsubscribes_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "unsubscribes" */
-export type Unsubscribes_Aggregate_Order_By = {
-  avg?: Maybe<Unsubscribes_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Unsubscribes_Max_Order_By>;
-  min?: Maybe<Unsubscribes_Min_Order_By>;
-  stddev?: Maybe<Unsubscribes_Stddev_Order_By>;
-  stddev_pop?: Maybe<Unsubscribes_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Unsubscribes_Stddev_Samp_Order_By>;
-  sum?: Maybe<Unsubscribes_Sum_Order_By>;
-  var_pop?: Maybe<Unsubscribes_Var_Pop_Order_By>;
-  var_samp?: Maybe<Unsubscribes_Var_Samp_Order_By>;
-  variance?: Maybe<Unsubscribes_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "unsubscribes" */
-export type Unsubscribes_Arr_Rel_Insert_Input = {
-  data: Array<Unsubscribes_Insert_Input>;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Unsubscribes_Avg_Fields = {
-  __typename?: 'unsubscribes_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "unsubscribes" */
-export type Unsubscribes_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "unsubscribes". All fields are combined with a logical 'AND'. */
-export type Unsubscribes_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Unsubscribes_Bool_Exp>>>;
-  _not?: Maybe<Unsubscribes_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Unsubscribes_Bool_Exp>>>;
-  email_type?: Maybe<String_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
-  user?: Maybe<Users_Bool_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "unsubscribes" */
-export enum Unsubscribes_Constraint {
-  /** unique or primary key constraint */
-  UnsubscribesEmailTypeUserIdKey = 'unsubscribes_email_type_user_id_key',
-  /** unique or primary key constraint */
-  UnsubscribesPkey = 'unsubscribes_pkey'
-}
-
-/** input type for incrementing integer column in table "unsubscribes" */
-export type Unsubscribes_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "unsubscribes" */
-export type Unsubscribes_Insert_Input = {
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type Unsubscribes_Max_Fields = {
-  __typename?: 'unsubscribes_max_fields';
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "unsubscribes" */
-export type Unsubscribes_Max_Order_By = {
-  email_type?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Unsubscribes_Min_Fields = {
-  __typename?: 'unsubscribes_min_fields';
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "unsubscribes" */
-export type Unsubscribes_Min_Order_By = {
-  email_type?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "unsubscribes" */
-export type Unsubscribes_Mutation_Response = {
-  __typename?: 'unsubscribes_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Unsubscribes>;
-};
-
-/** input type for inserting object relation for remote table "unsubscribes" */
-export type Unsubscribes_Obj_Rel_Insert_Input = {
-  data: Unsubscribes_Insert_Input;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-/** on conflict condition type for table "unsubscribes" */
-export type Unsubscribes_On_Conflict = {
-  constraint: Unsubscribes_Constraint;
-  update_columns: Array<Unsubscribes_Update_Column>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "unsubscribes" */
-export type Unsubscribes_Order_By = {
-  email_type?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  user?: Maybe<Users_Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "unsubscribes" */
-export type Unsubscribes_Pk_Columns_Input = {
-  id: Scalars['Int'];
-};
-
-/** select columns of table "unsubscribes" */
-export enum Unsubscribes_Select_Column {
-  /** column name */
-  EmailType = 'email_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** input type for updating data in table "unsubscribes" */
-export type Unsubscribes_Set_Input = {
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Unsubscribes_Stddev_Fields = {
-  __typename?: 'unsubscribes_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "unsubscribes" */
-export type Unsubscribes_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Unsubscribes_Stddev_Pop_Fields = {
-  __typename?: 'unsubscribes_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "unsubscribes" */
-export type Unsubscribes_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Unsubscribes_Stddev_Samp_Fields = {
-  __typename?: 'unsubscribes_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "unsubscribes" */
-export type Unsubscribes_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Unsubscribes_Sum_Fields = {
-  __typename?: 'unsubscribes_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "unsubscribes" */
-export type Unsubscribes_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "unsubscribes" */
-export enum Unsubscribes_Update_Column {
-  /** column name */
-  EmailType = 'email_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** aggregate var_pop on columns */
-export type Unsubscribes_Var_Pop_Fields = {
-  __typename?: 'unsubscribes_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "unsubscribes" */
-export type Unsubscribes_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Unsubscribes_Var_Samp_Fields = {
-  __typename?: 'unsubscribes_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "unsubscribes" */
-export type Unsubscribes_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Unsubscribes_Variance_Fields = {
-  __typename?: 'unsubscribes_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "unsubscribes" */
-export type Unsubscribes_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** columns and relationships of "user_dashboards" */
-export type User_Dashboards = {
-  __typename?: 'user_dashboards';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId: Scalars['Int'];
-};
-
-/** aggregated selection of "user_dashboards" */
-export type User_Dashboards_Aggregate = {
-  __typename?: 'user_dashboards_aggregate';
-  aggregate?: Maybe<User_Dashboards_Aggregate_Fields>;
-  nodes: Array<User_Dashboards>;
-};
-
-/** aggregate fields of "user_dashboards" */
-export type User_Dashboards_Aggregate_Fields = {
-  __typename?: 'user_dashboards_aggregate_fields';
-  avg?: Maybe<User_Dashboards_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<User_Dashboards_Max_Fields>;
-  min?: Maybe<User_Dashboards_Min_Fields>;
-  stddev?: Maybe<User_Dashboards_Stddev_Fields>;
-  stddev_pop?: Maybe<User_Dashboards_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<User_Dashboards_Stddev_Samp_Fields>;
-  sum?: Maybe<User_Dashboards_Sum_Fields>;
-  var_pop?: Maybe<User_Dashboards_Var_Pop_Fields>;
-  var_samp?: Maybe<User_Dashboards_Var_Samp_Fields>;
-  variance?: Maybe<User_Dashboards_Variance_Fields>;
-};
-
-
-/** aggregate fields of "user_dashboards" */
-export type User_Dashboards_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<User_Dashboards_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "user_dashboards" */
-export type User_Dashboards_Aggregate_Order_By = {
-  avg?: Maybe<User_Dashboards_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<User_Dashboards_Max_Order_By>;
-  min?: Maybe<User_Dashboards_Min_Order_By>;
-  stddev?: Maybe<User_Dashboards_Stddev_Order_By>;
-  stddev_pop?: Maybe<User_Dashboards_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<User_Dashboards_Stddev_Samp_Order_By>;
-  sum?: Maybe<User_Dashboards_Sum_Order_By>;
-  var_pop?: Maybe<User_Dashboards_Var_Pop_Order_By>;
-  var_samp?: Maybe<User_Dashboards_Var_Samp_Order_By>;
-  variance?: Maybe<User_Dashboards_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "user_dashboards" */
-export type User_Dashboards_Arr_Rel_Insert_Input = {
-  data: Array<User_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type User_Dashboards_Avg_Fields = {
-  __typename?: 'user_dashboards_avg_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "user_dashboards" */
-export type User_Dashboards_Avg_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "user_dashboards". All fields are combined with a logical 'AND'. */
-export type User_Dashboards_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<User_Dashboards_Bool_Exp>>>;
-  _not?: Maybe<User_Dashboards_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<User_Dashboards_Bool_Exp>>>;
-  createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dashboardId?: Maybe<Int_Comparison_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-  updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "user_dashboards" */
-export enum User_Dashboards_Constraint {
-  /** unique or primary key constraint */
-  UserDashboardsPkey = 'user_dashboards_pkey'
-}
-
-/** input type for incrementing integer column in table "user_dashboards" */
-export type User_Dashboards_Inc_Input = {
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "user_dashboards" */
-export type User_Dashboards_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type User_Dashboards_Max_Fields = {
-  __typename?: 'user_dashboards_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "user_dashboards" */
-export type User_Dashboards_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type User_Dashboards_Min_Fields = {
-  __typename?: 'user_dashboards_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "user_dashboards" */
-export type User_Dashboards_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "user_dashboards" */
-export type User_Dashboards_Mutation_Response = {
-  __typename?: 'user_dashboards_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<User_Dashboards>;
-};
-
-/** input type for inserting object relation for remote table "user_dashboards" */
-export type User_Dashboards_Obj_Rel_Insert_Input = {
-  data: User_Dashboards_Insert_Input;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-/** on conflict condition type for table "user_dashboards" */
-export type User_Dashboards_On_Conflict = {
-  constraint: User_Dashboards_Constraint;
-  update_columns: Array<User_Dashboards_Update_Column>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "user_dashboards" */
-export type User_Dashboards_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "user_dashboards" */
-export type User_Dashboards_Pk_Columns_Input = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-/** select columns of table "user_dashboards" */
-export enum User_Dashboards_Select_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
-}
-
-/** input type for updating data in table "user_dashboards" */
-export type User_Dashboards_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type User_Dashboards_Stddev_Fields = {
-  __typename?: 'user_dashboards_stddev_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "user_dashboards" */
-export type User_Dashboards_Stddev_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type User_Dashboards_Stddev_Pop_Fields = {
-  __typename?: 'user_dashboards_stddev_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "user_dashboards" */
-export type User_Dashboards_Stddev_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type User_Dashboards_Stddev_Samp_Fields = {
-  __typename?: 'user_dashboards_stddev_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "user_dashboards" */
-export type User_Dashboards_Stddev_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type User_Dashboards_Sum_Fields = {
-  __typename?: 'user_dashboards_sum_fields';
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "user_dashboards" */
-export type User_Dashboards_Sum_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** update columns of table "user_dashboards" */
-export enum User_Dashboards_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
-}
-
-/** aggregate var_pop on columns */
-export type User_Dashboards_Var_Pop_Fields = {
-  __typename?: 'user_dashboards_var_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "user_dashboards" */
-export type User_Dashboards_Var_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type User_Dashboards_Var_Samp_Fields = {
-  __typename?: 'user_dashboards_var_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "user_dashboards" */
-export type User_Dashboards_Var_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type User_Dashboards_Variance_Fields = {
-  __typename?: 'user_dashboards_variance_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "user_dashboards" */
-export type User_Dashboards_Variance_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "user_features" */
@@ -26877,12 +16643,6 @@ export type User_Features_Aggregate_Order_By = {
   variance?: Maybe<User_Features_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "user_features" */
-export type User_Features_Arr_Rel_Insert_Input = {
-  data: Array<User_Features_Insert_Input>;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type User_Features_Avg_Fields = {
   __typename?: 'user_features_avg_fields';
@@ -26905,26 +16665,6 @@ export type User_Features_Bool_Exp = {
   featureId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
   userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "user_features" */
-export enum User_Features_Constraint {
-  /** unique or primary key constraint */
-  UserFeaturesPkey = 'user_features_pkey'
-}
-
-/** input type for incrementing integer column in table "user_features" */
-export type User_Features_Inc_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "user_features" */
-export type User_Features_Insert_Input = {
-  feature?: Maybe<Features_Obj_Rel_Insert_Input>;
-  featureId?: Maybe<Scalars['Int']>;
-  user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -26953,28 +16693,6 @@ export type User_Features_Min_Order_By = {
   userId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "user_features" */
-export type User_Features_Mutation_Response = {
-  __typename?: 'user_features_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<User_Features>;
-};
-
-/** input type for inserting object relation for remote table "user_features" */
-export type User_Features_Obj_Rel_Insert_Input = {
-  data: User_Features_Insert_Input;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
-/** on conflict condition type for table "user_features" */
-export type User_Features_On_Conflict = {
-  constraint: User_Features_Constraint;
-  update_columns: Array<User_Features_Update_Column>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "user_features" */
 export type User_Features_Order_By = {
   feature?: Maybe<Features_Order_By>;
@@ -26996,12 +16714,6 @@ export enum User_Features_Select_Column {
   /** column name */
   UserId = 'userId'
 }
-
-/** input type for updating data in table "user_features" */
-export type User_Features_Set_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type User_Features_Stddev_Fields = {
@@ -27055,14 +16767,6 @@ export type User_Features_Sum_Order_By = {
   userId?: Maybe<Order_By>;
 };
 
-/** update columns of table "user_features" */
-export enum User_Features_Update_Column {
-  /** column name */
-  FeatureId = 'featureId',
-  /** column name */
-  UserId = 'userId'
-}
-
 /** aggregate var_pop on columns */
 export type User_Features_Var_Pop_Fields = {
   __typename?: 'user_features_var_pop_fields';
@@ -27112,7 +16816,6 @@ export type User_Prefs = {
   __typename?: 'user_prefs';
   /** Timestamp indicating when the User Preference was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
@@ -27182,7 +16885,6 @@ export type User_Prefs_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type User_Prefs_Avg_Fields = {
   __typename?: 'user_prefs_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27190,7 +16892,6 @@ export type User_Prefs_Avg_Fields = {
 
 /** order by avg() on columns of table "user_prefs" */
 export type User_Prefs_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27202,7 +16903,6 @@ export type User_Prefs_Bool_Exp = {
   _not?: Maybe<User_Prefs_Bool_Exp>;
   _or?: Maybe<Array<Maybe<User_Prefs_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
@@ -27221,33 +16921,17 @@ export enum User_Prefs_Constraint {
   UserPrefsUserIdPrefKeyKey = 'user_prefs_user_id_pref_key_key'
 }
 
-/** input type for incrementing integer column in table "user_prefs" */
-export type User_Prefs_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "user_prefs" */
 export type User_Prefs_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
   prefValue?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type User_Prefs_Max_Fields = {
   __typename?: 'user_prefs_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
@@ -27259,7 +16943,6 @@ export type User_Prefs_Max_Fields = {
 /** order by max() on columns of table "user_prefs" */
 export type User_Prefs_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   prefKey?: Maybe<Order_By>;
@@ -27272,7 +16955,6 @@ export type User_Prefs_Max_Order_By = {
 export type User_Prefs_Min_Fields = {
   __typename?: 'user_prefs_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
@@ -27284,7 +16966,6 @@ export type User_Prefs_Min_Fields = {
 /** order by min() on columns of table "user_prefs" */
 export type User_Prefs_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   prefKey?: Maybe<Order_By>;
@@ -27318,7 +16999,6 @@ export type User_Prefs_On_Conflict = {
 /** ordering options when selecting data from "user_prefs" */
 export type User_Prefs_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -27339,8 +17019,6 @@ export enum User_Prefs_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateCreate = 'date_create',
-  /** column name */
   Id = 'id',
   /** column name */
   OrganizationId = 'organizationId',
@@ -27356,20 +17034,13 @@ export enum User_Prefs_Select_Column {
 
 /** input type for updating data in table "user_prefs" */
 export type User_Prefs_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
   prefValue?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type User_Prefs_Stddev_Fields = {
   __typename?: 'user_prefs_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27377,7 +17048,6 @@ export type User_Prefs_Stddev_Fields = {
 
 /** order by stddev() on columns of table "user_prefs" */
 export type User_Prefs_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27386,7 +17056,6 @@ export type User_Prefs_Stddev_Order_By = {
 /** aggregate stddev_pop on columns */
 export type User_Prefs_Stddev_Pop_Fields = {
   __typename?: 'user_prefs_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27394,7 +17063,6 @@ export type User_Prefs_Stddev_Pop_Fields = {
 
 /** order by stddev_pop() on columns of table "user_prefs" */
 export type User_Prefs_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27403,7 +17071,6 @@ export type User_Prefs_Stddev_Pop_Order_By = {
 /** aggregate stddev_samp on columns */
 export type User_Prefs_Stddev_Samp_Fields = {
   __typename?: 'user_prefs_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27411,7 +17078,6 @@ export type User_Prefs_Stddev_Samp_Fields = {
 
 /** order by stddev_samp() on columns of table "user_prefs" */
 export type User_Prefs_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27420,7 +17086,6 @@ export type User_Prefs_Stddev_Samp_Order_By = {
 /** aggregate sum on columns */
 export type User_Prefs_Sum_Fields = {
   __typename?: 'user_prefs_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
@@ -27428,7 +17093,6 @@ export type User_Prefs_Sum_Fields = {
 
 /** order by sum() on columns of table "user_prefs" */
 export type User_Prefs_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27437,27 +17101,14 @@ export type User_Prefs_Sum_Order_By = {
 /** update columns of table "user_prefs" */
 export enum User_Prefs_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   PrefKey = 'prefKey',
   /** column name */
-  PrefValue = 'prefValue',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  PrefValue = 'prefValue'
 }
 
 /** aggregate var_pop on columns */
 export type User_Prefs_Var_Pop_Fields = {
   __typename?: 'user_prefs_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27465,7 +17116,6 @@ export type User_Prefs_Var_Pop_Fields = {
 
 /** order by var_pop() on columns of table "user_prefs" */
 export type User_Prefs_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27474,7 +17124,6 @@ export type User_Prefs_Var_Pop_Order_By = {
 /** aggregate var_samp on columns */
 export type User_Prefs_Var_Samp_Fields = {
   __typename?: 'user_prefs_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27482,7 +17131,6 @@ export type User_Prefs_Var_Samp_Fields = {
 
 /** order by var_samp() on columns of table "user_prefs" */
 export type User_Prefs_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27491,7 +17139,6 @@ export type User_Prefs_Var_Samp_Order_By = {
 /** aggregate variance on columns */
 export type User_Prefs_Variance_Fields = {
   __typename?: 'user_prefs_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27499,73 +17146,10 @@ export type User_Prefs_Variance_Fields = {
 
 /** order by variance() on columns of table "user_prefs" */
 export type User_Prefs_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
-
-/**
- * Enum for our User Roles
- *
- *
- * columns and relationships of "user_role_types"
- */
-export type User_Role_Types = {
-  __typename?: 'user_role_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "user_role_types" */
-export type User_Role_Types_Aggregate = {
-  __typename?: 'user_role_types_aggregate';
-  aggregate?: Maybe<User_Role_Types_Aggregate_Fields>;
-  nodes: Array<User_Role_Types>;
-};
-
-/** aggregate fields of "user_role_types" */
-export type User_Role_Types_Aggregate_Fields = {
-  __typename?: 'user_role_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<User_Role_Types_Max_Fields>;
-  min?: Maybe<User_Role_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "user_role_types" */
-export type User_Role_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<User_Role_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "user_role_types" */
-export type User_Role_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<User_Role_Types_Max_Order_By>;
-  min?: Maybe<User_Role_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "user_role_types" */
-export type User_Role_Types_Arr_Rel_Insert_Input = {
-  data: Array<User_Role_Types_Insert_Input>;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "user_role_types". All fields are combined with a logical 'AND'. */
-export type User_Role_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<User_Role_Types_Bool_Exp>>>;
-  _not?: Maybe<User_Role_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<User_Role_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "user_role_types" */
-export enum User_Role_Types_Constraint {
-  /** unique or primary key constraint */
-  UserRoleTypesPkey = 'user_role_types_pkey'
-}
 
 export enum User_Role_Types_Enum {
   /** 	Full administrator access. */
@@ -27587,104 +17171,14 @@ export type User_Role_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<User_Role_Types_Enum>>;
 };
 
-/** input type for inserting data into table "user_role_types" */
-export type User_Role_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type User_Role_Types_Max_Fields = {
-  __typename?: 'user_role_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "user_role_types" */
-export type User_Role_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type User_Role_Types_Min_Fields = {
-  __typename?: 'user_role_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "user_role_types" */
-export type User_Role_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "user_role_types" */
-export type User_Role_Types_Mutation_Response = {
-  __typename?: 'user_role_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<User_Role_Types>;
-};
-
-/** input type for inserting object relation for remote table "user_role_types" */
-export type User_Role_Types_Obj_Rel_Insert_Input = {
-  data: User_Role_Types_Insert_Input;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "user_role_types" */
-export type User_Role_Types_On_Conflict = {
-  constraint: User_Role_Types_Constraint;
-  update_columns: Array<User_Role_Types_Update_Column>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "user_role_types" */
-export type User_Role_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "user_role_types" */
-export type User_Role_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "user_role_types" */
-export enum User_Role_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "user_role_types" */
-export type User_Role_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "user_role_types" */
-export enum User_Role_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
 /** columns and relationships of "user_roles" */
 export type User_Roles = {
   __typename?: 'user_roles';
   /** Timestamp indicating when a user role was added */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** Soft delete mechanism for a User Role. Rows with non-null values are omitted from list results. */
   removedAt?: Maybe<Scalars['timestamptz']>;
   role: User_Role_Types_Enum;
@@ -27749,19 +17243,13 @@ export type User_Roles_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type User_Roles_Avg_Fields = {
   __typename?: 'user_roles_avg_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "user_roles" */
 export type User_Roles_Avg_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
@@ -27771,11 +17259,8 @@ export type User_Roles_Bool_Exp = {
   _not?: Maybe<User_Roles_Bool_Exp>;
   _or?: Maybe<Array<Maybe<User_Roles_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  date_added?: Maybe<Int_Comparison_Exp>;
-  date_removed?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   removedAt?: Maybe<Timestamptz_Comparison_Exp>;
   role?: Maybe<User_Role_Types_Enum_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -27791,26 +17276,10 @@ export enum User_Roles_Constraint {
   UserRolesUserIdRoleKey = 'user_roles_user_id_role_key'
 }
 
-/** input type for incrementing integer column in table "user_roles" */
-export type User_Roles_Inc_Input = {
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "user_roles" */
 export type User_Roles_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
   role?: Maybe<User_Role_Types_Enum>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
   userId?: Maybe<Scalars['Int']>;
 };
@@ -27819,10 +17288,7 @@ export type User_Roles_Insert_Input = {
 export type User_Roles_Max_Fields = {
   __typename?: 'user_roles_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userId?: Maybe<Scalars['Int']>;
@@ -27831,10 +17297,7 @@ export type User_Roles_Max_Fields = {
 /** order by max() on columns of table "user_roles" */
 export type User_Roles_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   removedAt?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27844,10 +17307,7 @@ export type User_Roles_Max_Order_By = {
 export type User_Roles_Min_Fields = {
   __typename?: 'user_roles_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userId?: Maybe<Scalars['Int']>;
@@ -27856,10 +17316,7 @@ export type User_Roles_Min_Fields = {
 /** order by min() on columns of table "user_roles" */
 export type User_Roles_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   removedAt?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27890,11 +17347,8 @@ export type User_Roles_On_Conflict = {
 /** ordering options when selecting data from "user_roles" */
 export type User_Roles_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   removedAt?: Maybe<Order_By>;
   role?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -27912,13 +17366,7 @@ export enum User_Roles_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateAdded = 'date_added',
-  /** column name */
-  DateRemoved = 'date_removed',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   RemovedAt = 'removedAt',
   /** column name */
@@ -27931,169 +17379,103 @@ export enum User_Roles_Select_Column {
 
 /** input type for updating data in table "user_roles" */
 export type User_Roles_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
-  role?: Maybe<User_Role_Types_Enum>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type User_Roles_Stddev_Fields = {
   __typename?: 'user_roles_stddev_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "user_roles" */
 export type User_Roles_Stddev_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type User_Roles_Stddev_Pop_Fields = {
   __typename?: 'user_roles_stddev_pop_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "user_roles" */
 export type User_Roles_Stddev_Pop_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type User_Roles_Stddev_Samp_Fields = {
   __typename?: 'user_roles_stddev_samp_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "user_roles" */
 export type User_Roles_Stddev_Samp_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type User_Roles_Sum_Fields = {
   __typename?: 'user_roles_sum_fields';
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "user_roles" */
 export type User_Roles_Sum_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** update columns of table "user_roles" */
 export enum User_Roles_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateAdded = 'date_added',
-  /** column name */
-  DateRemoved = 'date_removed',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  RemovedAt = 'removedAt',
-  /** column name */
-  Role = 'role',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  RemovedAt = 'removedAt'
 }
 
 /** aggregate var_pop on columns */
 export type User_Roles_Var_Pop_Fields = {
   __typename?: 'user_roles_var_pop_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "user_roles" */
 export type User_Roles_Var_Pop_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type User_Roles_Var_Samp_Fields = {
   __typename?: 'user_roles_var_samp_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "user_roles" */
 export type User_Roles_Var_Samp_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type User_Roles_Variance_Fields = {
   __typename?: 'user_roles_variance_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "user_roles" */
 export type User_Roles_Variance_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
@@ -28117,18 +17499,11 @@ export type Users = {
   apiKeysByRevokerId_aggregate: Api_Keys_Aggregate;
   /** An aggregated array relationship */
   apiKeys_aggregate: Api_Keys_Aggregate;
-  auth0Id?: Maybe<Scalars['String']>;
   /** Remote relationship field */
   auth0Profile?: Maybe<Auth0Profile>;
   avatarUrl?: Maybe<Scalars['String']>;
   /** Timestamp indicating when the user was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  /** An array relationship */
-  dashboards: Array<User_Dashboards>;
-  /** An aggregated array relationship */
-  dashboards_aggregate: User_Dashboards_Aggregate;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   /** Soft delete mechanism for a User. Rows with non-null values are omitted from list results. */
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   /** The `User`'s email address */
@@ -28158,10 +17533,8 @@ export type Users = {
   modelsUploaded_aggregate: Models_Aggregate;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   primaryDashboard?: Maybe<Dashboards>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   /** An array relationship */
   question_likes: Array<Question_Likes>;
   /** An aggregated array relationship */
@@ -28296,36 +17669,6 @@ export type UsersApiKeys_AggregateArgs = {
   offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Api_Keys_Order_By>>;
   where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/**
- * Users are Transform end users. They belong to Organizations and Teams within Organizations.
- *
- *
- * columns and relationships of "users"
- */
-export type UsersDashboardsArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/**
- * Users are Transform end users. They belong to Organizations and Teams within Organizations.
- *
- *
- * columns and relationships of "users"
- */
-export type UsersDashboards_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
 };
 
 
@@ -28832,20 +18175,12 @@ export type Users_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Users_Avg_Fields = {
   __typename?: 'users_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "users" */
 export type Users_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "users". All fields are combined with a logical 'AND'. */
@@ -28856,12 +18191,8 @@ export type Users_Bool_Exp = {
   annotations?: Maybe<Annotations_Bool_Exp>;
   apiKeys?: Maybe<Api_Keys_Bool_Exp>;
   apiKeysByRevokerId?: Maybe<Api_Keys_Bool_Exp>;
-  auth0Id?: Maybe<String_Comparison_Exp>;
   avatarUrl?: Maybe<String_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dashboards?: Maybe<User_Dashboards_Bool_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
-  date_deactivate?: Maybe<Int_Comparison_Exp>;
   deactivatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   email?: Maybe<String_Comparison_Exp>;
   features?: Maybe<User_Features_Bool_Exp>;
@@ -28871,9 +18202,7 @@ export type Users_Bool_Exp = {
   metric_views?: Maybe<Metric_View_Bool_Exp>;
   modelsUploaded?: Maybe<Models_Bool_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   primaryDashboard?: Maybe<Dashboards_Bool_Exp>;
-  primaryDashboardId?: Maybe<Int_Comparison_Exp>;
   question_likes?: Maybe<Question_Likes_Bool_Exp>;
   question_replies?: Maybe<Question_Replies_Bool_Exp>;
   questions?: Maybe<Questions_Bool_Exp>;
@@ -28898,36 +18227,13 @@ export enum Users_Constraint {
   UsersPkey = 'users_pkey'
 }
 
-/** input type for incrementing integer column in table "users" */
-export type Users_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "users" */
 export type Users_Insert_Input = {
   annotations?: Maybe<Annotations_Arr_Rel_Insert_Input>;
-  apiKeys?: Maybe<Api_Keys_Arr_Rel_Insert_Input>;
-  apiKeysByRevokerId?: Maybe<Api_Keys_Arr_Rel_Insert_Input>;
-  auth0Id?: Maybe<Scalars['String']>;
-  avatarUrl?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboards?: Maybe<User_Dashboards_Arr_Rel_Insert_Input>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
-  features?: Maybe<User_Features_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars['Int']>;
   metricCollections?: Maybe<Metric_Collections_Arr_Rel_Insert_Input>;
   metric_approvals?: Maybe<Metric_Approvals_Arr_Rel_Insert_Input>;
   metric_views?: Maybe<Metric_View_Arr_Rel_Insert_Input>;
-  modelsUploaded?: Maybe<Models_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   primaryDashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
   primaryDashboardId?: Maybe<Scalars['Int']>;
   question_likes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
@@ -28938,7 +18244,6 @@ export type Users_Insert_Input = {
   savedQueries?: Maybe<Saved_Queries_Arr_Rel_Insert_Input>;
   team_members?: Maybe<Team_Members_Arr_Rel_Insert_Input>;
   teamsCreated?: Maybe<Teams_Arr_Rel_Insert_Input>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
   userRoles?: Maybe<User_Roles_Arr_Rel_Insert_Input>;
   user_prefs?: Maybe<User_Prefs_Arr_Rel_Insert_Input>;
@@ -28947,32 +18252,22 @@ export type Users_Insert_Input = {
 /** aggregate max on columns */
 export type Users_Max_Fields = {
   __typename?: 'users_max_fields';
-  auth0Id?: Maybe<Scalars['String']>;
   avatarUrl?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "users" */
 export type Users_Max_Order_By = {
-  auth0Id?: Maybe<Order_By>;
   avatarUrl?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userName?: Maybe<Order_By>;
 };
@@ -28980,32 +18275,22 @@ export type Users_Max_Order_By = {
 /** aggregate min on columns */
 export type Users_Min_Fields = {
   __typename?: 'users_min_fields';
-  auth0Id?: Maybe<Scalars['String']>;
   avatarUrl?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "users" */
 export type Users_Min_Order_By = {
-  auth0Id?: Maybe<Order_By>;
   avatarUrl?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userName?: Maybe<Order_By>;
 };
@@ -29037,12 +18322,8 @@ export type Users_Order_By = {
   annotations_aggregate?: Maybe<Annotations_Aggregate_Order_By>;
   apiKeysByRevokerId_aggregate?: Maybe<Api_Keys_Aggregate_Order_By>;
   apiKeys_aggregate?: Maybe<Api_Keys_Aggregate_Order_By>;
-  auth0Id?: Maybe<Order_By>;
   avatarUrl?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  dashboards_aggregate?: Maybe<User_Dashboards_Aggregate_Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   features_aggregate?: Maybe<User_Features_Aggregate_Order_By>;
@@ -29052,9 +18333,7 @@ export type Users_Order_By = {
   metric_views_aggregate?: Maybe<Metric_View_Aggregate_Order_By>;
   modelsUploaded_aggregate?: Maybe<Models_Aggregate_Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   primaryDashboard?: Maybe<Dashboards_Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   question_likes_aggregate?: Maybe<Question_Likes_Aggregate_Order_By>;
   question_replies_aggregate?: Maybe<Question_Replies_Aggregate_Order_By>;
   questionsByResolvedBy_aggregate?: Maybe<Questions_Aggregate_Order_By>;
@@ -29077,25 +18356,15 @@ export type Users_Pk_Columns_Input = {
 /** select columns of table "users" */
 export enum Users_Select_Column {
   /** column name */
-  Auth0Id = 'auth0Id',
-  /** column name */
   AvatarUrl = 'avatarUrl',
   /** column name */
   CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDeactivate = 'date_deactivate',
   /** column name */
   DeactivatedAt = 'deactivatedAt',
   /** column name */
   Email = 'email',
   /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
   /** column name */
   UpdatedAt = 'updatedAt',
   /** column name */
@@ -29104,120 +18373,61 @@ export enum Users_Select_Column {
 
 /** input type for updating data in table "users" */
 export type Users_Set_Input = {
-  auth0Id?: Maybe<Scalars['String']>;
-  avatarUrl?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Users_Stddev_Fields = {
   __typename?: 'users_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "users" */
 export type Users_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Users_Stddev_Pop_Fields = {
   __typename?: 'users_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "users" */
 export type Users_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Users_Stddev_Samp_Fields = {
   __typename?: 'users_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "users" */
 export type Users_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Users_Sum_Fields = {
   __typename?: 'users_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "users" */
 export type Users_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** update columns of table "users" */
 export enum Users_Update_Column {
   /** column name */
-  Auth0Id = 'auth0Id',
-  /** column name */
-  AvatarUrl = 'avatarUrl',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDeactivate = 'date_deactivate',
-  /** column name */
   DeactivatedAt = 'deactivatedAt',
   /** column name */
   Email = 'email',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
   /** column name */
   UserName = 'userName'
 }
@@ -29225,58 +18435,34 @@ export enum Users_Update_Column {
 /** aggregate var_pop on columns */
 export type Users_Var_Pop_Fields = {
   __typename?: 'users_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "users" */
 export type Users_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Users_Var_Samp_Fields = {
   __typename?: 'users_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "users" */
 export type Users_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Users_Variance_Fields = {
   __typename?: 'users_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "users" */
 export type Users_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 
@@ -29286,7 +18472,7 @@ export type SetMqlServerMutationVariables = Exact<{
 
 
 export type SetMqlServerMutation = (
-  { __typename?: 'mutation_root' }
+  { __typename?: 'Mutation' }
   & { createUserPreference?: Maybe<(
     { __typename?: 'user_prefs' }
     & Pick<User_Prefs, 'id' | 'prefKey' | 'prefValue' | 'userId' | 'createdAt'>

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -9,11 +9,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /**
-   * The `DateTime` scalar type represents a DateTime
-   * value as specified by
-   * [iso8601](https://en.wikipedia.org/wiki/ISO_8601).
-   */
+  /** Wrapper around Graphene DateTime that is capable of handling string dates */
   DateTime: any;
 };
 
@@ -338,6 +334,8 @@ export type CreateMqlMaterializationInput = {
   metrics?: Maybe<Array<Scalars['String']>>;
   groupBy?: Maybe<Array<Scalars['String']>>;
   where?: Maybe<ConstraintInput>;
+  /** String-based constraint input field using SQL syntax */
+  constraint?: Maybe<Scalars['String']>;
   cacheMode?: Maybe<CacheMode>;
   clientMutationId?: Maybe<Scalars['String']>;
 };
@@ -395,7 +393,10 @@ export type CreateMqlQueryInput = {
   modelKey?: Maybe<ModelKeyInput>;
   metrics?: Maybe<Array<Scalars['String']>>;
   groupBy?: Maybe<Array<Scalars['String']>>;
+  /** Dict-based constraint input field */
   where?: Maybe<ConstraintInput>;
+  /** String-based constraint input field using SQL syntax */
+  constraint?: Maybe<Scalars['String']>;
   order?: Maybe<Array<Scalars['String']>>;
   limit?: Maybe<Scalars['Int']>;
   /** Set to True if you want to automatically add a default Time Series dimension to the query. This is useful for plotting the metric in time series without needing to know the time dimension up front. */

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -17,12 +17,3834 @@ export type Scalars = {
   DateTime: any;
   bigint: any;
   date: any;
-  entity: any;
   json: any;
   jsonb: any;
-  questionorreply: any;
   timestamptz: any;
   uuid: any;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  /** fetch data from the table: "annotations" using primary key columns */
+  annotation?: Maybe<Annotations>;
+  /** fetch data from the table: "annotations" */
+  annotations: Array<Annotations>;
+  /** fetch aggregated fields from the table: "annotations" */
+  annotationsAggregate: Annotations_Aggregate;
+  /** fetch data from the table: "api_keys" using primary key columns */
+  apiKey?: Maybe<Api_Keys>;
+  /** fetch data from the table: "api_keys" */
+  apiKeys: Array<Api_Keys>;
+  /** fetch aggregated fields from the table: "api_keys" */
+  apiKeysAggregate: Api_Keys_Aggregate;
+  auth0Profile?: Maybe<Auth0Profile>;
+  /** fetch data from the table: "dashboards" using primary key columns */
+  dashboard?: Maybe<Dashboards>;
+  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
+  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
+  /** fetch data from the table: "dashboard_item_configs" */
+  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
+  /** fetch aggregated fields from the table: "dashboard_item_configs" */
+  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
+  /** fetch data from the table: "dashboard_sections" using primary key columns */
+  dashboardSection?: Maybe<Dashboard_Sections>;
+  /** fetch data from the table: "dashboard_sections" */
+  dashboardSections: Array<Dashboard_Sections>;
+  /** fetch aggregated fields from the table: "dashboard_sections" */
+  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
+  /** fetch data from the table: "dashboards" */
+  dashboards: Array<Dashboards>;
+  /** fetch aggregated fields from the table: "dashboards" */
+  dashboardsAggregate: Dashboards_Aggregate;
+  /** fetch data from the table: "org_data_sources" using primary key columns */
+  dataSource?: Maybe<Org_Data_Sources>;
+  /** fetch data from the table: "data_source_versions" using primary key columns */
+  dataSourceVersion?: Maybe<Data_Source_Versions>;
+  /** fetch data from the table: "data_source_versions" */
+  dataSourceVersions: Array<Data_Source_Versions>;
+  /** fetch aggregated fields from the table: "data_source_versions" */
+  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
+  /** fetch data from the table: "org_data_sources" */
+  dataSources: Array<Org_Data_Sources>;
+  /** fetch aggregated fields from the table: "org_data_sources" */
+  dataSourcesAggregate: Org_Data_Sources_Aggregate;
+  /** fetch data from the table: "features" using primary key columns */
+  feature?: Maybe<Features>;
+  /** fetch data from the table: "features" */
+  features: Array<Features>;
+  /** fetch aggregated fields from the table: "features" */
+  featuresAggregate: Features_Aggregate;
+  latestMqlServer?: Maybe<MqlServerVersion>;
+  /** execute function "me" which returns "users" */
+  me: Array<Users>;
+  /** execute function "me" and query aggregates on result of table type "users" */
+  me_aggregate: Users_Aggregate;
+  /** fetch data from the table: "metric_annotations" using primary key columns */
+  metricAnnotation?: Maybe<Metric_Annotations>;
+  /** fetch data from the table: "metric_annotations" */
+  metricAnnotations: Array<Metric_Annotations>;
+  /** fetch aggregated fields from the table: "metric_annotations" */
+  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
+  /** fetch data from the table: "metric_approvals" using primary key columns */
+  metricApproval?: Maybe<Metric_Approvals>;
+  /** fetch data from the table: "metric_approvals" */
+  metricApprovals: Array<Metric_Approvals>;
+  /** fetch aggregated fields from the table: "metric_approvals" */
+  metricApprovalsAggregate: Metric_Approvals_Aggregate;
+  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
+  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
+  /** fetch data from the table: "metric_collections" using primary key columns */
+  metricCollection?: Maybe<Metric_Collections>;
+  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
+  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** fetch data from the table: "metric_collection_metrics" */
+  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
+  /** fetch aggregated fields from the table: "metric_collection_metrics" */
+  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
+  /** fetch data from the table: "metric_collection_view" using primary key columns */
+  metricCollectionView?: Maybe<Metric_Collection_View>;
+  /** fetch aggregated fields from the table: "metric_collection_view" */
+  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
+  /** fetch data from the table: "metric_collection_view" */
+  metricCollectionViews: Array<Metric_Collection_View>;
+  /** fetch data from the table: "metric_collections" */
+  metricCollections: Array<Metric_Collections>;
+  /** fetch aggregated fields from the table: "metric_collections" */
+  metricCollectionsAggregate: Metric_Collections_Aggregate;
+  /** fetch data from the table: "metric_current_description" */
+  metricCurrentDescriptions: Array<Metric_Current_Description>;
+  /** fetch data from the table: "metric_descriptions" using primary key columns */
+  metricDescription?: Maybe<Metric_Descriptions>;
+  /** fetch data from the table: "metric_descriptions" */
+  metricDescriptions: Array<Metric_Descriptions>;
+  /** fetch aggregated fields from the table: "metric_descriptions" */
+  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
+  /** fetch data from the table: "metric_team_owners" using primary key columns */
+  metricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** fetch data from the table: "metric_team_owners" */
+  metricTeamOwners: Array<Metric_Team_Owners>;
+  /** fetch aggregated fields from the table: "metric_team_owners" */
+  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
+  /** fetch data from the table: "metric_user_owners" using primary key columns */
+  metricUserOwner?: Maybe<Metric_User_Owners>;
+  /** fetch data from the table: "metric_user_owners" */
+  metricUserOwners: Array<Metric_User_Owners>;
+  /** fetch aggregated fields from the table: "metric_user_owners" */
+  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
+  /** fetch data from the table: "metric_versions" using primary key columns */
+  metricVersion?: Maybe<Metric_Versions>;
+  /** fetch data from the table: "metric_versions" */
+  metricVersions: Array<Metric_Versions>;
+  /** fetch aggregated fields from the table: "metric_versions" */
+  metricVersionsAggregate: Metric_Versions_Aggregate;
+  /** fetch data from the table: "metric_view" */
+  metricViews: Array<Metric_View>;
+  /** fetch aggregated fields from the table: "metric_view" */
+  metricViewsAggregate: Metric_View_Aggregate;
+  /** fetch aggregated fields from the table: "metric_current_description" */
+  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
+  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
+  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
+  /** fetch data from the table: "org_metrics_current_view" */
+  metrics: Array<Org_Metrics_Current_View>;
+  /** fetch aggregated fields from the table: "org_metrics_current_view" */
+  metricsAggregate: Org_Metrics_Current_View_Aggregate;
+  /** fetch data from the table: "models" using primary key columns */
+  model?: Maybe<Models>;
+  /** fetch data from the table: "model_data_sources" using primary key columns */
+  modelDataSource?: Maybe<Model_Data_Sources>;
+  /** fetch data from the table: "model_data_sources" */
+  modelDataSources: Array<Model_Data_Sources>;
+  /** fetch aggregated fields from the table: "model_data_sources" */
+  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
+  /** fetch data from the table: "model_metrics" using primary key columns */
+  modelMetric?: Maybe<Model_Metrics>;
+  /** fetch data from the table: "model_metrics" */
+  modelMetrics: Array<Model_Metrics>;
+  /** fetch aggregated fields from the table: "model_metrics" */
+  modelMetricsAggregate: Model_Metrics_Aggregate;
+  /** fetch data from the table: "model_current" */
+  model_current: Array<Model_Current>;
+  /** fetch data from the table: "models" */
+  models: Array<Models>;
+  /** fetch aggregated fields from the table: "models" */
+  modelsAggregate: Models_Aggregate;
+  /** fetch data from the table: "mql_heartbeats" using primary key columns */
+  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
+  /** fetch data from the table: "mql_heartbeats" */
+  mqlHeartbeats: Array<Mql_Heartbeats>;
+  mqlServerUrl?: Maybe<Scalars['String']>;
+  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
+  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
+  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
+  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
+  /** execute function "my_org" which returns "organizations" */
+  my_org: Array<Organizations>;
+  /** fetch data from the table: "org_mql_servers" using primary key columns */
+  orgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** fetch data from the table: "org_mql_servers" */
+  orgMqlServers: Array<Org_Mql_Servers>;
+  /** fetch aggregated fields from the table: "org_mql_servers" */
+  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
+  /** fetch data from the table: "organizations" using primary key columns */
+  organization?: Maybe<Organizations>;
+  /** fetch data from the table: "organization_features" using primary key columns */
+  organizationFeature?: Maybe<Organization_Features>;
+  /** fetch data from the table: "organization_features" */
+  organizationFeatures: Array<Organization_Features>;
+  /** fetch aggregated fields from the table: "organization_features" */
+  organizationFeaturesAggregate: Organization_Features_Aggregate;
+  /** fetch data from the table: "organizations" */
+  organizations: Array<Organizations>;
+  /** fetch data from the table: "priorities" */
+  priorities: Array<Priorities>;
+  /** fetch data from the table: "priorities" using primary key columns */
+  priorities_by_pk?: Maybe<Priorities>;
+  /** fetch data from the table: "questions" using primary key columns */
+  question?: Maybe<Questions>;
+  /** fetch data from the table: "question_directed_to" */
+  questionDirectedTo: Array<Question_Directed_To>;
+  /** fetch aggregated fields from the table: "question_directed_to" */
+  questionDirectedToAggregate: Question_Directed_To_Aggregate;
+  /** fetch data from the table: "question_directed_to" using primary key columns */
+  questionDirectedToByPK?: Maybe<Question_Directed_To>;
+  /** fetch data from the table: "question_likes" using primary key columns */
+  questionLike?: Maybe<Question_Likes>;
+  /** fetch data from the table: "question_likes" */
+  questionLikes: Array<Question_Likes>;
+  /** fetch aggregated fields from the table: "question_likes" */
+  questionLikesAggregate: Question_Likes_Aggregate;
+  /** fetch data from the table: "question_replies" */
+  questionReplies: Array<Question_Replies>;
+  /** fetch aggregated fields from the table: "question_replies" */
+  questionRepliesAggregate: Question_Replies_Aggregate;
+  /** fetch data from the table: "question_replies" using primary key columns */
+  questionReply?: Maybe<Question_Replies>;
+  /** fetch data from the table: "questions" */
+  questions: Array<Questions>;
+  /** fetch aggregated fields from the table: "questions" */
+  questionsAggregate: Questions_Aggregate;
+  /** fetch data from the table: "saved_queries" */
+  savedQueries: Array<Saved_Queries>;
+  /** fetch aggregated fields from the table: "saved_queries" */
+  savedQueriesAggregate: Saved_Queries_Aggregate;
+  /** fetch data from the table: "saved_queries" using primary key columns */
+  savedQuery?: Maybe<Saved_Queries>;
+  /** fetch data from the table: "saved_query_metrics" using primary key columns */
+  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** fetch data from the table: "saved_query_metrics" */
+  savedQueryMetrics: Array<Saved_Query_Metrics>;
+  /** fetch aggregated fields from the table: "saved_query_metrics" */
+  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
+  /** fetch data from the table: "teams" using primary key columns */
+  team?: Maybe<Teams>;
+  /** fetch data from the table: "team_dashboards" using primary key columns */
+  teamDashboard?: Maybe<Team_Dashboards>;
+  /** fetch data from the table: "team_dashboards" */
+  teamDashboards: Array<Team_Dashboards>;
+  /** fetch aggregated fields from the table: "team_dashboards" */
+  teamDashboardsAggregate: Team_Dashboards_Aggregate;
+  /** fetch data from the table: "team_members" using primary key columns */
+  teamMember?: Maybe<Team_Members>;
+  /** fetch data from the table: "team_members" */
+  teamMembers: Array<Team_Members>;
+  /** fetch aggregated fields from the table: "team_members" */
+  teamMembersAggregate: Team_Members_Aggregate;
+  /** fetch data from the table: "team_views" */
+  team_views: Array<Team_Views>;
+  /** fetch data from the table: "team_views" using primary key columns */
+  team_views_by_pk?: Maybe<Team_Views>;
+  /** fetch data from the table: "teams" */
+  teams: Array<Teams>;
+  /** fetch aggregated fields from the table: "teams" */
+  teamsAggregate: Teams_Aggregate;
+  /** fetch data from the table: "users" using primary key columns */
+  user?: Maybe<Users>;
+  /** fetch data from the table: "user_features" using primary key columns */
+  userFeature?: Maybe<User_Features>;
+  /** fetch data from the table: "user_features" */
+  userFeatures: Array<User_Features>;
+  /** fetch aggregated fields from the table: "user_features" */
+  userFeaturesAggregate: User_Features_Aggregate;
+  /** fetch data from the table: "user_prefs" using primary key columns */
+  userPreference?: Maybe<User_Prefs>;
+  /** fetch data from the table: "user_prefs" */
+  userPreferences: Array<User_Prefs>;
+  /** fetch aggregated fields from the table: "user_prefs" */
+  userPreferencesAggregate: User_Prefs_Aggregate;
+  /** fetch data from the table: "user_roles" using primary key columns */
+  userRole?: Maybe<User_Roles>;
+  /** fetch data from the table: "user_roles" */
+  userRoles: Array<User_Roles>;
+  /** fetch aggregated fields from the table: "user_roles" */
+  userRolesAggregate: User_Roles_Aggregate;
+  /** fetch data from the table: "users" */
+  users: Array<Users>;
+  /** fetch aggregated fields from the table: "users" */
+  usersAggregate: Users_Aggregate;
+  heartbeat: Scalars['String'];
+};
+
+
+export type QueryAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+export type QueryAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+export type QueryApiKeyArgs = {
+  prefix: Scalars['String'];
+};
+
+
+export type QueryApiKeysArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+export type QueryApiKeysAggregateArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+export type QueryAuth0ProfileArgs = {
+  auth0Id: Scalars['String'];
+};
+
+
+export type QueryDashboardArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDashboardItemConfigArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDashboardItemConfigsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+export type QueryDashboardItemConfigsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+export type QueryDashboardSectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDashboardSectionsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+export type QueryDashboardSectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+export type QueryDashboardsArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+export type QueryDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+export type QueryDataSourceArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDataSourceVersionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryDataSourceVersionsArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+export type QueryDataSourceVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+export type QueryDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryFeatureArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryFeaturesArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+export type QueryFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+export type QueryMeArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+export type QueryMe_AggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+export type QueryMetricAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+export type QueryMetricAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+export type QueryMetricApprovalArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricApprovalsArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+export type QueryMetricApprovalsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+export type QueryMetricByIdTempArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionMetricsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionViewArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricCollectionViewAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+export type QueryMetricCollectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+export type QueryMetricCurrentDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+export type QueryMetricDescriptionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+export type QueryMetricDescriptionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+export type QueryMetricTeamOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricTeamOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricTeamOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricUserOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricUserOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricUserOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+export type QueryMetricVersionArgs = {
+  id: Scalars['bigint'];
+};
+
+
+export type QueryMetricVersionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+export type QueryMetricVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+export type QueryMetricViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+export type QueryMetricViewsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+export type QueryMetric_Current_Description_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+export type QueryMetric_Lineage_Data_SourcesArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryMetric_Lineage_Data_Sources_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryMetric_Lineage_Data_Sources_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryModelArgs = {
+  id: Scalars['bigint'];
+};
+
+
+export type QueryModelDataSourceArgs = {
+  dataSourceVersionId: Scalars['Int'];
+  modelId: Scalars['Int'];
+};
+
+
+export type QueryModelDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryModelDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+export type QueryModelMetricArgs = {
+  metricId: Scalars['bigint'];
+  metricVersionId: Scalars['bigint'];
+  modelId: Scalars['bigint'];
+};
+
+
+export type QueryModelMetricsArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+export type QueryModelMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+export type QueryModel_CurrentArgs = {
+  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Current_Order_By>>;
+  where?: Maybe<Model_Current_Bool_Exp>;
+};
+
+
+export type QueryModelsArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+export type QueryModelsAggregateArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+export type QueryMqlHeartbeatArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryMqlHeartbeatsArgs = {
+  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
+  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
+};
+
+
+export type QueryMy_Most_Viewed_MetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryMy_Most_Viewed_Metrics_AggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+export type QueryMy_OrgArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+export type QueryOrgMqlServerArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryOrgMqlServersArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+export type QueryOrgMqlServersAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+export type QueryOrganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryOrganizationFeatureArgs = {
+  featureId: Scalars['Int'];
+  organizationId: Scalars['Int'];
+};
+
+
+export type QueryOrganizationFeaturesArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+export type QueryOrganizationFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+export type QueryOrganizationsArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+export type QueryPrioritiesArgs = {
+  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Priorities_Order_By>>;
+  where?: Maybe<Priorities_Bool_Exp>;
+};
+
+
+export type QueryPriorities_By_PkArgs = {
+  value: Scalars['String'];
+};
+
+
+export type QueryQuestionArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionDirectedToArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+export type QueryQuestionDirectedToAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+export type QueryQuestionDirectedToByPkArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionLikeArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionLikesArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+export type QueryQuestionLikesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+export type QueryQuestionRepliesArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+export type QueryQuestionRepliesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+export type QueryQuestionReplyArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryQuestionsArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+export type QueryQuestionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+export type QuerySavedQueriesArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+export type QuerySavedQueriesAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+export type QuerySavedQueryArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QuerySavedQueryMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QuerySavedQueryMetricsArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+export type QuerySavedQueryMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+export type QueryTeamArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryTeamDashboardArgs = {
+  dashboardId: Scalars['Int'];
+  team_id: Scalars['Int'];
+};
+
+
+export type QueryTeamDashboardsArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+export type QueryTeamDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+export type QueryTeamMemberArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryTeamMembersArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+export type QueryTeamMembersAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+export type QueryTeam_ViewsArgs = {
+  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Views_Order_By>>;
+  where?: Maybe<Team_Views_Bool_Exp>;
+};
+
+
+export type QueryTeam_Views_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryTeamsArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+export type QueryTeamsAggregateArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+export type QueryUserArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryUserFeatureArgs = {
+  featureId: Scalars['Int'];
+  userId: Scalars['Int'];
+};
+
+
+export type QueryUserFeaturesArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+export type QueryUserFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+export type QueryUserPreferenceArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryUserPreferencesArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+export type QueryUserPreferencesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+export type QueryUserRoleArgs = {
+  id: Scalars['Int'];
+};
+
+
+export type QueryUserRolesArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+export type QueryUserRolesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+export type QueryUsersArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+export type QueryUsersAggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+/** Base mutation object exposed by GraphQL. */
+export type Mutation = {
+  __typename?: 'Mutation';
+  /** insert a single row into the table: "metric_collection_metrics" */
+  addMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** insert data into the table: "metric_collection_metrics" */
+  addMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
+  /** insert a single row into the table: "team_members" */
+  addTeamMember?: Maybe<Team_Members>;
+  /** insert data into the table: "team_members" */
+  addTeamMembers?: Maybe<Team_Members_Mutation_Response>;
+  /** perform the action: "addUserRole" */
+  addUserRole?: Maybe<AddUserRoleOutput>;
+  /** insert a single row into the table: "metric_approvals" */
+  approveMetric?: Maybe<Metric_Approvals>;
+  /** insert data into the table: "metric_approvals" */
+  approveMetrics?: Maybe<Metric_Approvals_Mutation_Response>;
+  /** insert a single row into the table: "user_roles" */
+  assignUserRole?: Maybe<User_Roles>;
+  /** insert data into the table: "user_roles" */
+  assignUserRoles?: Maybe<User_Roles_Mutation_Response>;
+  /** insert a single row into the table: "annotations" */
+  createAnnotation?: Maybe<Annotations>;
+  /** insert data into the table: "annotations" */
+  createAnnotations?: Maybe<Annotations_Mutation_Response>;
+  /** perform the action: "createApiKey" */
+  createApiKey?: Maybe<CreateApiKeyOutput>;
+  /** insert a single row into the table: "dashboards" */
+  createDashboard?: Maybe<Dashboards>;
+  /** insert a single row into the table: "dashboard_item_configs" */
+  createDashboardItem?: Maybe<Dashboard_Item_Configs>;
+  /** insert data into the table: "dashboard_item_configs" */
+  createDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
+  /** insert a single row into the table: "dashboard_sections" */
+  createDashboardSection?: Maybe<Dashboard_Sections>;
+  /** insert data into the table: "dashboard_sections" */
+  createDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
+  /** insert data into the table: "dashboards" */
+  createDashboards?: Maybe<Dashboards_Mutation_Response>;
+  /** insert a single row into the table: "metric_annotations" */
+  createMetricAnnotation?: Maybe<Metric_Annotations>;
+  /** insert data into the table: "metric_annotations" */
+  createMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
+  /** insert a single row into the table: "metric_collections" */
+  createMetricCollection?: Maybe<Metric_Collections>;
+  /** insert a single row into the table: "metric_collection_view" */
+  createMetricCollectionView?: Maybe<Metric_Collection_View>;
+  /** insert data into the table: "metric_collection_view" */
+  createMetricCollectionViews?: Maybe<Metric_Collection_View_Mutation_Response>;
+  /** insert data into the table: "metric_collections" */
+  createMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
+  /** insert a single row into the table: "metric_descriptions" */
+  createMetricDescription?: Maybe<Metric_Descriptions>;
+  /** insert data into the table: "metric_descriptions" */
+  createMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
+  /** insert a single row into the table: "metric_team_owners" */
+  createMetricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** insert data into the table: "metric_team_owners" */
+  createMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
+  /** insert a single row into the table: "metric_user_owners" */
+  createMetricUserOwner?: Maybe<Metric_User_Owners>;
+  /** insert data into the table: "metric_user_owners" */
+  createMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
+  /** insert a single row into the table: "metric_view" */
+  createMetricView?: Maybe<Metric_View>;
+  /** insert data into the table: "metric_view" */
+  createMetricViews?: Maybe<Metric_View_Mutation_Response>;
+  /** insert a single row into the table: "mql_heartbeats" */
+  createMqlHeartbeat?: Maybe<Mql_Heartbeats>;
+  /** insert data into the table: "mql_heartbeats" */
+  createMqlHeartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
+  /** insert a single row into the table: "org_mql_servers" */
+  createOrgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** insert data into the table: "org_mql_servers" */
+  createOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
+  /** insert a single row into the table: "questions" */
+  createQuestion?: Maybe<Questions>;
+  /** insert data into the table: "question_replies" */
+  createQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
+  /** insert a single row into the table: "question_replies" */
+  createQuestionReply?: Maybe<Question_Replies>;
+  /** insert data into the table: "questions" */
+  createQuestions?: Maybe<Questions_Mutation_Response>;
+  /** insert data into the table: "saved_queries" */
+  createSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
+  /** insert a single row into the table: "saved_queries" */
+  createSavedQuery?: Maybe<Saved_Queries>;
+  /** insert a single row into the table: "teams" */
+  createTeam?: Maybe<Teams>;
+  /** insert a single row into the table: "team_dashboards" */
+  createTeamDashboard?: Maybe<Team_Dashboards>;
+  /** insert data into the table: "team_dashboards" */
+  createTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
+  /** insert a single row into the table: "team_views" */
+  createTeamView?: Maybe<Team_Views>;
+  /** insert data into the table: "team_views" */
+  createTeamViews?: Maybe<Team_Views_Mutation_Response>;
+  /** insert data into the table: "teams" */
+  createTeams?: Maybe<Teams_Mutation_Response>;
+  /** perform the action: "createUser" */
+  createUser?: Maybe<CreateUserOutput>;
+  /** insert a single row into the table: "user_prefs" */
+  createUserPreference?: Maybe<User_Prefs>;
+  /** insert data into the table: "user_prefs" */
+  createUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
+  /** insert a single row into the table: "saved_query_metrics" */
+  createdSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** insert data into the table: "saved_query_metrics" */
+  createdSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
+  /** perform the action: "deactivateUser" */
+  deactivateUser?: Maybe<DeactivateUserOutput>;
+  /** delete single row from the table: "dashboard_item_configs" */
+  deleteDashboardItem?: Maybe<Dashboard_Item_Configs>;
+  /** delete data from the table: "dashboard_item_configs" */
+  deleteDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
+  /** delete single row from the table: "dashboard_sections" */
+  deleteDashboardSection?: Maybe<Dashboard_Sections>;
+  /** delete data from the table: "dashboard_sections" */
+  deleteDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
+  /** delete single row from the table: "metric_annotations" */
+  deleteMetricAnnotation?: Maybe<Metric_Annotations>;
+  /** delete data from the table: "metric_annotations" */
+  deleteMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
+  /** delete single row from the table: "metric_collections" */
+  deleteMetricCollection?: Maybe<Metric_Collections>;
+  /** delete data from the table: "metric_collections" */
+  deleteMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
+  /** delete single row from the table: "metric_descriptions" */
+  deleteMetricDescription?: Maybe<Metric_Descriptions>;
+  /** delete data from the table: "metric_descriptions" */
+  deleteMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
+  /** delete single row from the table: "metric_team_owners" */
+  deleteMetricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** delete data from the table: "metric_team_owners" */
+  deleteMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
+  /** delete single row from the table: "metric_user_owners" */
+  deleteMetricUserOwner?: Maybe<Metric_User_Owners>;
+  /** delete data from the table: "metric_user_owners" */
+  deleteMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
+  /** delete single row from the table: "org_mql_servers" */
+  deleteOrgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** delete data from the table: "org_mql_servers" */
+  deleteOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
+  /** delete data from the table: "question_replies" */
+  deleteQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
+  /** delete single row from the table: "question_replies" */
+  deleteQuestionReply?: Maybe<Question_Replies>;
+  /** delete single row from the table: "saved_query_metrics" */
+  deleteSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** delete data from the table: "saved_query_metrics" */
+  deleteSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
+  /** delete single row from the table: "team_dashboards" */
+  deleteTeamDashboard?: Maybe<Team_Dashboards>;
+  /** delete data from the table: "team_dashboards" */
+  deleteTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
+  /** delete single row from the table: "user_prefs" */
+  deleteUserPreference?: Maybe<User_Prefs>;
+  /** delete data from the table: "user_prefs" */
+  deleteUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
+  /** insert a single row into the table: "question_directed_to" */
+  directQuestionTo?: Maybe<Question_Directed_To>;
+  /** insert data into the table: "question_directed_to" */
+  directQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
+  /** insert data into the table: "users" */
+  insert_users?: Maybe<Users_Mutation_Response>;
+  /** insert a single row into the table: "users" */
+  insert_users_one?: Maybe<Users>;
+  /** insert a single row into the table: "question_likes" */
+  likeQuestion?: Maybe<Question_Likes>;
+  /** insert data into the table: "question_likes" */
+  likeQuestions?: Maybe<Question_Likes_Mutation_Response>;
+  logMqlLog?: Maybe<LogMqlLogs>;
+  /** perform the action: "reactivateUser" */
+  reactivateUser?: Maybe<ReactivateUserOutput>;
+  /** delete single row from the table: "question_directed_to" */
+  removeDirectQuestionTo?: Maybe<Question_Directed_To>;
+  /** delete data from the table: "question_directed_to" */
+  removeDirectQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
+  /** delete single row from the table: "metric_approvals" */
+  removeMetricApproval?: Maybe<Metric_Approvals>;
+  /** delete data from the table: "metric_approvals" */
+  removeMetricApprovals?: Maybe<Metric_Approvals_Mutation_Response>;
+  /** delete single row from the table: "metric_collection_metrics" */
+  removeMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** delete data from the table: "metric_collection_metrics" */
+  removeMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
+  /** delete single row from the table: "team_members" */
+  removeTeamMember?: Maybe<Team_Members>;
+  /** delete data from the table: "team_members" */
+  removeTeamMembers?: Maybe<Team_Members_Mutation_Response>;
+  /** perform the action: "removeUserRole" */
+  removeUserRole?: Maybe<RemoveUserRoleOutput>;
+  /** delete single row from the table: "question_likes" */
+  unlikeQuestion?: Maybe<Question_Likes>;
+  /** delete data from the table: "question_likes" */
+  unlikeQuestions?: Maybe<Question_Likes_Mutation_Response>;
+  /** update single row of the table: "annotations" */
+  updateAnnotation?: Maybe<Annotations>;
+  /** update data of the table: "annotations" */
+  updateAnnotations?: Maybe<Annotations_Mutation_Response>;
+  /** update single row of the table: "api_keys" */
+  updateApiKey?: Maybe<Api_Keys>;
+  /** update data of the table: "api_keys" */
+  updateApiKeys?: Maybe<Api_Keys_Mutation_Response>;
+  /** update single row of the table: "dashboards" */
+  updateDashboard?: Maybe<Dashboards>;
+  /** update single row of the table: "dashboard_item_configs" */
+  updateDashboardItem?: Maybe<Dashboard_Item_Configs>;
+  /** update data of the table: "dashboard_item_configs" */
+  updateDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
+  /** update single row of the table: "dashboard_sections" */
+  updateDashboardSection?: Maybe<Dashboard_Sections>;
+  /** update data of the table: "dashboard_sections" */
+  updateDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
+  /** update data of the table: "dashboards" */
+  updateDashboards?: Maybe<Dashboards_Mutation_Response>;
+  /** update single row of the table: "metric_annotations" */
+  updateMetricAnnotation?: Maybe<Metric_Annotations>;
+  /** update data of the table: "metric_annotations" */
+  updateMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
+  /** update single row of the table: "metric_collections" */
+  updateMetricCollection?: Maybe<Metric_Collections>;
+  /** update data of the table: "metric_collections" */
+  updateMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
+  /** perform the action: "updateMyEmail" */
+  updateMyEmail?: Maybe<UpdateMyEmailOutput>;
+  /** update single row of the table: "org_mql_servers" */
+  updateOrgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** update data of the table: "org_mql_servers" */
+  updateOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
+  /** update single row of the table: "organizations" */
+  updateOrganization?: Maybe<Organizations>;
+  /** update data of the table: "organizations" */
+  updateOrganizations?: Maybe<Organizations_Mutation_Response>;
+  /** update single row of the table: "questions" */
+  updateQuestion?: Maybe<Questions>;
+  /** update data of the table: "question_replies" */
+  updateQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
+  /** update single row of the table: "question_replies" */
+  updateQuestionReply?: Maybe<Question_Replies>;
+  /** update data of the table: "questions" */
+  updateQuestions?: Maybe<Questions_Mutation_Response>;
+  /** update data of the table: "saved_queries" */
+  updateSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
+  /** update single row of the table: "saved_queries" */
+  updateSavedQuery?: Maybe<Saved_Queries>;
+  /** update single row of the table: "teams" */
+  updateTeam?: Maybe<Teams>;
+  /** update single row of the table: "team_members" */
+  updateTeamMember?: Maybe<Team_Members>;
+  /** update data of the table: "team_members" */
+  updateTeamMembers?: Maybe<Team_Members_Mutation_Response>;
+  /** update data of the table: "teams" */
+  updateTeams?: Maybe<Teams_Mutation_Response>;
+  /** update single row of the table: "users" */
+  updateUser?: Maybe<Users>;
+  /** update single row of the table: "user_prefs" */
+  updateUserPreference?: Maybe<User_Prefs>;
+  /** update data of the table: "user_prefs" */
+  updateUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
+  /** update single row of the table: "user_roles" */
+  updateUserRole?: Maybe<User_Roles>;
+  /** update data of the table: "user_roles" */
+  updateUserRoles?: Maybe<User_Roles_Mutation_Response>;
+  /** update data of the table: "users" */
+  updateUsers?: Maybe<Users_Mutation_Response>;
+  /** update data of the table: "metric_collection_metrics" */
+  update_metric_collection_metrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
+  /** update single row of the table: "metric_collection_metrics" */
+  update_metric_collection_metrics_by_pk?: Maybe<Metric_Collection_Metrics>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddMetricCollectionMetricArgs = {
+  object: Metric_Collection_Metrics_Insert_Input;
+  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddMetricCollectionMetricsArgs = {
+  objects: Array<Metric_Collection_Metrics_Insert_Input>;
+  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddTeamMemberArgs = {
+  object: Team_Members_Insert_Input;
+  on_conflict?: Maybe<Team_Members_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddTeamMembersArgs = {
+  objects: Array<Team_Members_Insert_Input>;
+  on_conflict?: Maybe<Team_Members_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAddUserRoleArgs = {
+  input: AddUserRoleInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationApproveMetricArgs = {
+  object: Metric_Approvals_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationApproveMetricsArgs = {
+  objects: Array<Metric_Approvals_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAssignUserRoleArgs = {
+  object: User_Roles_Insert_Input;
+  on_conflict?: Maybe<User_Roles_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationAssignUserRolesArgs = {
+  objects: Array<User_Roles_Insert_Input>;
+  on_conflict?: Maybe<User_Roles_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateAnnotationArgs = {
+  object: Annotations_Insert_Input;
+  on_conflict?: Maybe<Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateAnnotationsArgs = {
+  objects: Array<Annotations_Insert_Input>;
+  on_conflict?: Maybe<Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardArgs = {
+  object: Dashboards_Insert_Input;
+  on_conflict?: Maybe<Dashboards_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardItemArgs = {
+  object: Dashboard_Item_Configs_Insert_Input;
+  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardItemsArgs = {
+  objects: Array<Dashboard_Item_Configs_Insert_Input>;
+  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardSectionArgs = {
+  object: Dashboard_Sections_Insert_Input;
+  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardSectionsArgs = {
+  objects: Array<Dashboard_Sections_Insert_Input>;
+  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateDashboardsArgs = {
+  objects: Array<Dashboards_Insert_Input>;
+  on_conflict?: Maybe<Dashboards_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricAnnotationArgs = {
+  object: Metric_Annotations_Insert_Input;
+  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricAnnotationsArgs = {
+  objects: Array<Metric_Annotations_Insert_Input>;
+  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionArgs = {
+  object: Metric_Collections_Insert_Input;
+  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionViewArgs = {
+  object: Metric_Collection_View_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionViewsArgs = {
+  objects: Array<Metric_Collection_View_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricCollectionsArgs = {
+  objects: Array<Metric_Collections_Insert_Input>;
+  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricDescriptionArgs = {
+  object: Metric_Descriptions_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricDescriptionsArgs = {
+  objects: Array<Metric_Descriptions_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricTeamOwnerArgs = {
+  object: Metric_Team_Owners_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricTeamOwnersArgs = {
+  objects: Array<Metric_Team_Owners_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricUserOwnerArgs = {
+  object: Metric_User_Owners_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricUserOwnersArgs = {
+  objects: Array<Metric_User_Owners_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricViewArgs = {
+  object: Metric_View_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMetricViewsArgs = {
+  objects: Array<Metric_View_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMqlHeartbeatArgs = {
+  object: Mql_Heartbeats_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateMqlHeartbeatsArgs = {
+  objects: Array<Mql_Heartbeats_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateOrgMqlServerArgs = {
+  object: Org_Mql_Servers_Insert_Input;
+  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateOrgMqlServersArgs = {
+  objects: Array<Org_Mql_Servers_Insert_Input>;
+  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionArgs = {
+  object: Questions_Insert_Input;
+  on_conflict?: Maybe<Questions_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionRepliesArgs = {
+  objects: Array<Question_Replies_Insert_Input>;
+  on_conflict?: Maybe<Question_Replies_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionReplyArgs = {
+  object: Question_Replies_Insert_Input;
+  on_conflict?: Maybe<Question_Replies_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateQuestionsArgs = {
+  objects: Array<Questions_Insert_Input>;
+  on_conflict?: Maybe<Questions_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateSavedQueriesArgs = {
+  objects: Array<Saved_Queries_Insert_Input>;
+  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateSavedQueryArgs = {
+  object: Saved_Queries_Insert_Input;
+  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamArgs = {
+  object: Teams_Insert_Input;
+  on_conflict?: Maybe<Teams_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamDashboardArgs = {
+  object: Team_Dashboards_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamDashboardsArgs = {
+  objects: Array<Team_Dashboards_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamViewArgs = {
+  object: Team_Views_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamViewsArgs = {
+  objects: Array<Team_Views_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateTeamsArgs = {
+  objects: Array<Teams_Insert_Input>;
+  on_conflict?: Maybe<Teams_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateUserArgs = {
+  input: CreateUserInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateUserPreferenceArgs = {
+  object: User_Prefs_Insert_Input;
+  on_conflict?: Maybe<User_Prefs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreateUserPreferencesArgs = {
+  objects: Array<User_Prefs_Insert_Input>;
+  on_conflict?: Maybe<User_Prefs_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreatedSavedQueryMetricArgs = {
+  object: Saved_Query_Metrics_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationCreatedSavedQueryMetricsArgs = {
+  objects: Array<Saved_Query_Metrics_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeactivateUserArgs = {
+  input: DeactivateUserInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardItemArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardItemsArgs = {
+  where: Dashboard_Item_Configs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardSectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteDashboardSectionsArgs = {
+  where: Dashboard_Sections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricAnnotationsArgs = {
+  where: Metric_Annotations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricCollectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricCollectionsArgs = {
+  where: Metric_Collections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricDescriptionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricDescriptionsArgs = {
+  where: Metric_Descriptions_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricTeamOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricTeamOwnersArgs = {
+  where: Metric_Team_Owners_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricUserOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteMetricUserOwnersArgs = {
+  where: Metric_User_Owners_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteOrgMqlServerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteOrgMqlServersArgs = {
+  where: Org_Mql_Servers_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteQuestionRepliesArgs = {
+  where: Question_Replies_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteQuestionReplyArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteSavedQueryMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteSavedQueryMetricsArgs = {
+  where: Saved_Query_Metrics_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteTeamDashboardArgs = {
+  dashboardId: Scalars['Int'];
+  team_id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteTeamDashboardsArgs = {
+  where: Team_Dashboards_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteUserPreferenceArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDeleteUserPreferencesArgs = {
+  where: User_Prefs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDirectQuestionToArgs = {
+  object: Question_Directed_To_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationDirectQuestionToMultipleArgs = {
+  objects: Array<Question_Directed_To_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationInsert_UsersArgs = {
+  objects: Array<Users_Insert_Input>;
+  on_conflict?: Maybe<Users_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationInsert_Users_OneArgs = {
+  object: Users_Insert_Input;
+  on_conflict?: Maybe<Users_On_Conflict>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationLikeQuestionArgs = {
+  object: Question_Likes_Insert_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationLikeQuestionsArgs = {
+  objects: Array<Question_Likes_Insert_Input>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationLogMqlLogArgs = {
+  level?: Maybe<Scalars['String']>;
+  message?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<Scalars['String']>>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationReactivateUserArgs = {
+  input: ReactivateUserInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveDirectQuestionToArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveDirectQuestionToMultipleArgs = {
+  where: Question_Directed_To_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricApprovalArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricApprovalsArgs = {
+  where: Metric_Approvals_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricCollectionMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveMetricCollectionMetricsArgs = {
+  where: Metric_Collection_Metrics_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveTeamMemberArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveTeamMembersArgs = {
+  where: Team_Members_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationRemoveUserRoleArgs = {
+  input: RemoveUserRoleInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUnlikeQuestionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUnlikeQuestionsArgs = {
+  where: Question_Likes_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateAnnotationArgs = {
+  _set?: Maybe<Annotations_Set_Input>;
+  pk_columns: Annotations_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateAnnotationsArgs = {
+  _set?: Maybe<Annotations_Set_Input>;
+  where: Annotations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateApiKeyArgs = {
+  _set?: Maybe<Api_Keys_Set_Input>;
+  pk_columns: Api_Keys_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateApiKeysArgs = {
+  _set?: Maybe<Api_Keys_Set_Input>;
+  where: Api_Keys_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardArgs = {
+  _set?: Maybe<Dashboards_Set_Input>;
+  pk_columns: Dashboards_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardItemArgs = {
+  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
+  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
+  pk_columns: Dashboard_Item_Configs_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardItemsArgs = {
+  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
+  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
+  where: Dashboard_Item_Configs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardSectionArgs = {
+  _set?: Maybe<Dashboard_Sections_Set_Input>;
+  pk_columns: Dashboard_Sections_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardSectionsArgs = {
+  _set?: Maybe<Dashboard_Sections_Set_Input>;
+  where: Dashboard_Sections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateDashboardsArgs = {
+  _set?: Maybe<Dashboards_Set_Input>;
+  where: Dashboards_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricAnnotationArgs = {
+  _inc?: Maybe<Metric_Annotations_Inc_Input>;
+  _set?: Maybe<Metric_Annotations_Set_Input>;
+  pk_columns: Metric_Annotations_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricAnnotationsArgs = {
+  _inc?: Maybe<Metric_Annotations_Inc_Input>;
+  _set?: Maybe<Metric_Annotations_Set_Input>;
+  where: Metric_Annotations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricCollectionArgs = {
+  _inc?: Maybe<Metric_Collections_Inc_Input>;
+  _set?: Maybe<Metric_Collections_Set_Input>;
+  pk_columns: Metric_Collections_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMetricCollectionsArgs = {
+  _inc?: Maybe<Metric_Collections_Inc_Input>;
+  _set?: Maybe<Metric_Collections_Set_Input>;
+  where: Metric_Collections_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateMyEmailArgs = {
+  input: UpdateMyEmailInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrgMqlServerArgs = {
+  _set?: Maybe<Org_Mql_Servers_Set_Input>;
+  pk_columns: Org_Mql_Servers_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrgMqlServersArgs = {
+  _set?: Maybe<Org_Mql_Servers_Set_Input>;
+  where: Org_Mql_Servers_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrganizationArgs = {
+  _set?: Maybe<Organizations_Set_Input>;
+  pk_columns: Organizations_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateOrganizationsArgs = {
+  _set?: Maybe<Organizations_Set_Input>;
+  where: Organizations_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionArgs = {
+  _inc?: Maybe<Questions_Inc_Input>;
+  _set?: Maybe<Questions_Set_Input>;
+  pk_columns: Questions_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionRepliesArgs = {
+  _set?: Maybe<Question_Replies_Set_Input>;
+  where: Question_Replies_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionReplyArgs = {
+  _set?: Maybe<Question_Replies_Set_Input>;
+  pk_columns: Question_Replies_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateQuestionsArgs = {
+  _inc?: Maybe<Questions_Inc_Input>;
+  _set?: Maybe<Questions_Set_Input>;
+  where: Questions_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateSavedQueriesArgs = {
+  _inc?: Maybe<Saved_Queries_Inc_Input>;
+  _set?: Maybe<Saved_Queries_Set_Input>;
+  where: Saved_Queries_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateSavedQueryArgs = {
+  _inc?: Maybe<Saved_Queries_Inc_Input>;
+  _set?: Maybe<Saved_Queries_Set_Input>;
+  pk_columns: Saved_Queries_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamArgs = {
+  _inc?: Maybe<Teams_Inc_Input>;
+  _set?: Maybe<Teams_Set_Input>;
+  pk_columns: Teams_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamMemberArgs = {
+  _set?: Maybe<Team_Members_Set_Input>;
+  pk_columns: Team_Members_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamMembersArgs = {
+  _set?: Maybe<Team_Members_Set_Input>;
+  where: Team_Members_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateTeamsArgs = {
+  _inc?: Maybe<Teams_Inc_Input>;
+  _set?: Maybe<Teams_Set_Input>;
+  where: Teams_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserArgs = {
+  _set?: Maybe<Users_Set_Input>;
+  pk_columns: Users_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserPreferenceArgs = {
+  _set?: Maybe<User_Prefs_Set_Input>;
+  pk_columns: User_Prefs_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserPreferencesArgs = {
+  _set?: Maybe<User_Prefs_Set_Input>;
+  where: User_Prefs_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserRoleArgs = {
+  _set?: Maybe<User_Roles_Set_Input>;
+  pk_columns: User_Roles_Pk_Columns_Input;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUserRolesArgs = {
+  _set?: Maybe<User_Roles_Set_Input>;
+  where: User_Roles_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdateUsersArgs = {
+  _set?: Maybe<Users_Set_Input>;
+  where: Users_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdate_Metric_Collection_MetricsArgs = {
+  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
+  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
+  where: Metric_Collection_Metrics_Bool_Exp;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationUpdate_Metric_Collection_Metrics_By_PkArgs = {
+  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
+  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
+  pk_columns: Metric_Collection_Metrics_Pk_Columns_Input;
+};
+
+/** subscription root */
+export type Subscription = {
+  __typename?: 'Subscription';
+  /** fetch data from the table: "annotations" using primary key columns */
+  annotation?: Maybe<Annotations>;
+  /** fetch data from the table: "annotations" */
+  annotations: Array<Annotations>;
+  /** fetch aggregated fields from the table: "annotations" */
+  annotationsAggregate: Annotations_Aggregate;
+  /** fetch data from the table: "api_keys" using primary key columns */
+  apiKey?: Maybe<Api_Keys>;
+  /** fetch data from the table: "api_keys" */
+  apiKeys: Array<Api_Keys>;
+  /** fetch aggregated fields from the table: "api_keys" */
+  apiKeysAggregate: Api_Keys_Aggregate;
+  /** fetch data from the table: "dashboards" using primary key columns */
+  dashboard?: Maybe<Dashboards>;
+  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
+  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
+  /** fetch data from the table: "dashboard_item_configs" */
+  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
+  /** fetch aggregated fields from the table: "dashboard_item_configs" */
+  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
+  /** fetch data from the table: "dashboard_sections" using primary key columns */
+  dashboardSection?: Maybe<Dashboard_Sections>;
+  /** fetch data from the table: "dashboard_sections" */
+  dashboardSections: Array<Dashboard_Sections>;
+  /** fetch aggregated fields from the table: "dashboard_sections" */
+  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
+  /** fetch data from the table: "dashboards" */
+  dashboards: Array<Dashboards>;
+  /** fetch aggregated fields from the table: "dashboards" */
+  dashboardsAggregate: Dashboards_Aggregate;
+  /** fetch data from the table: "org_data_sources" using primary key columns */
+  dataSource?: Maybe<Org_Data_Sources>;
+  /** fetch data from the table: "data_source_versions" using primary key columns */
+  dataSourceVersion?: Maybe<Data_Source_Versions>;
+  /** fetch data from the table: "data_source_versions" */
+  dataSourceVersions: Array<Data_Source_Versions>;
+  /** fetch aggregated fields from the table: "data_source_versions" */
+  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
+  /** fetch data from the table: "org_data_sources" */
+  dataSources: Array<Org_Data_Sources>;
+  /** fetch aggregated fields from the table: "org_data_sources" */
+  dataSourcesAggregate: Org_Data_Sources_Aggregate;
+  /** fetch data from the table: "features" using primary key columns */
+  feature?: Maybe<Features>;
+  /** fetch data from the table: "features" */
+  features: Array<Features>;
+  /** fetch aggregated fields from the table: "features" */
+  featuresAggregate: Features_Aggregate;
+  /** execute function "me" which returns "users" */
+  me: Array<Users>;
+  /** execute function "me" and query aggregates on result of table type "users" */
+  me_aggregate: Users_Aggregate;
+  /** fetch data from the table: "metric_annotations" using primary key columns */
+  metricAnnotation?: Maybe<Metric_Annotations>;
+  /** fetch data from the table: "metric_annotations" */
+  metricAnnotations: Array<Metric_Annotations>;
+  /** fetch aggregated fields from the table: "metric_annotations" */
+  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
+  /** fetch data from the table: "metric_approvals" using primary key columns */
+  metricApproval?: Maybe<Metric_Approvals>;
+  /** fetch data from the table: "metric_approvals" */
+  metricApprovals: Array<Metric_Approvals>;
+  /** fetch aggregated fields from the table: "metric_approvals" */
+  metricApprovalsAggregate: Metric_Approvals_Aggregate;
+  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
+  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
+  /** fetch data from the table: "metric_collections" using primary key columns */
+  metricCollection?: Maybe<Metric_Collections>;
+  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
+  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
+  /** fetch data from the table: "metric_collection_metrics" */
+  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
+  /** fetch aggregated fields from the table: "metric_collection_metrics" */
+  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
+  /** fetch data from the table: "metric_collection_view" using primary key columns */
+  metricCollectionView?: Maybe<Metric_Collection_View>;
+  /** fetch aggregated fields from the table: "metric_collection_view" */
+  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
+  /** fetch data from the table: "metric_collection_view" */
+  metricCollectionViews: Array<Metric_Collection_View>;
+  /** fetch data from the table: "metric_collections" */
+  metricCollections: Array<Metric_Collections>;
+  /** fetch aggregated fields from the table: "metric_collections" */
+  metricCollectionsAggregate: Metric_Collections_Aggregate;
+  /** fetch data from the table: "metric_current_description" */
+  metricCurrentDescriptions: Array<Metric_Current_Description>;
+  /** fetch data from the table: "metric_descriptions" using primary key columns */
+  metricDescription?: Maybe<Metric_Descriptions>;
+  /** fetch data from the table: "metric_descriptions" */
+  metricDescriptions: Array<Metric_Descriptions>;
+  /** fetch aggregated fields from the table: "metric_descriptions" */
+  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
+  /** fetch data from the table: "metric_team_owners" using primary key columns */
+  metricTeamOwner?: Maybe<Metric_Team_Owners>;
+  /** fetch data from the table: "metric_team_owners" */
+  metricTeamOwners: Array<Metric_Team_Owners>;
+  /** fetch aggregated fields from the table: "metric_team_owners" */
+  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
+  /** fetch data from the table: "metric_user_owners" using primary key columns */
+  metricUserOwner?: Maybe<Metric_User_Owners>;
+  /** fetch data from the table: "metric_user_owners" */
+  metricUserOwners: Array<Metric_User_Owners>;
+  /** fetch aggregated fields from the table: "metric_user_owners" */
+  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
+  /** fetch data from the table: "metric_versions" using primary key columns */
+  metricVersion?: Maybe<Metric_Versions>;
+  /** fetch data from the table: "metric_versions" */
+  metricVersions: Array<Metric_Versions>;
+  /** fetch aggregated fields from the table: "metric_versions" */
+  metricVersionsAggregate: Metric_Versions_Aggregate;
+  /** fetch data from the table: "metric_view" */
+  metricViews: Array<Metric_View>;
+  /** fetch aggregated fields from the table: "metric_view" */
+  metricViewsAggregate: Metric_View_Aggregate;
+  /** fetch aggregated fields from the table: "metric_current_description" */
+  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
+  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
+  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
+  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
+  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
+  /** fetch data from the table: "org_metrics_current_view" */
+  metrics: Array<Org_Metrics_Current_View>;
+  /** fetch aggregated fields from the table: "org_metrics_current_view" */
+  metricsAggregate: Org_Metrics_Current_View_Aggregate;
+  /** fetch data from the table: "models" using primary key columns */
+  model?: Maybe<Models>;
+  /** fetch data from the table: "model_data_sources" using primary key columns */
+  modelDataSource?: Maybe<Model_Data_Sources>;
+  /** fetch data from the table: "model_data_sources" */
+  modelDataSources: Array<Model_Data_Sources>;
+  /** fetch aggregated fields from the table: "model_data_sources" */
+  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
+  /** fetch data from the table: "model_metrics" using primary key columns */
+  modelMetric?: Maybe<Model_Metrics>;
+  /** fetch data from the table: "model_metrics" */
+  modelMetrics: Array<Model_Metrics>;
+  /** fetch aggregated fields from the table: "model_metrics" */
+  modelMetricsAggregate: Model_Metrics_Aggregate;
+  /** fetch data from the table: "model_current" */
+  model_current: Array<Model_Current>;
+  /** fetch data from the table: "models" */
+  models: Array<Models>;
+  /** fetch aggregated fields from the table: "models" */
+  modelsAggregate: Models_Aggregate;
+  /** fetch data from the table: "mql_heartbeats" using primary key columns */
+  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
+  /** fetch data from the table: "mql_heartbeats" */
+  mqlHeartbeats: Array<Mql_Heartbeats>;
+  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
+  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
+  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
+  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
+  /** execute function "my_org" which returns "organizations" */
+  my_org: Array<Organizations>;
+  /** fetch data from the table: "org_mql_servers" using primary key columns */
+  orgMqlServer?: Maybe<Org_Mql_Servers>;
+  /** fetch data from the table: "org_mql_servers" */
+  orgMqlServers: Array<Org_Mql_Servers>;
+  /** fetch aggregated fields from the table: "org_mql_servers" */
+  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
+  /** fetch data from the table: "organizations" using primary key columns */
+  organization?: Maybe<Organizations>;
+  /** fetch data from the table: "organization_features" using primary key columns */
+  organizationFeature?: Maybe<Organization_Features>;
+  /** fetch data from the table: "organization_features" */
+  organizationFeatures: Array<Organization_Features>;
+  /** fetch aggregated fields from the table: "organization_features" */
+  organizationFeaturesAggregate: Organization_Features_Aggregate;
+  /** fetch data from the table: "organizations" */
+  organizations: Array<Organizations>;
+  /** fetch data from the table: "priorities" */
+  priorities: Array<Priorities>;
+  /** fetch data from the table: "priorities" using primary key columns */
+  priorities_by_pk?: Maybe<Priorities>;
+  /** fetch data from the table: "questions" using primary key columns */
+  question?: Maybe<Questions>;
+  /** fetch data from the table: "question_directed_to" */
+  questionDirectedTo: Array<Question_Directed_To>;
+  /** fetch aggregated fields from the table: "question_directed_to" */
+  questionDirectedToAggregate: Question_Directed_To_Aggregate;
+  /** fetch data from the table: "question_directed_to" using primary key columns */
+  questionDirectedToByPK?: Maybe<Question_Directed_To>;
+  /** fetch data from the table: "question_likes" using primary key columns */
+  questionLike?: Maybe<Question_Likes>;
+  /** fetch data from the table: "question_likes" */
+  questionLikes: Array<Question_Likes>;
+  /** fetch aggregated fields from the table: "question_likes" */
+  questionLikesAggregate: Question_Likes_Aggregate;
+  /** fetch data from the table: "question_replies" */
+  questionReplies: Array<Question_Replies>;
+  /** fetch aggregated fields from the table: "question_replies" */
+  questionRepliesAggregate: Question_Replies_Aggregate;
+  /** fetch data from the table: "question_replies" using primary key columns */
+  questionReply?: Maybe<Question_Replies>;
+  /** fetch data from the table: "questions" */
+  questions: Array<Questions>;
+  /** fetch aggregated fields from the table: "questions" */
+  questionsAggregate: Questions_Aggregate;
+  /** fetch data from the table: "saved_queries" */
+  savedQueries: Array<Saved_Queries>;
+  /** fetch aggregated fields from the table: "saved_queries" */
+  savedQueriesAggregate: Saved_Queries_Aggregate;
+  /** fetch data from the table: "saved_queries" using primary key columns */
+  savedQuery?: Maybe<Saved_Queries>;
+  /** fetch data from the table: "saved_query_metrics" using primary key columns */
+  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
+  /** fetch data from the table: "saved_query_metrics" */
+  savedQueryMetrics: Array<Saved_Query_Metrics>;
+  /** fetch aggregated fields from the table: "saved_query_metrics" */
+  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
+  /** fetch data from the table: "teams" using primary key columns */
+  team?: Maybe<Teams>;
+  /** fetch data from the table: "team_dashboards" using primary key columns */
+  teamDashboard?: Maybe<Team_Dashboards>;
+  /** fetch data from the table: "team_dashboards" */
+  teamDashboards: Array<Team_Dashboards>;
+  /** fetch aggregated fields from the table: "team_dashboards" */
+  teamDashboardsAggregate: Team_Dashboards_Aggregate;
+  /** fetch data from the table: "team_members" using primary key columns */
+  teamMember?: Maybe<Team_Members>;
+  /** fetch data from the table: "team_members" */
+  teamMembers: Array<Team_Members>;
+  /** fetch aggregated fields from the table: "team_members" */
+  teamMembersAggregate: Team_Members_Aggregate;
+  /** fetch data from the table: "team_views" */
+  team_views: Array<Team_Views>;
+  /** fetch data from the table: "team_views" using primary key columns */
+  team_views_by_pk?: Maybe<Team_Views>;
+  /** fetch data from the table: "teams" */
+  teams: Array<Teams>;
+  /** fetch aggregated fields from the table: "teams" */
+  teamsAggregate: Teams_Aggregate;
+  /** fetch data from the table: "users" using primary key columns */
+  user?: Maybe<Users>;
+  /** fetch data from the table: "user_features" using primary key columns */
+  userFeature?: Maybe<User_Features>;
+  /** fetch data from the table: "user_features" */
+  userFeatures: Array<User_Features>;
+  /** fetch aggregated fields from the table: "user_features" */
+  userFeaturesAggregate: User_Features_Aggregate;
+  /** fetch data from the table: "user_prefs" using primary key columns */
+  userPreference?: Maybe<User_Prefs>;
+  /** fetch data from the table: "user_prefs" */
+  userPreferences: Array<User_Prefs>;
+  /** fetch aggregated fields from the table: "user_prefs" */
+  userPreferencesAggregate: User_Prefs_Aggregate;
+  /** fetch data from the table: "user_roles" using primary key columns */
+  userRole?: Maybe<User_Roles>;
+  /** fetch data from the table: "user_roles" */
+  userRoles: Array<User_Roles>;
+  /** fetch aggregated fields from the table: "user_roles" */
+  userRolesAggregate: User_Roles_Aggregate;
+  /** fetch data from the table: "users" */
+  users: Array<Users>;
+  /** fetch aggregated fields from the table: "users" */
+  usersAggregate: Users_Aggregate;
+};
+
+
+/** subscription root */
+export type SubscriptionAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Annotations_Order_By>>;
+  where?: Maybe<Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionApiKeyArgs = {
+  prefix: Scalars['String'];
+};
+
+
+/** subscription root */
+export type SubscriptionApiKeysArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionApiKeysAggregateArgs = {
+  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Api_Keys_Order_By>>;
+  where?: Maybe<Api_Keys_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardItemConfigArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardItemConfigsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardItemConfigsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
+  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardSectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardSectionsArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardSectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
+  where?: Maybe<Dashboard_Sections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardsArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Dashboards_Order_By>>;
+  where?: Maybe<Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceVersionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceVersionsArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourceVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
+  where?: Maybe<Data_Source_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
+  where?: Maybe<Org_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionFeatureArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionFeaturesArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Features_Order_By>>;
+  where?: Maybe<Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMeArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMe_AggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricAnnotationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricAnnotationsArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricAnnotationsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
+  where?: Maybe<Metric_Annotations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricApprovalArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricApprovalsArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricApprovalsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
+  where?: Maybe<Metric_Approvals_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricByIdTempArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionMetricsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
+  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionViewArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionViewAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
+  where?: Maybe<Metric_Collection_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCollectionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
+  where?: Maybe<Metric_Collections_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricCurrentDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricDescriptionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricDescriptionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricDescriptionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
+  where?: Maybe<Metric_Descriptions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricTeamOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricTeamOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricTeamOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
+  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricUserOwnerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricUserOwnersArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricUserOwnersAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
+  where?: Maybe<Metric_User_Owners_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricVersionArgs = {
+  id: Scalars['bigint'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricVersionsArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricVersionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
+  where?: Maybe<Metric_Versions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricViewsArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricViewsAggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_View_Order_By>>;
+  where?: Maybe<Metric_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Current_Description_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
+  where?: Maybe<Metric_Current_Description_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Lineage_Data_SourcesArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Lineage_Data_Sources_AggregateArgs = {
+  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
+  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetric_Lineage_Data_Sources_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelArgs = {
+  id: Scalars['bigint'];
+};
+
+
+/** subscription root */
+export type SubscriptionModelDataSourceArgs = {
+  dataSourceVersionId: Scalars['Int'];
+  modelId: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionModelDataSourcesArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelDataSourcesAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
+  where?: Maybe<Model_Data_Sources_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelMetricArgs = {
+  metricId: Scalars['bigint'];
+  metricVersionId: Scalars['bigint'];
+  modelId: Scalars['bigint'];
+};
+
+
+/** subscription root */
+export type SubscriptionModelMetricsArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
+  where?: Maybe<Model_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModel_CurrentArgs = {
+  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Model_Current_Order_By>>;
+  where?: Maybe<Model_Current_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelsArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionModelsAggregateArgs = {
+  distinct_on?: Maybe<Array<Models_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Models_Order_By>>;
+  where?: Maybe<Models_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMqlHeartbeatArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionMqlHeartbeatsArgs = {
+  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
+  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMy_Most_Viewed_MetricsArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMy_Most_Viewed_Metrics_AggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
+  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionMy_OrgArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrgMqlServerArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionOrgMqlServersArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrgMqlServersAggregateArgs = {
+  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
+  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationFeatureArgs = {
+  featureId: Scalars['Int'];
+  organizationId: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationFeaturesArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organization_Features_Order_By>>;
+  where?: Maybe<Organization_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionOrganizationsArgs = {
+  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Organizations_Order_By>>;
+  where?: Maybe<Organizations_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionPrioritiesArgs = {
+  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Priorities_Order_By>>;
+  where?: Maybe<Priorities_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionPriorities_By_PkArgs = {
+  value: Scalars['String'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionDirectedToArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionDirectedToAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
+  where?: Maybe<Question_Directed_To_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionDirectedToByPkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionLikeArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionLikesArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionLikesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Likes_Order_By>>;
+  where?: Maybe<Question_Likes_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionRepliesArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionRepliesAggregateArgs = {
+  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Question_Replies_Order_By>>;
+  where?: Maybe<Question_Replies_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionReplyArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionsArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionQuestionsAggregateArgs = {
+  distinct_on?: Maybe<Array<Questions_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Questions_Order_By>>;
+  where?: Maybe<Questions_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueriesArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueriesAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
+  where?: Maybe<Saved_Queries_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryMetricArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryMetricsArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionSavedQueryMetricsAggregateArgs = {
+  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
+  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamDashboardArgs = {
+  dashboardId: Scalars['Int'];
+  team_id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamDashboardsArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamDashboardsAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
+  where?: Maybe<Team_Dashboards_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamMemberArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamMembersArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamMembersAggregateArgs = {
+  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Members_Order_By>>;
+  where?: Maybe<Team_Members_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeam_ViewsArgs = {
+  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Team_Views_Order_By>>;
+  where?: Maybe<Team_Views_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeam_Views_By_PkArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionTeamsArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionTeamsAggregateArgs = {
+  distinct_on?: Maybe<Array<Teams_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Teams_Order_By>>;
+  where?: Maybe<Teams_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserFeatureArgs = {
+  featureId: Scalars['Int'];
+  userId: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserFeaturesArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserFeaturesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Features_Order_By>>;
+  where?: Maybe<User_Features_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserPreferenceArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserPreferencesArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserPreferencesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Prefs_Order_By>>;
+  where?: Maybe<User_Prefs_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserRoleArgs = {
+  id: Scalars['Int'];
+};
+
+
+/** subscription root */
+export type SubscriptionUserRolesArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUserRolesAggregateArgs = {
+  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<User_Roles_Order_By>>;
+  where?: Maybe<User_Roles_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUsersArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
+};
+
+
+/** subscription root */
+export type SubscriptionUsersAggregateArgs = {
+  distinct_on?: Maybe<Array<Users_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Users_Order_By>>;
+  where?: Maybe<Users_Bool_Exp>;
 };
 
 export type AddUserRoleInput = {
@@ -141,42 +3963,6 @@ export type MqlServerVersion = {
   versionHash?: Maybe<Scalars['String']>;
 };
 
-/** Base mutation object exposed by GraphQL. */
-export type Mutation = {
-  __typename?: 'Mutation';
-  logMqlLog?: Maybe<LogMqlLogs>;
-};
-
-
-/** Base mutation object exposed by GraphQL. */
-export type MutationLogMqlLogArgs = {
-  level?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<Scalars['String']>>;
-};
-
-/**
- * Base Query object exposed by GraphQL.
- *
- * Each field defined below is accessible by the API, by calling the equivalent resolver.
- */
-export type Query = {
-  __typename?: 'Query';
-  auth0Profile?: Maybe<Auth0Profile>;
-  latestMqlServer?: Maybe<MqlServerVersion>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-};
-
-
-/**
- * Base Query object exposed by GraphQL.
- *
- * Each field defined below is accessible by the API, by calling the equivalent resolver.
- */
-export type QueryAuth0ProfileArgs = {
-  auth0Id: Scalars['String'];
-};
-
 export type ReactivateUserInput = {
   userId: Scalars['Int'];
 };
@@ -252,17 +4038,12 @@ export type Annotations = {
   __typename?: 'annotations';
   /** An object relationship */
   author: Users;
-  authorId: Scalars['Int'];
   /** Timestamp indicating when the `Annotation` was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
   /** Last date when the `Annotation`  applies */
   dateEndedAt?: Maybe<Scalars['date']>;
   /** Date when the `Annotation` first applies */
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  /** Soft delete mechanism for an Annotation. Rows with non-null values are omitted from list results. */
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   /** A qualitative assessment of the expected impact helps contextualize the annotation for future consumers. */
   expectedImpact: Scalars['String'];
   /** ID field to identify an Annotation */
@@ -271,14 +4052,11 @@ export type Annotations = {
   metricAnnotations: Array<Metric_Annotations>;
   /** An aggregated array relationship */
   metricAnnotations_aggregate: Metric_Annotations_Aggregate;
-  notified_at?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   priority?: Maybe<Priorities_Enum>;
   /** The full description of an annotation with the complete context needed to understand what took place. */
   text: Scalars['String'];
-  timestamp_created?: Maybe<Scalars['Int']>;
   /** A short title to identify the annotation in a list view or tooltip */
   title: Scalars['String'];
   /** Timestamp indicating when the `Annotation` was last updated. */
@@ -369,18 +4147,12 @@ export type Annotations_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Annotations_Avg_Fields = {
   __typename?: 'annotations_avg_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "annotations" */
 export type Annotations_Avg_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "annotations". All fields are combined with a logical 'AND'. */
@@ -389,22 +4161,15 @@ export type Annotations_Bool_Exp = {
   _not?: Maybe<Annotations_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Annotations_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   dateEndedAt?: Maybe<Date_Comparison_Exp>;
   dateStartedAt?: Maybe<Date_Comparison_Exp>;
-  date_end?: Maybe<String_Comparison_Exp>;
-  date_start?: Maybe<String_Comparison_Exp>;
-  deletedAt?: Maybe<Timestamptz_Comparison_Exp>;
   expectedImpact?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metricAnnotations?: Maybe<Metric_Annotations_Bool_Exp>;
-  notified_at?: Maybe<Timestamptz_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   priority?: Maybe<Priorities_Enum_Comparison_Exp>;
   text?: Maybe<String_Comparison_Exp>;
-  timestamp_created?: Maybe<Int_Comparison_Exp>;
   title?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
 };
@@ -415,72 +4180,39 @@ export enum Annotations_Constraint {
   AnnotationsPkey = 'annotations_pkey'
 }
 
-/** input type for incrementing integer column in table "annotations" */
-export type Annotations_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "annotations" */
 export type Annotations_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
   metricAnnotations?: Maybe<Metric_Annotations_Arr_Rel_Insert_Input>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Annotations_Max_Fields = {
   __typename?: 'annotations_max_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "annotations" */
 export type Annotations_Max_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   dateEndedAt?: Maybe<Order_By>;
   dateStartedAt?: Maybe<Order_By>;
-  date_end?: Maybe<Order_By>;
-  date_start?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   expectedImpact?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -488,38 +4220,24 @@ export type Annotations_Max_Order_By = {
 /** aggregate min on columns */
 export type Annotations_Min_Fields = {
   __typename?: 'annotations_min_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "annotations" */
 export type Annotations_Min_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   dateEndedAt?: Maybe<Order_By>;
   dateStartedAt?: Maybe<Order_By>;
-  date_end?: Maybe<Order_By>;
-  date_start?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   expectedImpact?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -549,22 +4267,15 @@ export type Annotations_On_Conflict = {
 /** ordering options when selecting data from "annotations" */
 export type Annotations_Order_By = {
   author?: Maybe<Users_Order_By>;
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   dateEndedAt?: Maybe<Order_By>;
   dateStartedAt?: Maybe<Order_By>;
-  date_end?: Maybe<Order_By>;
-  date_start?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   expectedImpact?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricAnnotations_aggregate?: Maybe<Metric_Annotations_Aggregate_Order_By>;
-  notified_at?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   priority?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -578,33 +4289,19 @@ export type Annotations_Pk_Columns_Input = {
 /** select columns of table "annotations" */
 export enum Annotations_Select_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
   CreatedAt = 'createdAt',
   /** column name */
   DateEndedAt = 'dateEndedAt',
   /** column name */
   DateStartedAt = 'dateStartedAt',
   /** column name */
-  DateEnd = 'date_end',
-  /** column name */
-  DateStart = 'date_start',
-  /** column name */
-  DeletedAt = 'deletedAt',
-  /** column name */
   ExpectedImpact = 'expectedImpact',
   /** column name */
   Id = 'id',
   /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   Priority = 'priority',
   /** column name */
   Text = 'text',
-  /** column name */
-  TimestampCreated = 'timestamp_created',
   /** column name */
   Title = 'title',
   /** column name */
@@ -613,177 +4310,108 @@ export enum Annotations_Select_Column {
 
 /** input type for updating data in table "annotations" */
 export type Annotations_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dateEndedAt?: Maybe<Scalars['date']>;
   dateStartedAt?: Maybe<Scalars['date']>;
-  date_end?: Maybe<Scalars['String']>;
-  date_start?: Maybe<Scalars['String']>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
   expectedImpact?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
   text?: Maybe<Scalars['String']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Annotations_Stddev_Fields = {
   __typename?: 'annotations_stddev_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "annotations" */
 export type Annotations_Stddev_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Annotations_Stddev_Pop_Fields = {
   __typename?: 'annotations_stddev_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "annotations" */
 export type Annotations_Stddev_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Annotations_Stddev_Samp_Fields = {
   __typename?: 'annotations_stddev_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "annotations" */
 export type Annotations_Stddev_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Annotations_Sum_Fields = {
   __typename?: 'annotations_sum_fields';
-  authorId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  timestamp_created?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "annotations" */
 export type Annotations_Sum_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** update columns of table "annotations" */
 export enum Annotations_Update_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
   DateEndedAt = 'dateEndedAt',
   /** column name */
   DateStartedAt = 'dateStartedAt',
-  /** column name */
-  DateEnd = 'date_end',
-  /** column name */
-  DateStart = 'date_start',
   /** column name */
   DeletedAt = 'deletedAt',
   /** column name */
   ExpectedImpact = 'expectedImpact',
   /** column name */
-  Id = 'id',
-  /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   Priority = 'priority',
   /** column name */
   Text = 'text',
   /** column name */
-  TimestampCreated = 'timestamp_created',
-  /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
 export type Annotations_Var_Pop_Fields = {
   __typename?: 'annotations_var_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "annotations" */
 export type Annotations_Var_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Annotations_Var_Samp_Fields = {
   __typename?: 'annotations_var_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "annotations" */
 export type Annotations_Var_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Annotations_Variance_Fields = {
   __typename?: 'annotations_variance_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  timestamp_created?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "annotations" */
 export type Annotations_Variance_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  timestamp_created?: Maybe<Order_By>;
 };
 
 /**
@@ -796,29 +4424,22 @@ export type Api_Keys = {
   __typename?: 'api_keys';
   /** A timestamp for when the `APIKey` was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
   /** A timestamp for the last time the `ApiKey` was used. */
   lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** The first few characters of the `ApiKey`. Useful for identifying the key without revealing it entirely. */
   prefix: Scalars['String'];
   /** If the `ApiKey` has been revoked (soft deleted), this is the timestamp for when it was revoked. */
   revokedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   revoker?: Maybe<Users>;
-  revokerId?: Maybe<Scalars['Int']>;
   scope?: Maybe<Scalars['String']>;
-  secretHash: Scalars['String'];
   type: Scalars['String'];
   /** A timestamp for the last time the `ApiKey` was used. */
   updatedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   user: Users;
-  userId: Scalars['Int'];
 };
 
 /** aggregated selection of "api_keys" */
@@ -831,17 +4452,9 @@ export type Api_Keys_Aggregate = {
 /** aggregate fields of "api_keys" */
 export type Api_Keys_Aggregate_Fields = {
   __typename?: 'api_keys_aggregate_fields';
-  avg?: Maybe<Api_Keys_Avg_Fields>;
   count?: Maybe<Scalars['Int']>;
   max?: Maybe<Api_Keys_Max_Fields>;
   min?: Maybe<Api_Keys_Min_Fields>;
-  stddev?: Maybe<Api_Keys_Stddev_Fields>;
-  stddev_pop?: Maybe<Api_Keys_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Api_Keys_Stddev_Samp_Fields>;
-  sum?: Maybe<Api_Keys_Sum_Fields>;
-  var_pop?: Maybe<Api_Keys_Var_Pop_Fields>;
-  var_samp?: Maybe<Api_Keys_Var_Samp_Fields>;
-  variance?: Maybe<Api_Keys_Variance_Fields>;
 };
 
 
@@ -853,44 +4466,9 @@ export type Api_Keys_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "api_keys" */
 export type Api_Keys_Aggregate_Order_By = {
-  avg?: Maybe<Api_Keys_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Api_Keys_Max_Order_By>;
   min?: Maybe<Api_Keys_Min_Order_By>;
-  stddev?: Maybe<Api_Keys_Stddev_Order_By>;
-  stddev_pop?: Maybe<Api_Keys_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Api_Keys_Stddev_Samp_Order_By>;
-  sum?: Maybe<Api_Keys_Sum_Order_By>;
-  var_pop?: Maybe<Api_Keys_Var_Pop_Order_By>;
-  var_samp?: Maybe<Api_Keys_Var_Samp_Order_By>;
-  variance?: Maybe<Api_Keys_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "api_keys" */
-export type Api_Keys_Arr_Rel_Insert_Input = {
-  data: Array<Api_Keys_Insert_Input>;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Api_Keys_Avg_Fields = {
-  __typename?: 'api_keys_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "api_keys" */
-export type Api_Keys_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "api_keys". All fields are combined with a logical 'AND'. */
@@ -899,22 +4477,15 @@ export type Api_Keys_Bool_Exp = {
   _not?: Maybe<Api_Keys_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Api_Keys_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
-  date_revoked?: Maybe<Int_Comparison_Exp>;
   lastUsedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  last_used_ts?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   prefix?: Maybe<String_Comparison_Exp>;
   revokedAt?: Maybe<Timestamptz_Comparison_Exp>;
   revoker?: Maybe<Users_Bool_Exp>;
-  revokerId?: Maybe<Int_Comparison_Exp>;
   scope?: Maybe<String_Comparison_Exp>;
-  secretHash?: Maybe<String_Comparison_Exp>;
   type?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "api_keys" */
@@ -923,109 +4494,50 @@ export enum Api_Keys_Constraint {
   ApiKeysPkey = 'api_keys_pkey'
 }
 
-/** input type for incrementing integer column in table "api_keys" */
-export type Api_Keys_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  revokerId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "api_keys" */
-export type Api_Keys_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  prefix?: Maybe<Scalars['String']>;
-  revokedAt?: Maybe<Scalars['timestamptz']>;
-  revoker?: Maybe<Users_Obj_Rel_Insert_Input>;
-  revokerId?: Maybe<Scalars['Int']>;
-  scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** aggregate max on columns */
 export type Api_Keys_Max_Fields = {
   __typename?: 'api_keys_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
   lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefix?: Maybe<Scalars['String']>;
   revokedAt?: Maybe<Scalars['timestamptz']>;
-  revokerId?: Maybe<Scalars['Int']>;
   scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "api_keys" */
 export type Api_Keys_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
   lastUsedAt?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   prefix?: Maybe<Order_By>;
   revokedAt?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
   scope?: Maybe<Order_By>;
-  secretHash?: Maybe<Order_By>;
   type?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Api_Keys_Min_Fields = {
   __typename?: 'api_keys_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
   lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefix?: Maybe<Scalars['String']>;
   revokedAt?: Maybe<Scalars['timestamptz']>;
-  revokerId?: Maybe<Scalars['Int']>;
   scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
   type?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "api_keys" */
 export type Api_Keys_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
   lastUsedAt?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   prefix?: Maybe<Order_By>;
   revokedAt?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
   scope?: Maybe<Order_By>;
-  secretHash?: Maybe<Order_By>;
   type?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "api_keys" */
@@ -1035,12 +4547,6 @@ export type Api_Keys_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Api_Keys>;
-};
-
-/** input type for inserting object relation for remote table "api_keys" */
-export type Api_Keys_Obj_Rel_Insert_Input = {
-  data: Api_Keys_Insert_Input;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
 };
 
 /** on conflict condition type for table "api_keys" */
@@ -1053,22 +4559,15 @@ export type Api_Keys_On_Conflict = {
 /** ordering options when selecting data from "api_keys" */
 export type Api_Keys_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
   lastUsedAt?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   prefix?: Maybe<Order_By>;
   revokedAt?: Maybe<Order_By>;
   revoker?: Maybe<Users_Order_By>;
-  revokerId?: Maybe<Order_By>;
   scope?: Maybe<Order_By>;
-  secretHash?: Maybe<Order_By>;
   type?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "api_keys" */
@@ -1082,229 +4581,29 @@ export enum Api_Keys_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateRevoked = 'date_revoked',
-  /** column name */
   LastUsedAt = 'lastUsedAt',
-  /** column name */
-  LastUsedTs = 'last_used_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   Prefix = 'prefix',
   /** column name */
   RevokedAt = 'revokedAt',
   /** column name */
-  RevokerId = 'revokerId',
-  /** column name */
   Scope = 'scope',
-  /** column name */
-  SecretHash = 'secretHash',
   /** column name */
   Type = 'type',
   /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  UpdatedAt = 'updatedAt'
 }
 
 /** input type for updating data in table "api_keys" */
 export type Api_Keys_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  lastUsedAt?: Maybe<Scalars['timestamptz']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  prefix?: Maybe<Scalars['String']>;
   revokedAt?: Maybe<Scalars['timestamptz']>;
-  revokerId?: Maybe<Scalars['Int']>;
-  scope?: Maybe<Scalars['String']>;
-  secretHash?: Maybe<Scalars['String']>;
-  type?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Api_Keys_Stddev_Fields = {
-  __typename?: 'api_keys_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "api_keys" */
-export type Api_Keys_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Api_Keys_Stddev_Pop_Fields = {
-  __typename?: 'api_keys_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "api_keys" */
-export type Api_Keys_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Api_Keys_Stddev_Samp_Fields = {
-  __typename?: 'api_keys_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "api_keys" */
-export type Api_Keys_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Api_Keys_Sum_Fields = {
-  __typename?: 'api_keys_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
-  date_revoked?: Maybe<Scalars['Int']>;
-  last_used_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  revokerId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "api_keys" */
-export type Api_Keys_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** update columns of table "api_keys" */
 export enum Api_Keys_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateRevoked = 'date_revoked',
-  /** column name */
-  LastUsedAt = 'lastUsedAt',
-  /** column name */
-  LastUsedTs = 'last_used_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Prefix = 'prefix',
-  /** column name */
-  RevokedAt = 'revokedAt',
-  /** column name */
-  RevokerId = 'revokerId',
-  /** column name */
-  Scope = 'scope',
-  /** column name */
-  SecretHash = 'secretHash',
-  /** column name */
-  Type = 'type',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  RevokedAt = 'revokedAt'
 }
-
-/** aggregate var_pop on columns */
-export type Api_Keys_Var_Pop_Fields = {
-  __typename?: 'api_keys_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "api_keys" */
-export type Api_Keys_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Api_Keys_Var_Samp_Fields = {
-  __typename?: 'api_keys_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "api_keys" */
-export type Api_Keys_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Api_Keys_Variance_Fields = {
-  __typename?: 'api_keys_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_revoked?: Maybe<Scalars['Float']>;
-  last_used_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  revokerId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "api_keys" */
-export type Api_Keys_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_revoked?: Maybe<Order_By>;
-  last_used_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  revokerId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
 
 
 /** expression to compare columns of type bigint. All fields are combined with logical 'AND'. */
@@ -1320,304 +4619,6 @@ export type Bigint_Comparison_Exp = {
   _nin?: Maybe<Array<Scalars['bigint']>>;
 };
 
-/** columns and relationships of "branch_metadatas" */
-export type Branch_Metadatas = {
-  __typename?: 'branch_metadatas';
-  commit: Scalars['String'];
-  id: Scalars['Int'];
-  model_key: Scalars['String'];
-  timestamp: Scalars['Int'];
-};
-
-/** aggregated selection of "branch_metadatas" */
-export type Branch_Metadatas_Aggregate = {
-  __typename?: 'branch_metadatas_aggregate';
-  aggregate?: Maybe<Branch_Metadatas_Aggregate_Fields>;
-  nodes: Array<Branch_Metadatas>;
-};
-
-/** aggregate fields of "branch_metadatas" */
-export type Branch_Metadatas_Aggregate_Fields = {
-  __typename?: 'branch_metadatas_aggregate_fields';
-  avg?: Maybe<Branch_Metadatas_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Branch_Metadatas_Max_Fields>;
-  min?: Maybe<Branch_Metadatas_Min_Fields>;
-  stddev?: Maybe<Branch_Metadatas_Stddev_Fields>;
-  stddev_pop?: Maybe<Branch_Metadatas_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Branch_Metadatas_Stddev_Samp_Fields>;
-  sum?: Maybe<Branch_Metadatas_Sum_Fields>;
-  var_pop?: Maybe<Branch_Metadatas_Var_Pop_Fields>;
-  var_samp?: Maybe<Branch_Metadatas_Var_Samp_Fields>;
-  variance?: Maybe<Branch_Metadatas_Variance_Fields>;
-};
-
-
-/** aggregate fields of "branch_metadatas" */
-export type Branch_Metadatas_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "branch_metadatas" */
-export type Branch_Metadatas_Aggregate_Order_By = {
-  avg?: Maybe<Branch_Metadatas_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Branch_Metadatas_Max_Order_By>;
-  min?: Maybe<Branch_Metadatas_Min_Order_By>;
-  stddev?: Maybe<Branch_Metadatas_Stddev_Order_By>;
-  stddev_pop?: Maybe<Branch_Metadatas_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Branch_Metadatas_Stddev_Samp_Order_By>;
-  sum?: Maybe<Branch_Metadatas_Sum_Order_By>;
-  var_pop?: Maybe<Branch_Metadatas_Var_Pop_Order_By>;
-  var_samp?: Maybe<Branch_Metadatas_Var_Samp_Order_By>;
-  variance?: Maybe<Branch_Metadatas_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "branch_metadatas" */
-export type Branch_Metadatas_Arr_Rel_Insert_Input = {
-  data: Array<Branch_Metadatas_Insert_Input>;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Branch_Metadatas_Avg_Fields = {
-  __typename?: 'branch_metadatas_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "branch_metadatas". All fields are combined with a logical 'AND'. */
-export type Branch_Metadatas_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Branch_Metadatas_Bool_Exp>>>;
-  _not?: Maybe<Branch_Metadatas_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Branch_Metadatas_Bool_Exp>>>;
-  commit?: Maybe<String_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
-  model_key?: Maybe<String_Comparison_Exp>;
-  timestamp?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "branch_metadatas" */
-export enum Branch_Metadatas_Constraint {
-  /** unique or primary key constraint */
-  BranchMetadatasPkey = 'branch_metadatas_pkey',
-  /** unique or primary key constraint */
-  IxBranchMetadatasModelKey = 'ix_branch_metadatas_model_key'
-}
-
-/** input type for incrementing integer column in table "branch_metadatas" */
-export type Branch_Metadatas_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "branch_metadatas" */
-export type Branch_Metadatas_Insert_Input = {
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type Branch_Metadatas_Max_Fields = {
-  __typename?: 'branch_metadatas_max_fields';
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Max_Order_By = {
-  commit?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  model_key?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Branch_Metadatas_Min_Fields = {
-  __typename?: 'branch_metadatas_min_fields';
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Min_Order_By = {
-  commit?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  model_key?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "branch_metadatas" */
-export type Branch_Metadatas_Mutation_Response = {
-  __typename?: 'branch_metadatas_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Branch_Metadatas>;
-};
-
-/** input type for inserting object relation for remote table "branch_metadatas" */
-export type Branch_Metadatas_Obj_Rel_Insert_Input = {
-  data: Branch_Metadatas_Insert_Input;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-/** on conflict condition type for table "branch_metadatas" */
-export type Branch_Metadatas_On_Conflict = {
-  constraint: Branch_Metadatas_Constraint;
-  update_columns: Array<Branch_Metadatas_Update_Column>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "branch_metadatas" */
-export type Branch_Metadatas_Order_By = {
-  commit?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  model_key?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "branch_metadatas" */
-export type Branch_Metadatas_Pk_Columns_Input = {
-  id: Scalars['Int'];
-};
-
-/** select columns of table "branch_metadatas" */
-export enum Branch_Metadatas_Select_Column {
-  /** column name */
-  Commit = 'commit',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  ModelKey = 'model_key',
-  /** column name */
-  Timestamp = 'timestamp'
-}
-
-/** input type for updating data in table "branch_metadatas" */
-export type Branch_Metadatas_Set_Input = {
-  commit?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  model_key?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Branch_Metadatas_Stddev_Fields = {
-  __typename?: 'branch_metadatas_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Branch_Metadatas_Stddev_Pop_Fields = {
-  __typename?: 'branch_metadatas_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Branch_Metadatas_Stddev_Samp_Fields = {
-  __typename?: 'branch_metadatas_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Branch_Metadatas_Sum_Fields = {
-  __typename?: 'branch_metadatas_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  timestamp?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** update columns of table "branch_metadatas" */
-export enum Branch_Metadatas_Update_Column {
-  /** column name */
-  Commit = 'commit',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  ModelKey = 'model_key',
-  /** column name */
-  Timestamp = 'timestamp'
-}
-
-/** aggregate var_pop on columns */
-export type Branch_Metadatas_Var_Pop_Fields = {
-  __typename?: 'branch_metadatas_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Branch_Metadatas_Var_Samp_Fields = {
-  __typename?: 'branch_metadatas_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Branch_Metadatas_Variance_Fields = {
-  __typename?: 'branch_metadatas_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  timestamp?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "branch_metadatas" */
-export type Branch_Metadatas_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  timestamp?: Maybe<Order_By>;
-};
-
 /**
  * Dashboard Item Configs are the inputs that configure a DashboardItem.
  *
@@ -1629,7 +4630,6 @@ export type Dashboard_Item_Configs = {
   dashboardRenderableType: Dashboard_Renderable_Types_Enum;
   /** An object relationship */
   dashboardSection: Dashboard_Sections;
-  dashboardSectionId: Scalars['Int'];
   id: Scalars['Int'];
   /** An object relationship */
   metricCollection?: Maybe<Metric_Collections>;
@@ -1700,7 +4700,6 @@ export type Dashboard_Item_Configs_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Dashboard_Item_Configs_Avg_Fields = {
   __typename?: 'dashboard_item_configs_avg_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1711,7 +4710,6 @@ export type Dashboard_Item_Configs_Avg_Fields = {
 
 /** order by avg() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Avg_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1727,7 +4725,6 @@ export type Dashboard_Item_Configs_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Dashboard_Item_Configs_Bool_Exp>>>;
   dashboardRenderableType?: Maybe<Dashboard_Renderable_Types_Enum_Comparison_Exp>;
   dashboardSection?: Maybe<Dashboard_Sections_Bool_Exp>;
-  dashboardSectionId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metricCollection?: Maybe<Metric_Collections_Bool_Exp>;
   metricCollectionId?: Maybe<Int_Comparison_Exp>;
@@ -1750,7 +4747,6 @@ export enum Dashboard_Item_Configs_Constraint {
 /** input type for incrementing integer column in table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Inc_Input = {
   dashboardSectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
@@ -1763,7 +4759,6 @@ export type Dashboard_Item_Configs_Insert_Input = {
   dashboardRenderableType?: Maybe<Dashboard_Renderable_Types_Enum>;
   dashboardSection?: Maybe<Dashboard_Sections_Obj_Rel_Insert_Input>;
   dashboardSectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1779,7 +4774,6 @@ export type Dashboard_Item_Configs_Insert_Input = {
 /** aggregate max on columns */
 export type Dashboard_Item_Configs_Max_Fields = {
   __typename?: 'dashboard_item_configs_max_fields';
-  dashboardSectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1792,7 +4786,6 @@ export type Dashboard_Item_Configs_Max_Fields = {
 
 /** order by max() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Max_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1806,7 +4799,6 @@ export type Dashboard_Item_Configs_Max_Order_By = {
 /** aggregate min on columns */
 export type Dashboard_Item_Configs_Min_Fields = {
   __typename?: 'dashboard_item_configs_min_fields';
-  dashboardSectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1819,7 +4811,6 @@ export type Dashboard_Item_Configs_Min_Fields = {
 
 /** order by min() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Min_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1856,7 +4847,6 @@ export type Dashboard_Item_Configs_On_Conflict = {
 export type Dashboard_Item_Configs_Order_By = {
   dashboardRenderableType?: Maybe<Order_By>;
   dashboardSection?: Maybe<Dashboard_Sections_Order_By>;
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollection?: Maybe<Metric_Collections_Order_By>;
   metricCollectionId?: Maybe<Order_By>;
@@ -1880,8 +4870,6 @@ export enum Dashboard_Item_Configs_Select_Column {
   /** column name */
   DashboardRenderableType = 'dashboardRenderableType',
   /** column name */
-  DashboardSectionId = 'dashboardSectionId',
-  /** column name */
   Id = 'id',
   /** column name */
   MetricCollectionId = 'metricCollectionId',
@@ -1903,7 +4891,6 @@ export enum Dashboard_Item_Configs_Select_Column {
 export type Dashboard_Item_Configs_Set_Input = {
   dashboardRenderableType?: Maybe<Dashboard_Renderable_Types_Enum>;
   dashboardSectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
@@ -1916,7 +4903,6 @@ export type Dashboard_Item_Configs_Set_Input = {
 /** aggregate stddev on columns */
 export type Dashboard_Item_Configs_Stddev_Fields = {
   __typename?: 'dashboard_item_configs_stddev_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1927,7 +4913,6 @@ export type Dashboard_Item_Configs_Stddev_Fields = {
 
 /** order by stddev() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Stddev_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1939,7 +4924,6 @@ export type Dashboard_Item_Configs_Stddev_Order_By = {
 /** aggregate stddev_pop on columns */
 export type Dashboard_Item_Configs_Stddev_Pop_Fields = {
   __typename?: 'dashboard_item_configs_stddev_pop_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1950,7 +4934,6 @@ export type Dashboard_Item_Configs_Stddev_Pop_Fields = {
 
 /** order by stddev_pop() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Stddev_Pop_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1962,7 +4945,6 @@ export type Dashboard_Item_Configs_Stddev_Pop_Order_By = {
 /** aggregate stddev_samp on columns */
 export type Dashboard_Item_Configs_Stddev_Samp_Fields = {
   __typename?: 'dashboard_item_configs_stddev_samp_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -1973,7 +4955,6 @@ export type Dashboard_Item_Configs_Stddev_Samp_Fields = {
 
 /** order by stddev_samp() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Stddev_Samp_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -1985,7 +4966,6 @@ export type Dashboard_Item_Configs_Stddev_Samp_Order_By = {
 /** aggregate sum on columns */
 export type Dashboard_Item_Configs_Sum_Fields = {
   __typename?: 'dashboard_item_configs_sum_fields';
-  dashboardSectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
@@ -1996,7 +4976,6 @@ export type Dashboard_Item_Configs_Sum_Fields = {
 
 /** order by sum() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Sum_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2011,8 +4990,6 @@ export enum Dashboard_Item_Configs_Update_Column {
   DashboardRenderableType = 'dashboardRenderableType',
   /** column name */
   DashboardSectionId = 'dashboardSectionId',
-  /** column name */
-  Id = 'id',
   /** column name */
   MetricCollectionId = 'metricCollectionId',
   /** column name */
@@ -2032,7 +5009,6 @@ export enum Dashboard_Item_Configs_Update_Column {
 /** aggregate var_pop on columns */
 export type Dashboard_Item_Configs_Var_Pop_Fields = {
   __typename?: 'dashboard_item_configs_var_pop_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -2043,7 +5019,6 @@ export type Dashboard_Item_Configs_Var_Pop_Fields = {
 
 /** order by var_pop() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Var_Pop_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2055,7 +5030,6 @@ export type Dashboard_Item_Configs_Var_Pop_Order_By = {
 /** aggregate var_samp on columns */
 export type Dashboard_Item_Configs_Var_Samp_Fields = {
   __typename?: 'dashboard_item_configs_var_samp_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -2066,7 +5040,6 @@ export type Dashboard_Item_Configs_Var_Samp_Fields = {
 
 /** order by var_samp() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Var_Samp_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2078,7 +5051,6 @@ export type Dashboard_Item_Configs_Var_Samp_Order_By = {
 /** aggregate variance on columns */
 export type Dashboard_Item_Configs_Variance_Fields = {
   __typename?: 'dashboard_item_configs_variance_fields';
-  dashboardSectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricCollectionId?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
@@ -2089,7 +5061,6 @@ export type Dashboard_Item_Configs_Variance_Fields = {
 
 /** order by variance() on columns of table "dashboard_item_configs" */
 export type Dashboard_Item_Configs_Variance_Order_By = {
-  dashboardSectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollectionId?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
@@ -2097,68 +5068,6 @@ export type Dashboard_Item_Configs_Variance_Order_By = {
   teamId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
-
-/**
- * Enum for the possible layouts for a Dashboard
- *
- *
- * columns and relationships of "dashboard_layouts"
- */
-export type Dashboard_Layouts = {
-  __typename?: 'dashboard_layouts';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate = {
-  __typename?: 'dashboard_layouts_aggregate';
-  aggregate?: Maybe<Dashboard_Layouts_Aggregate_Fields>;
-  nodes: Array<Dashboard_Layouts>;
-};
-
-/** aggregate fields of "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate_Fields = {
-  __typename?: 'dashboard_layouts_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dashboard_Layouts_Max_Fields>;
-  min?: Maybe<Dashboard_Layouts_Min_Fields>;
-};
-
-
-/** aggregate fields of "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dashboard_layouts" */
-export type Dashboard_Layouts_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dashboard_Layouts_Max_Order_By>;
-  min?: Maybe<Dashboard_Layouts_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dashboard_layouts" */
-export type Dashboard_Layouts_Arr_Rel_Insert_Input = {
-  data: Array<Dashboard_Layouts_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dashboard_layouts". All fields are combined with a logical 'AND'. */
-export type Dashboard_Layouts_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dashboard_Layouts_Bool_Exp>>>;
-  _not?: Maybe<Dashboard_Layouts_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dashboard_Layouts_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dashboard_layouts" */
-export enum Dashboard_Layouts_Constraint {
-  /** unique or primary key constraint */
-  DashboardLayoutsPkey = 'dashboard_layouts_pkey'
-}
 
 export enum Dashboard_Layouts_Enum {
   /** This version has a side panel that collapses on small breakpoint. */
@@ -2175,155 +5084,6 @@ export type Dashboard_Layouts_Enum_Comparison_Exp = {
   _neq?: Maybe<Dashboard_Layouts_Enum>;
   _nin?: Maybe<Array<Dashboard_Layouts_Enum>>;
 };
-
-/** input type for inserting data into table "dashboard_layouts" */
-export type Dashboard_Layouts_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dashboard_Layouts_Max_Fields = {
-  __typename?: 'dashboard_layouts_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dashboard_layouts" */
-export type Dashboard_Layouts_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dashboard_Layouts_Min_Fields = {
-  __typename?: 'dashboard_layouts_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dashboard_layouts" */
-export type Dashboard_Layouts_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dashboard_layouts" */
-export type Dashboard_Layouts_Mutation_Response = {
-  __typename?: 'dashboard_layouts_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dashboard_Layouts>;
-};
-
-/** input type for inserting object relation for remote table "dashboard_layouts" */
-export type Dashboard_Layouts_Obj_Rel_Insert_Input = {
-  data: Dashboard_Layouts_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-/** on conflict condition type for table "dashboard_layouts" */
-export type Dashboard_Layouts_On_Conflict = {
-  constraint: Dashboard_Layouts_Constraint;
-  update_columns: Array<Dashboard_Layouts_Update_Column>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dashboard_layouts" */
-export type Dashboard_Layouts_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dashboard_layouts" */
-export type Dashboard_Layouts_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dashboard_layouts" */
-export enum Dashboard_Layouts_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dashboard_layouts" */
-export type Dashboard_Layouts_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dashboard_layouts" */
-export enum Dashboard_Layouts_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/**
- * Enum for Dashboard Renderable components. Note: It is expected that this be replaced by an Interface shortly.
- *
- *
- * columns and relationships of "dashboard_renderable_types"
- */
-export type Dashboard_Renderable_Types = {
-  __typename?: 'dashboard_renderable_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate = {
-  __typename?: 'dashboard_renderable_types_aggregate';
-  aggregate?: Maybe<Dashboard_Renderable_Types_Aggregate_Fields>;
-  nodes: Array<Dashboard_Renderable_Types>;
-};
-
-/** aggregate fields of "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate_Fields = {
-  __typename?: 'dashboard_renderable_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dashboard_Renderable_Types_Max_Fields>;
-  min?: Maybe<Dashboard_Renderable_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dashboard_Renderable_Types_Max_Order_By>;
-  min?: Maybe<Dashboard_Renderable_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Arr_Rel_Insert_Input = {
-  data: Array<Dashboard_Renderable_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dashboard_renderable_types". All fields are combined with a logical 'AND'. */
-export type Dashboard_Renderable_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dashboard_Renderable_Types_Bool_Exp>>>;
-  _not?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dashboard_Renderable_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dashboard_renderable_types" */
-export enum Dashboard_Renderable_Types_Constraint {
-  /** unique or primary key constraint */
-  DashboardRenderableTypesPkey = 'dashboard_renderable_types_pkey'
-}
 
 export enum Dashboard_Renderable_Types_Enum {
   /** Banners can let users know what's happening or be used as a page title. */
@@ -2353,155 +5113,6 @@ export type Dashboard_Renderable_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Dashboard_Renderable_Types_Enum>>;
 };
 
-/** input type for inserting data into table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dashboard_Renderable_Types_Max_Fields = {
-  __typename?: 'dashboard_renderable_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dashboard_Renderable_Types_Min_Fields = {
-  __typename?: 'dashboard_renderable_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Mutation_Response = {
-  __typename?: 'dashboard_renderable_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dashboard_Renderable_Types>;
-};
-
-/** input type for inserting object relation for remote table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Obj_Rel_Insert_Input = {
-  data: Dashboard_Renderable_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_On_Conflict = {
-  constraint: Dashboard_Renderable_Types_Constraint;
-  update_columns: Array<Dashboard_Renderable_Types_Update_Column>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dashboard_renderable_types" */
-export enum Dashboard_Renderable_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dashboard_renderable_types" */
-export type Dashboard_Renderable_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dashboard_renderable_types" */
-export enum Dashboard_Renderable_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/**
- * An Enum for the various Section Types on a Dashboard
- *
- *
- * columns and relationships of "dashboard_section_types"
- */
-export type Dashboard_Section_Types = {
-  __typename?: 'dashboard_section_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate = {
-  __typename?: 'dashboard_section_types_aggregate';
-  aggregate?: Maybe<Dashboard_Section_Types_Aggregate_Fields>;
-  nodes: Array<Dashboard_Section_Types>;
-};
-
-/** aggregate fields of "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate_Fields = {
-  __typename?: 'dashboard_section_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dashboard_Section_Types_Max_Fields>;
-  min?: Maybe<Dashboard_Section_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dashboard_section_types" */
-export type Dashboard_Section_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dashboard_Section_Types_Max_Order_By>;
-  min?: Maybe<Dashboard_Section_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dashboard_section_types" */
-export type Dashboard_Section_Types_Arr_Rel_Insert_Input = {
-  data: Array<Dashboard_Section_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dashboard_section_types". All fields are combined with a logical 'AND'. */
-export type Dashboard_Section_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dashboard_Section_Types_Bool_Exp>>>;
-  _not?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dashboard_Section_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dashboard_section_types" */
-export enum Dashboard_Section_Types_Constraint {
-  /** unique or primary key constraint */
-  DashboardSectionTypesPkey = 'dashboard_section_types_pkey'
-}
-
 export enum Dashboard_Section_Types_Enum {
   /** The Header appears at the top of the Dashboard and remains sticky during scrolling. */
   Header = 'HEADER',
@@ -2520,93 +5131,6 @@ export type Dashboard_Section_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Dashboard_Section_Types_Enum>>;
 };
 
-/** input type for inserting data into table "dashboard_section_types" */
-export type Dashboard_Section_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dashboard_Section_Types_Max_Fields = {
-  __typename?: 'dashboard_section_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dashboard_section_types" */
-export type Dashboard_Section_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dashboard_Section_Types_Min_Fields = {
-  __typename?: 'dashboard_section_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dashboard_section_types" */
-export type Dashboard_Section_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dashboard_section_types" */
-export type Dashboard_Section_Types_Mutation_Response = {
-  __typename?: 'dashboard_section_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dashboard_Section_Types>;
-};
-
-/** input type for inserting object relation for remote table "dashboard_section_types" */
-export type Dashboard_Section_Types_Obj_Rel_Insert_Input = {
-  data: Dashboard_Section_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "dashboard_section_types" */
-export type Dashboard_Section_Types_On_Conflict = {
-  constraint: Dashboard_Section_Types_Constraint;
-  update_columns: Array<Dashboard_Section_Types_Update_Column>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dashboard_section_types" */
-export type Dashboard_Section_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dashboard_section_types" */
-export type Dashboard_Section_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dashboard_section_types" */
-export enum Dashboard_Section_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dashboard_section_types" */
-export type Dashboard_Section_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dashboard_section_types" */
-export enum Dashboard_Section_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
 /**
  * Dashboard Sections are logical groupings of Dashboard Items within the UI. The type specifies where the section appears on the page.
  *
@@ -2623,7 +5147,6 @@ export type Dashboard_Sections = {
   dashboardItemConfigs_aggregate: Dashboard_Item_Configs_Aggregate;
   /** The Section Type indicates the "zone" on page where the section's items will go. */
   dashboardSectionType: Dashboard_Section_Types_Enum;
-  dashboard_id: Scalars['Int'];
   id: Scalars['Int'];
 };
 
@@ -2711,13 +5234,11 @@ export type Dashboard_Sections_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Dashboard_Sections_Avg_Fields = {
   __typename?: 'dashboard_sections_avg_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Avg_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2729,7 +5250,6 @@ export type Dashboard_Sections_Bool_Exp = {
   dashboard?: Maybe<Dashboards_Bool_Exp>;
   dashboardItemConfigs?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
   dashboardSectionType?: Maybe<Dashboard_Section_Types_Enum_Comparison_Exp>;
-  dashboard_id?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
 };
 
@@ -2739,44 +5259,33 @@ export enum Dashboard_Sections_Constraint {
   DashboardSectionsPkey = 'dashboard_sections_pkey'
 }
 
-/** input type for incrementing integer column in table "dashboard_sections" */
-export type Dashboard_Sections_Inc_Input = {
-  dashboard_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "dashboard_sections" */
 export type Dashboard_Sections_Insert_Input = {
   dashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
   dashboardItemConfigs?: Maybe<Dashboard_Item_Configs_Arr_Rel_Insert_Input>;
   dashboardSectionType?: Maybe<Dashboard_Section_Types_Enum>;
   dashboard_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Dashboard_Sections_Max_Fields = {
   __typename?: 'dashboard_sections_max_fields';
-  dashboard_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Max_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Dashboard_Sections_Min_Fields = {
   __typename?: 'dashboard_sections_min_fields';
-  dashboard_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Min_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2807,7 +5316,6 @@ export type Dashboard_Sections_Order_By = {
   dashboard?: Maybe<Dashboards_Order_By>;
   dashboardItemConfigs_aggregate?: Maybe<Dashboard_Item_Configs_Aggregate_Order_By>;
   dashboardSectionType?: Maybe<Order_By>;
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2821,116 +5329,94 @@ export enum Dashboard_Sections_Select_Column {
   /** column name */
   DashboardSectionType = 'dashboardSectionType',
   /** column name */
-  DashboardId = 'dashboard_id',
-  /** column name */
   Id = 'id'
 }
 
 /** input type for updating data in table "dashboard_sections" */
 export type Dashboard_Sections_Set_Input = {
   dashboardSectionType?: Maybe<Dashboard_Section_Types_Enum>;
-  dashboard_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type Dashboard_Sections_Stddev_Fields = {
   __typename?: 'dashboard_sections_stddev_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Stddev_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Dashboard_Sections_Stddev_Pop_Fields = {
   __typename?: 'dashboard_sections_stddev_pop_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Stddev_Pop_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Dashboard_Sections_Stddev_Samp_Fields = {
   __typename?: 'dashboard_sections_stddev_samp_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Stddev_Samp_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Dashboard_Sections_Sum_Fields = {
   __typename?: 'dashboard_sections_sum_fields';
-  dashboard_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Sum_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** update columns of table "dashboard_sections" */
 export enum Dashboard_Sections_Update_Column {
   /** column name */
-  DashboardSectionType = 'dashboardSectionType',
-  /** column name */
-  DashboardId = 'dashboard_id',
-  /** column name */
-  Id = 'id'
+  DashboardSectionType = 'dashboardSectionType'
 }
 
 /** aggregate var_pop on columns */
 export type Dashboard_Sections_Var_Pop_Fields = {
   __typename?: 'dashboard_sections_var_pop_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Var_Pop_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Dashboard_Sections_Var_Samp_Fields = {
   __typename?: 'dashboard_sections_var_samp_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Var_Samp_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Dashboard_Sections_Variance_Fields = {
   __typename?: 'dashboard_sections_variance_fields';
-  dashboard_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "dashboard_sections" */
 export type Dashboard_Sections_Variance_Order_By = {
-  dashboard_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
 };
 
@@ -2948,11 +5434,9 @@ export type Dashboards = {
   dashboardSections: Array<Dashboard_Sections>;
   /** An aggregated array relationship */
   dashboardSections_aggregate: Dashboard_Sections_Aggregate;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organization_id: Scalars['Int'];
   /** An array relationship */
   teamOwners: Array<Team_Dashboards>;
   /** An aggregated array relationship */
@@ -2960,10 +5444,6 @@ export type Dashboards = {
   /** The Dashboard title appears in the header */
   title: Scalars['String'];
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  /** An array relationship */
-  userOwners: Array<User_Dashboards>;
-  /** An aggregated array relationship */
-  userOwners_aggregate: User_Dashboards_Aggregate;
 };
 
 
@@ -3026,36 +5506,6 @@ export type DashboardsTeamOwners_AggregateArgs = {
   where?: Maybe<Team_Dashboards_Bool_Exp>;
 };
 
-
-/**
- * Dashboards are a foundational tool for building custom pages in the Transform App
- *
- *
- * columns and relationships of "dashboards"
- */
-export type DashboardsUserOwnersArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/**
- * Dashboards are a foundational tool for building custom pages in the Transform App
- *
- *
- * columns and relationships of "dashboards"
- */
-export type DashboardsUserOwners_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
 /** aggregated selection of "dashboards" */
 export type Dashboards_Aggregate = {
   __typename?: 'dashboards_aggregate';
@@ -3111,13 +5561,11 @@ export type Dashboards_Arr_Rel_Insert_Input = {
 export type Dashboards_Avg_Fields = {
   __typename?: 'dashboards_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "dashboards" */
 export type Dashboards_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "dashboards". All fields are combined with a logical 'AND'. */
@@ -3128,14 +5576,11 @@ export type Dashboards_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   dashboardLayout?: Maybe<Dashboard_Layouts_Enum_Comparison_Exp>;
   dashboardSections?: Maybe<Dashboard_Sections_Bool_Exp>;
-  deletedAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
   teamOwners?: Maybe<Team_Dashboards_Bool_Exp>;
   title?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  userOwners?: Maybe<User_Dashboards_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "dashboards" */
@@ -3144,34 +5589,19 @@ export enum Dashboards_Constraint {
   DashboardsPkey = 'dashboards_pkey'
 }
 
-/** input type for incrementing integer column in table "dashboards" */
-export type Dashboards_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "dashboards" */
 export type Dashboards_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dashboardLayout?: Maybe<Dashboard_Layouts_Enum>;
   dashboardSections?: Maybe<Dashboard_Sections_Arr_Rel_Insert_Input>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organization_id?: Maybe<Scalars['Int']>;
   teamOwners?: Maybe<Team_Dashboards_Arr_Rel_Insert_Input>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userOwners?: Maybe<User_Dashboards_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
 export type Dashboards_Max_Fields = {
   __typename?: 'dashboards_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -3179,9 +5609,7 @@ export type Dashboards_Max_Fields = {
 /** order by max() on columns of table "dashboards" */
 export type Dashboards_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -3190,9 +5618,7 @@ export type Dashboards_Max_Order_By = {
 export type Dashboards_Min_Fields = {
   __typename?: 'dashboards_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -3200,9 +5626,7 @@ export type Dashboards_Min_Fields = {
 /** order by min() on columns of table "dashboards" */
 export type Dashboards_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -3234,14 +5658,11 @@ export type Dashboards_Order_By = {
   createdAt?: Maybe<Order_By>;
   dashboardLayout?: Maybe<Order_By>;
   dashboardSections_aggregate?: Maybe<Dashboard_Sections_Aggregate_Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organization_id?: Maybe<Order_By>;
   teamOwners_aggregate?: Maybe<Team_Dashboards_Aggregate_Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  userOwners_aggregate?: Maybe<User_Dashboards_Aggregate_Order_By>;
 };
 
 /** primary key columns input for table: "dashboards" */
@@ -3256,11 +5677,7 @@ export enum Dashboards_Select_Column {
   /** column name */
   DashboardLayout = 'dashboardLayout',
   /** column name */
-  DeletedAt = 'deletedAt',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
   /** column name */
   Title = 'title',
   /** column name */
@@ -3269,122 +5686,96 @@ export enum Dashboards_Select_Column {
 
 /** input type for updating data in table "dashboards" */
 export type Dashboards_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dashboardLayout?: Maybe<Dashboard_Layouts_Enum>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Dashboards_Stddev_Fields = {
   __typename?: 'dashboards_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "dashboards" */
 export type Dashboards_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Dashboards_Stddev_Pop_Fields = {
   __typename?: 'dashboards_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "dashboards" */
 export type Dashboards_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Dashboards_Stddev_Samp_Fields = {
   __typename?: 'dashboards_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "dashboards" */
 export type Dashboards_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Dashboards_Sum_Fields = {
   __typename?: 'dashboards_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "dashboards" */
 export type Dashboards_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** update columns of table "dashboards" */
 export enum Dashboards_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
   DashboardLayout = 'dashboardLayout',
   /** column name */
   DeletedAt = 'deletedAt',
   /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
 export type Dashboards_Var_Pop_Fields = {
   __typename?: 'dashboards_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "dashboards" */
 export type Dashboards_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Dashboards_Var_Samp_Fields = {
   __typename?: 'dashboards_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "dashboards" */
 export type Dashboards_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Dashboards_Variance_Fields = {
   __typename?: 'dashboards_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "dashboards" */
 export type Dashboards_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "data_source_versions" */
@@ -3413,7 +5804,6 @@ export type Data_Source_Versions = {
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
-  owners: Scalars['json'];
   sqlQuery?: Maybe<Scalars['String']>;
   sqlTable?: Maybe<Scalars['String']>;
 };
@@ -3494,12 +5884,6 @@ export type Data_Source_VersionsMutabilityArgs = {
   path?: Maybe<Scalars['String']>;
 };
 
-
-/** columns and relationships of "data_source_versions" */
-export type Data_Source_VersionsOwnersArgs = {
-  path?: Maybe<Scalars['String']>;
-};
-
 /** aggregated selection of "data_source_versions" */
 export type Data_Source_Versions_Aggregate = {
   __typename?: 'data_source_versions_aggregate';
@@ -3545,12 +5929,6 @@ export type Data_Source_Versions_Aggregate_Order_By = {
   variance?: Maybe<Data_Source_Versions_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "data_source_versions" */
-export type Data_Source_Versions_Arr_Rel_Insert_Input = {
-  data: Array<Data_Source_Versions_Insert_Input>;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Data_Source_Versions_Avg_Fields = {
   __typename?: 'data_source_versions_avg_fields';
@@ -3585,46 +5963,8 @@ export type Data_Source_Versions_Bool_Exp = {
   name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
-  owners?: Maybe<Json_Comparison_Exp>;
   sqlQuery?: Maybe<String_Comparison_Exp>;
   sqlTable?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "data_source_versions" */
-export enum Data_Source_Versions_Constraint {
-  /** unique or primary key constraint */
-  DataSourceVersionsHashOrganizationIdKey = 'data_source_versions_hash_organization_id_key',
-  /** unique or primary key constraint */
-  DataSourceVersionsPkey = 'data_source_versions_pkey'
-}
-
-/** input type for incrementing integer column in table "data_source_versions" */
-export type Data_Source_Versions_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "data_source_versions" */
-export type Data_Source_Versions_Insert_Input = {
-  connection?: Maybe<Scalars['String']>;
-  constraint?: Maybe<Scalars['json']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceMetadata?: Maybe<Scalars['json']>;
-  description?: Maybe<Scalars['String']>;
-  dimensions?: Maybe<Scalars['json']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  identifiers?: Maybe<Scalars['json']>;
-  measures?: Maybe<Scalars['json']>;
-  metricVersions?: Maybe<Metric_Lineage_Data_Sources_Arr_Rel_Insert_Input>;
-  modelDataSources?: Maybe<Model_Data_Sources_Arr_Rel_Insert_Input>;
-  mutability?: Maybe<Scalars['json']>;
-  name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  owners?: Maybe<Scalars['json']>;
-  sqlQuery?: Maybe<Scalars['String']>;
-  sqlTable?: Maybe<Scalars['String']>;
 };
 
 /** aggregate max on columns */
@@ -3681,28 +6021,6 @@ export type Data_Source_Versions_Min_Order_By = {
   sqlTable?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "data_source_versions" */
-export type Data_Source_Versions_Mutation_Response = {
-  __typename?: 'data_source_versions_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Data_Source_Versions>;
-};
-
-/** input type for inserting object relation for remote table "data_source_versions" */
-export type Data_Source_Versions_Obj_Rel_Insert_Input = {
-  data: Data_Source_Versions_Insert_Input;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
-/** on conflict condition type for table "data_source_versions" */
-export type Data_Source_Versions_On_Conflict = {
-  constraint: Data_Source_Versions_Constraint;
-  update_columns: Array<Data_Source_Versions_Update_Column>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "data_source_versions" */
 export type Data_Source_Versions_Order_By = {
   connection?: Maybe<Order_By>;
@@ -3721,7 +6039,6 @@ export type Data_Source_Versions_Order_By = {
   name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
-  owners?: Maybe<Order_By>;
   sqlQuery?: Maybe<Order_By>;
   sqlTable?: Maybe<Order_By>;
 };
@@ -3760,32 +6077,10 @@ export enum Data_Source_Versions_Select_Column {
   /** column name */
   OrganizationId = 'organizationId',
   /** column name */
-  Owners = 'owners',
-  /** column name */
   SqlQuery = 'sqlQuery',
   /** column name */
   SqlTable = 'sqlTable'
 }
-
-/** input type for updating data in table "data_source_versions" */
-export type Data_Source_Versions_Set_Input = {
-  connection?: Maybe<Scalars['String']>;
-  constraint?: Maybe<Scalars['json']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceMetadata?: Maybe<Scalars['json']>;
-  description?: Maybe<Scalars['String']>;
-  dimensions?: Maybe<Scalars['json']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  identifiers?: Maybe<Scalars['json']>;
-  measures?: Maybe<Scalars['json']>;
-  mutability?: Maybe<Scalars['json']>;
-  name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  owners?: Maybe<Scalars['json']>;
-  sqlQuery?: Maybe<Scalars['String']>;
-  sqlTable?: Maybe<Scalars['String']>;
-};
 
 /** aggregate stddev on columns */
 export type Data_Source_Versions_Stddev_Fields = {
@@ -3839,42 +6134,6 @@ export type Data_Source_Versions_Sum_Order_By = {
   organizationId?: Maybe<Order_By>;
 };
 
-/** update columns of table "data_source_versions" */
-export enum Data_Source_Versions_Update_Column {
-  /** column name */
-  Connection = 'connection',
-  /** column name */
-  Constraint = 'constraint',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DataSourceMetadata = 'dataSourceMetadata',
-  /** column name */
-  Description = 'description',
-  /** column name */
-  Dimensions = 'dimensions',
-  /** column name */
-  Hash = 'hash',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Identifiers = 'identifiers',
-  /** column name */
-  Measures = 'measures',
-  /** column name */
-  Mutability = 'mutability',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Owners = 'owners',
-  /** column name */
-  SqlQuery = 'sqlQuery',
-  /** column name */
-  SqlTable = 'sqlTable'
-}
-
 /** aggregate var_pop on columns */
 export type Data_Source_Versions_Var_Pop_Fields = {
   __typename?: 'data_source_versions_var_pop_fields';
@@ -3926,192 +6185,6 @@ export type Date_Comparison_Exp = {
   _lte?: Maybe<Scalars['date']>;
   _neq?: Maybe<Scalars['date']>;
   _nin?: Maybe<Array<Scalars['date']>>;
-};
-
-/** columns and relationships of "dw_engines" */
-export type Dw_Engines = {
-  __typename?: 'dw_engines';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "dw_engines" */
-export type Dw_Engines_Aggregate = {
-  __typename?: 'dw_engines_aggregate';
-  aggregate?: Maybe<Dw_Engines_Aggregate_Fields>;
-  nodes: Array<Dw_Engines>;
-};
-
-/** aggregate fields of "dw_engines" */
-export type Dw_Engines_Aggregate_Fields = {
-  __typename?: 'dw_engines_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Dw_Engines_Max_Fields>;
-  min?: Maybe<Dw_Engines_Min_Fields>;
-};
-
-
-/** aggregate fields of "dw_engines" */
-export type Dw_Engines_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Dw_Engines_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "dw_engines" */
-export type Dw_Engines_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Dw_Engines_Max_Order_By>;
-  min?: Maybe<Dw_Engines_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "dw_engines" */
-export type Dw_Engines_Arr_Rel_Insert_Input = {
-  data: Array<Dw_Engines_Insert_Input>;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "dw_engines". All fields are combined with a logical 'AND'. */
-export type Dw_Engines_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Dw_Engines_Bool_Exp>>>;
-  _not?: Maybe<Dw_Engines_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Dw_Engines_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "dw_engines" */
-export enum Dw_Engines_Constraint {
-  /** unique or primary key constraint */
-  DwEnginesPkey = 'dw_engines_pkey'
-}
-
-export enum Dw_Engines_Enum {
-  /** Data Bricks */
-  Databricks = 'DATABRICKS',
-  /** Livy */
-  Livy = 'LIVY',
-  /** mysql */
-  Mysql = 'MYSQL',
-  /** postgresql */
-  Postgresql = 'POSTGRESQL',
-  /** Presto Hive */
-  PrestoHive = 'PRESTO_HIVE',
-  /** Redshift */
-  Redshift = 'REDSHIFT',
-  /** Snowflake */
-  Snowflake = 'SNOWFLAKE',
-  /** sqlite */
-  Sqlite = 'SQLITE'
-}
-
-/** expression to compare columns of type dw_engines_enum. All fields are combined with logical 'AND'. */
-export type Dw_Engines_Enum_Comparison_Exp = {
-  _eq?: Maybe<Dw_Engines_Enum>;
-  _in?: Maybe<Array<Dw_Engines_Enum>>;
-  _is_null?: Maybe<Scalars['Boolean']>;
-  _neq?: Maybe<Dw_Engines_Enum>;
-  _nin?: Maybe<Array<Dw_Engines_Enum>>;
-};
-
-/** input type for inserting data into table "dw_engines" */
-export type Dw_Engines_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Dw_Engines_Max_Fields = {
-  __typename?: 'dw_engines_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "dw_engines" */
-export type Dw_Engines_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Dw_Engines_Min_Fields = {
-  __typename?: 'dw_engines_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "dw_engines" */
-export type Dw_Engines_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "dw_engines" */
-export type Dw_Engines_Mutation_Response = {
-  __typename?: 'dw_engines_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Dw_Engines>;
-};
-
-/** input type for inserting object relation for remote table "dw_engines" */
-export type Dw_Engines_Obj_Rel_Insert_Input = {
-  data: Dw_Engines_Insert_Input;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-/** on conflict condition type for table "dw_engines" */
-export type Dw_Engines_On_Conflict = {
-  constraint: Dw_Engines_Constraint;
-  update_columns: Array<Dw_Engines_Update_Column>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "dw_engines" */
-export type Dw_Engines_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "dw_engines" */
-export type Dw_Engines_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "dw_engines" */
-export enum Dw_Engines_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "dw_engines" */
-export type Dw_Engines_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "dw_engines" */
-export enum Dw_Engines_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-
-/** expression to compare columns of type entity. All fields are combined with logical 'AND'. */
-export type Entity_Comparison_Exp = {
-  _eq?: Maybe<Scalars['entity']>;
-  _gt?: Maybe<Scalars['entity']>;
-  _gte?: Maybe<Scalars['entity']>;
-  _in?: Maybe<Array<Scalars['entity']>>;
-  _is_null?: Maybe<Scalars['Boolean']>;
-  _lt?: Maybe<Scalars['entity']>;
-  _lte?: Maybe<Scalars['entity']>;
-  _neq?: Maybe<Scalars['entity']>;
-  _nin?: Maybe<Array<Scalars['entity']>>;
 };
 
 /** columns and relationships of "features" */
@@ -4217,12 +6290,6 @@ export type Features_Aggregate_Order_By = {
   variance?: Maybe<Features_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "features" */
-export type Features_Arr_Rel_Insert_Input = {
-  data: Array<Features_Insert_Input>;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Features_Avg_Fields = {
   __typename?: 'features_avg_fields';
@@ -4246,28 +6313,6 @@ export type Features_Bool_Exp = {
   retiredAt?: Maybe<Timestamptz_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   users?: Maybe<User_Features_Bool_Exp>;
-};
-
-/** unique or primary key constraints on table "features" */
-export enum Features_Constraint {
-  /** unique or primary key constraint */
-  FeaturesPkey = 'features_pkey'
-}
-
-/** input type for incrementing integer column in table "features" */
-export type Features_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "features" */
-export type Features_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organizations?: Maybe<Organization_Features_Arr_Rel_Insert_Input>;
-  retiredAt?: Maybe<Scalars['timestamptz']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  users?: Maybe<User_Features_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -4308,28 +6353,6 @@ export type Features_Min_Order_By = {
   updatedAt?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "features" */
-export type Features_Mutation_Response = {
-  __typename?: 'features_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Features>;
-};
-
-/** input type for inserting object relation for remote table "features" */
-export type Features_Obj_Rel_Insert_Input = {
-  data: Features_Insert_Input;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
-/** on conflict condition type for table "features" */
-export type Features_On_Conflict = {
-  constraint: Features_Constraint;
-  update_columns: Array<Features_Update_Column>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "features" */
 export type Features_Order_By = {
   createdAt?: Maybe<Order_By>;
@@ -4359,15 +6382,6 @@ export enum Features_Select_Column {
   /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "features" */
-export type Features_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  retiredAt?: Maybe<Scalars['timestamptz']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Features_Stddev_Fields = {
@@ -4412,20 +6426,6 @@ export type Features_Sum_Fields = {
 export type Features_Sum_Order_By = {
   id?: Maybe<Order_By>;
 };
-
-/** update columns of table "features" */
-export enum Features_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  RetiredAt = 'retiredAt',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
 
 /** aggregate var_pop on columns */
 export type Features_Var_Pop_Fields = {
@@ -4503,19 +6503,13 @@ export type Metric_Annotations = {
   __typename?: 'metric_annotations';
   /** An object relationship */
   annotation: Annotations;
-  annotationId: Scalars['Int'];
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name: Scalars['String'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregated selection of "metric_annotations" */
@@ -4572,18 +6566,12 @@ export type Metric_Annotations_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Metric_Annotations_Avg_Fields = {
   __typename?: 'metric_annotations_avg_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_annotations" */
 export type Metric_Annotations_Avg_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_annotations". All fields are combined with a logical 'AND'. */
@@ -4592,17 +6580,11 @@ export type Metric_Annotations_Bool_Exp = {
   _not?: Maybe<Metric_Annotations_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Annotations_Bool_Exp>>>;
   annotation?: Maybe<Annotations_Bool_Exp>;
-  annotationId?: Maybe<Int_Comparison_Exp>;
-  created_at?: Maybe<Timestamptz_Comparison_Exp>;
   dimensionName?: Maybe<String_Comparison_Exp>;
   dimensionValue?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-  updated_at?: Maybe<Timestamptz_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "metric_annotations" */
@@ -4614,79 +6596,47 @@ export enum Metric_Annotations_Constraint {
 /** input type for incrementing integer column in table "metric_annotations" */
 export type Metric_Annotations_Inc_Input = {
   annotationId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_annotations" */
 export type Metric_Annotations_Insert_Input = {
   annotation?: Maybe<Annotations_Obj_Rel_Insert_Input>;
   annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
   metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Annotations_Max_Fields = {
   __typename?: 'metric_annotations_max_fields';
-  annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "metric_annotations" */
 export type Metric_Annotations_Max_Order_By = {
-  annotationId?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
   dimensionName?: Maybe<Order_By>;
   dimensionValue?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updated_at?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Annotations_Min_Fields = {
   __typename?: 'metric_annotations_min_fields';
-  annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "metric_annotations" */
 export type Metric_Annotations_Min_Order_By = {
-  annotationId?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
   dimensionName?: Maybe<Order_By>;
   dimensionValue?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updated_at?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_annotations" */
@@ -4714,17 +6664,11 @@ export type Metric_Annotations_On_Conflict = {
 /** ordering options when selecting data from "metric_annotations" */
 export type Metric_Annotations_Order_By = {
   annotation?: Maybe<Annotations_Order_By>;
-  annotationId?: Maybe<Order_By>;
-  created_at?: Maybe<Order_By>;
   dimensionName?: Maybe<Order_By>;
   dimensionValue?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updated_at?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_annotations" */
@@ -4735,104 +6679,63 @@ export type Metric_Annotations_Pk_Columns_Input = {
 /** select columns of table "metric_annotations" */
 export enum Metric_Annotations_Select_Column {
   /** column name */
-  AnnotationId = 'annotationId',
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
   DimensionName = 'dimensionName',
   /** column name */
   DimensionValue = 'dimensionValue',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updated_at'
+  Id = 'id'
 }
 
 /** input type for updating data in table "metric_annotations" */
 export type Metric_Annotations_Set_Input = {
   annotationId?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
   dimensionName?: Maybe<Scalars['String']>;
   dimensionValue?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Metric_Annotations_Stddev_Fields = {
   __typename?: 'metric_annotations_stddev_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_annotations" */
 export type Metric_Annotations_Stddev_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Annotations_Stddev_Pop_Fields = {
   __typename?: 'metric_annotations_stddev_pop_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_annotations" */
 export type Metric_Annotations_Stddev_Pop_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Annotations_Stddev_Samp_Fields = {
   __typename?: 'metric_annotations_stddev_samp_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_annotations" */
 export type Metric_Annotations_Stddev_Samp_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Annotations_Sum_Fields = {
   __typename?: 'metric_annotations_sum_fields';
-  annotationId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_annotations" */
 export type Metric_Annotations_Sum_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** update columns of table "metric_annotations" */
@@ -4840,91 +6743,58 @@ export enum Metric_Annotations_Update_Column {
   /** column name */
   AnnotationId = 'annotationId',
   /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
   DimensionName = 'dimensionName',
   /** column name */
   DimensionValue = 'dimensionValue',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updated_at'
+  MetricId = 'metricId'
 }
 
 /** aggregate var_pop on columns */
 export type Metric_Annotations_Var_Pop_Fields = {
   __typename?: 'metric_annotations_var_pop_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_annotations" */
 export type Metric_Annotations_Var_Pop_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Annotations_Var_Samp_Fields = {
   __typename?: 'metric_annotations_var_samp_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_annotations" */
 export type Metric_Annotations_Var_Samp_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Annotations_Variance_Fields = {
   __typename?: 'metric_annotations_variance_fields';
-  annotationId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_annotations" */
 export type Metric_Annotations_Variance_Order_By = {
-  annotationId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "metric_approvals" */
 export type Metric_Approvals = {
   __typename?: 'metric_approvals';
-  approval_ts?: Maybe<Scalars['Int']>;
   /** Timestamp indicating when the approval was created */
   approvedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   approver: Users;
-  approverId: Scalars['Int'];
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_approvals" */
@@ -4975,26 +6845,17 @@ export type Metric_Approvals_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_approvals" */
 export type Metric_Approvals_Arr_Rel_Insert_Input = {
   data: Array<Metric_Approvals_Insert_Input>;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_Approvals_Avg_Fields = {
   __typename?: 'metric_approvals_avg_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_approvals" */
 export type Metric_Approvals_Avg_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_approvals". All fields are combined with a logical 'AND'. */
@@ -5002,91 +6863,43 @@ export type Metric_Approvals_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Metric_Approvals_Bool_Exp>>>;
   _not?: Maybe<Metric_Approvals_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Approvals_Bool_Exp>>>;
-  approval_ts?: Maybe<Int_Comparison_Exp>;
   approvedAt?: Maybe<Timestamptz_Comparison_Exp>;
   approver?: Maybe<Users_Bool_Exp>;
-  approverId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_approvals" */
-export enum Metric_Approvals_Constraint {
-  /** unique or primary key constraint */
-  MetricApprovalsPkey = 'metric_approvals_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_approvals" */
-export type Metric_Approvals_Inc_Input = {
-  approval_ts?: Maybe<Scalars['Int']>;
-  approverId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_approvals" */
 export type Metric_Approvals_Insert_Input = {
-  approval_ts?: Maybe<Scalars['Int']>;
-  approvedAt?: Maybe<Scalars['timestamptz']>;
   approver?: Maybe<Users_Obj_Rel_Insert_Input>;
-  approverId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Approvals_Max_Fields = {
   __typename?: 'metric_approvals_max_fields';
-  approval_ts?: Maybe<Scalars['Int']>;
   approvedAt?: Maybe<Scalars['timestamptz']>;
-  approverId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_approvals" */
 export type Metric_Approvals_Max_Order_By = {
-  approval_ts?: Maybe<Order_By>;
   approvedAt?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Approvals_Min_Fields = {
   __typename?: 'metric_approvals_min_fields';
-  approval_ts?: Maybe<Scalars['Int']>;
   approvedAt?: Maybe<Scalars['timestamptz']>;
-  approverId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_approvals" */
 export type Metric_Approvals_Min_Order_By = {
-  approval_ts?: Maybe<Order_By>;
   approvedAt?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_approvals" */
@@ -5101,28 +6914,15 @@ export type Metric_Approvals_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_approvals" */
 export type Metric_Approvals_Obj_Rel_Insert_Input = {
   data: Metric_Approvals_Insert_Input;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_approvals" */
-export type Metric_Approvals_On_Conflict = {
-  constraint: Metric_Approvals_Constraint;
-  update_columns: Array<Metric_Approvals_Update_Column>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_approvals" */
 export type Metric_Approvals_Order_By = {
-  approval_ts?: Maybe<Order_By>;
   approvedAt?: Maybe<Order_By>;
   approver?: Maybe<Users_Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_approvals" */
@@ -5133,181 +6933,86 @@ export type Metric_Approvals_Pk_Columns_Input = {
 /** select columns of table "metric_approvals" */
 export enum Metric_Approvals_Select_Column {
   /** column name */
-  ApprovalTs = 'approval_ts',
-  /** column name */
   ApprovedAt = 'approvedAt',
   /** column name */
-  ApproverId = 'approverId',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_approvals" */
-export type Metric_Approvals_Set_Input = {
-  approval_ts?: Maybe<Scalars['Int']>;
-  approvedAt?: Maybe<Scalars['timestamptz']>;
-  approverId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Approvals_Stddev_Fields = {
   __typename?: 'metric_approvals_stddev_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_approvals" */
 export type Metric_Approvals_Stddev_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Approvals_Stddev_Pop_Fields = {
   __typename?: 'metric_approvals_stddev_pop_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_approvals" */
 export type Metric_Approvals_Stddev_Pop_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Approvals_Stddev_Samp_Fields = {
   __typename?: 'metric_approvals_stddev_samp_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_approvals" */
 export type Metric_Approvals_Stddev_Samp_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Approvals_Sum_Fields = {
   __typename?: 'metric_approvals_sum_fields';
-  approval_ts?: Maybe<Scalars['Int']>;
-  approverId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_approvals" */
 export type Metric_Approvals_Sum_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_approvals" */
-export enum Metric_Approvals_Update_Column {
-  /** column name */
-  ApprovalTs = 'approval_ts',
-  /** column name */
-  ApprovedAt = 'approvedAt',
-  /** column name */
-  ApproverId = 'approverId',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_Approvals_Var_Pop_Fields = {
   __typename?: 'metric_approvals_var_pop_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_approvals" */
 export type Metric_Approvals_Var_Pop_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Approvals_Var_Samp_Fields = {
   __typename?: 'metric_approvals_var_samp_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_approvals" */
 export type Metric_Approvals_Var_Samp_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Approvals_Variance_Fields = {
   __typename?: 'metric_approvals_variance_fields';
-  approval_ts?: Maybe<Scalars['Float']>;
-  approverId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_approvals" */
 export type Metric_Approvals_Variance_Order_By = {
-  approval_ts?: Maybe<Order_By>;
-  approverId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /**
@@ -5327,8 +7032,6 @@ export type Metric_Collection_Metrics = {
   metric: Org_Metrics_Current_View;
   /** An object relationship */
   metricCollection: Metric_Collections;
-  metricCollectionId: Scalars['Int'];
-  metricId: Scalars['Int'];
   /** Integer used for ordering Metrics within a Metric Collection */
   position: Scalars['Int'];
   /** Timestamp indicating when the record was last updated */
@@ -5391,8 +7094,6 @@ export type Metric_Collection_Metrics_Avg_Fields = {
   __typename?: 'metric_collection_metrics_avg_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5400,8 +7101,6 @@ export type Metric_Collection_Metrics_Avg_Fields = {
 export type Metric_Collection_Metrics_Avg_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5415,8 +7114,6 @@ export type Metric_Collection_Metrics_Bool_Exp = {
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
   metricCollection?: Maybe<Metric_Collections_Bool_Exp>;
-  metricCollectionId?: Maybe<Int_Comparison_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   position?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
 };
@@ -5432,23 +7129,16 @@ export enum Metric_Collection_Metrics_Constraint {
 /** input type for incrementing integer column in table "metric_collection_metrics" */
 export type Metric_Collection_Metrics_Inc_Input = {
   emphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_collection_metrics" */
 export type Metric_Collection_Metrics_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricCollection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
   metricCollectionId?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -5457,8 +7147,6 @@ export type Metric_Collection_Metrics_Max_Fields = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -5468,8 +7156,6 @@ export type Metric_Collection_Metrics_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -5480,8 +7166,6 @@ export type Metric_Collection_Metrics_Min_Fields = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -5491,8 +7175,6 @@ export type Metric_Collection_Metrics_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -5526,8 +7208,6 @@ export type Metric_Collection_Metrics_Order_By = {
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
   metricCollection?: Maybe<Metric_Collections_Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -5546,10 +7226,6 @@ export enum Metric_Collection_Metrics_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  MetricCollectionId = 'metricCollectionId',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
   Position = 'position',
   /** column name */
   UpdatedAt = 'updatedAt'
@@ -5557,13 +7233,8 @@ export enum Metric_Collection_Metrics_Select_Column {
 
 /** input type for updating data in table "metric_collection_metrics" */
 export type Metric_Collection_Metrics_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   emphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
@@ -5571,8 +7242,6 @@ export type Metric_Collection_Metrics_Stddev_Fields = {
   __typename?: 'metric_collection_metrics_stddev_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5580,8 +7249,6 @@ export type Metric_Collection_Metrics_Stddev_Fields = {
 export type Metric_Collection_Metrics_Stddev_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5590,8 +7257,6 @@ export type Metric_Collection_Metrics_Stddev_Pop_Fields = {
   __typename?: 'metric_collection_metrics_stddev_pop_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5599,8 +7264,6 @@ export type Metric_Collection_Metrics_Stddev_Pop_Fields = {
 export type Metric_Collection_Metrics_Stddev_Pop_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5609,8 +7272,6 @@ export type Metric_Collection_Metrics_Stddev_Samp_Fields = {
   __typename?: 'metric_collection_metrics_stddev_samp_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5618,8 +7279,6 @@ export type Metric_Collection_Metrics_Stddev_Samp_Fields = {
 export type Metric_Collection_Metrics_Stddev_Samp_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5628,8 +7287,6 @@ export type Metric_Collection_Metrics_Sum_Fields = {
   __typename?: 'metric_collection_metrics_sum_fields';
   emphasis?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricCollectionId?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
   position?: Maybe<Scalars['Int']>;
 };
 
@@ -5637,27 +7294,15 @@ export type Metric_Collection_Metrics_Sum_Fields = {
 export type Metric_Collection_Metrics_Sum_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
 /** update columns of table "metric_collection_metrics" */
 export enum Metric_Collection_Metrics_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
   Emphasis = 'emphasis',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricCollectionId = 'metricCollectionId',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  Position = 'position',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Position = 'position'
 }
 
 /** aggregate var_pop on columns */
@@ -5665,8 +7310,6 @@ export type Metric_Collection_Metrics_Var_Pop_Fields = {
   __typename?: 'metric_collection_metrics_var_pop_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5674,8 +7317,6 @@ export type Metric_Collection_Metrics_Var_Pop_Fields = {
 export type Metric_Collection_Metrics_Var_Pop_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5684,8 +7325,6 @@ export type Metric_Collection_Metrics_Var_Samp_Fields = {
   __typename?: 'metric_collection_metrics_var_samp_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5693,8 +7332,6 @@ export type Metric_Collection_Metrics_Var_Samp_Fields = {
 export type Metric_Collection_Metrics_Var_Samp_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5703,8 +7340,6 @@ export type Metric_Collection_Metrics_Variance_Fields = {
   __typename?: 'metric_collection_metrics_variance_fields';
   emphasis?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricCollectionId?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
   position?: Maybe<Scalars['Float']>;
 };
 
@@ -5712,8 +7347,6 @@ export type Metric_Collection_Metrics_Variance_Fields = {
 export type Metric_Collection_Metrics_Variance_Order_By = {
   emphasis?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricCollectionId?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
   position?: Maybe<Order_By>;
 };
 
@@ -5721,12 +7354,8 @@ export type Metric_Collection_Metrics_Variance_Order_By = {
 export type Metric_Collection_View = {
   __typename?: 'metric_collection_view';
   created_at: Scalars['timestamptz'];
-  id: Scalars['Int'];
   /** An object relationship */
   metric_collection?: Maybe<Metric_Collections>;
-  metric_collection_id: Scalars['Int'];
-  organization_id: Scalars['Int'];
-  user_id: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_collection_view" */
@@ -5739,17 +7368,9 @@ export type Metric_Collection_View_Aggregate = {
 /** aggregate fields of "metric_collection_view" */
 export type Metric_Collection_View_Aggregate_Fields = {
   __typename?: 'metric_collection_view_aggregate_fields';
-  avg?: Maybe<Metric_Collection_View_Avg_Fields>;
   count?: Maybe<Scalars['Int']>;
   max?: Maybe<Metric_Collection_View_Max_Fields>;
   min?: Maybe<Metric_Collection_View_Min_Fields>;
-  stddev?: Maybe<Metric_Collection_View_Stddev_Fields>;
-  stddev_pop?: Maybe<Metric_Collection_View_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Metric_Collection_View_Stddev_Samp_Fields>;
-  sum?: Maybe<Metric_Collection_View_Sum_Fields>;
-  var_pop?: Maybe<Metric_Collection_View_Var_Pop_Fields>;
-  var_samp?: Maybe<Metric_Collection_View_Var_Samp_Fields>;
-  variance?: Maybe<Metric_Collection_View_Variance_Fields>;
 };
 
 
@@ -5761,40 +7382,14 @@ export type Metric_Collection_View_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "metric_collection_view" */
 export type Metric_Collection_View_Aggregate_Order_By = {
-  avg?: Maybe<Metric_Collection_View_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Metric_Collection_View_Max_Order_By>;
   min?: Maybe<Metric_Collection_View_Min_Order_By>;
-  stddev?: Maybe<Metric_Collection_View_Stddev_Order_By>;
-  stddev_pop?: Maybe<Metric_Collection_View_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Metric_Collection_View_Stddev_Samp_Order_By>;
-  sum?: Maybe<Metric_Collection_View_Sum_Order_By>;
-  var_pop?: Maybe<Metric_Collection_View_Var_Pop_Order_By>;
-  var_samp?: Maybe<Metric_Collection_View_Var_Samp_Order_By>;
-  variance?: Maybe<Metric_Collection_View_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "metric_collection_view" */
 export type Metric_Collection_View_Arr_Rel_Insert_Input = {
   data: Array<Metric_Collection_View_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Metric_Collection_View_Avg_Fields = {
-  __typename?: 'metric_collection_view_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_collection_view". All fields are combined with a logical 'AND'. */
@@ -5803,73 +7398,35 @@ export type Metric_Collection_View_Bool_Exp = {
   _not?: Maybe<Metric_Collection_View_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Collection_View_Bool_Exp>>>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
   metric_collection?: Maybe<Metric_Collections_Bool_Exp>;
-  metric_collection_id?: Maybe<Int_Comparison_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_collection_view" */
-export enum Metric_Collection_View_Constraint {
-  /** unique or primary key constraint */
-  MetricCollectionViewPkey = 'metric_collection_view_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_collection_view" */
-export type Metric_Collection_View_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_collection_view" */
 export type Metric_Collection_View_Insert_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
   metric_collection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
   metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Collection_View_Max_Fields = {
   __typename?: 'metric_collection_view_max_fields';
   created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_collection_view" */
 export type Metric_Collection_View_Max_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Collection_View_Min_Fields = {
   __typename?: 'metric_collection_view_min_fields';
   created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_collection_view" */
 export type Metric_Collection_View_Min_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_collection_view" */
@@ -5884,24 +7441,12 @@ export type Metric_Collection_View_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_collection_view" */
 export type Metric_Collection_View_Obj_Rel_Insert_Input = {
   data: Metric_Collection_View_Insert_Input;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_collection_view" */
-export type Metric_Collection_View_On_Conflict = {
-  constraint: Metric_Collection_View_Constraint;
-  update_columns: Array<Metric_Collection_View_Update_Column>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_collection_view" */
 export type Metric_Collection_View_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
   metric_collection?: Maybe<Metric_Collections_Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_collection_view" */
@@ -5912,158 +7457,8 @@ export type Metric_Collection_View_Pk_Columns_Input = {
 /** select columns of table "metric_collection_view" */
 export enum Metric_Collection_View_Select_Column {
   /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricCollectionId = 'metric_collection_id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  UserId = 'user_id'
+  CreatedAt = 'created_at'
 }
-
-/** input type for updating data in table "metric_collection_view" */
-export type Metric_Collection_View_Set_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Metric_Collection_View_Stddev_Fields = {
-  __typename?: 'metric_collection_view_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Metric_Collection_View_Stddev_Pop_Fields = {
-  __typename?: 'metric_collection_view_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Metric_Collection_View_Stddev_Samp_Fields = {
-  __typename?: 'metric_collection_view_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Metric_Collection_View_Sum_Fields = {
-  __typename?: 'metric_collection_view_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  metric_collection_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "metric_collection_view" */
-export enum Metric_Collection_View_Update_Column {
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricCollectionId = 'metric_collection_id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** aggregate var_pop on columns */
-export type Metric_Collection_View_Var_Pop_Fields = {
-  __typename?: 'metric_collection_view_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Metric_Collection_View_Var_Samp_Fields = {
-  __typename?: 'metric_collection_view_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Metric_Collection_View_Variance_Fields = {
-  __typename?: 'metric_collection_view_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  metric_collection_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "metric_collection_view" */
-export type Metric_Collection_View_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  metric_collection_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
 
 /**
  * Metric Collections are useful groupings of Metrics for analysis and easy filtering
@@ -6274,34 +7669,23 @@ export enum Metric_Collections_Constraint {
 
 /** input type for incrementing integer column in table "metric_collections" */
 export type Metric_Collections_Inc_Input = {
-  createdBy?: Maybe<Scalars['Int']>;
   defaultEmphasis?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_collections" */
 export type Metric_Collections_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   createdByUser?: Maybe<Users_Obj_Rel_Insert_Input>;
   defaultEmphasis?: Maybe<Scalars['Int']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
   metric_collection_views?: Maybe<Metric_Collection_View_Arr_Rel_Insert_Input>;
   metrics?: Maybe<Metric_Collection_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeam?: Maybe<Teams_Obj_Rel_Insert_Input>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   primaryDashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -6449,18 +7833,13 @@ export enum Metric_Collections_Select_Column {
 
 /** input type for updating data in table "metric_collections" */
 export type Metric_Collections_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   defaultEmphasis?: Maybe<Scalars['Int']>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
@@ -6550,19 +7929,11 @@ export type Metric_Collections_Sum_Order_By = {
 /** update columns of table "metric_collections" */
 export enum Metric_Collections_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedBy = 'createdBy',
-  /** column name */
   DefaultEmphasis = 'defaultEmphasis',
   /** column name */
   DeletedAt = 'deletedAt',
   /** column name */
   Description = 'description',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   OwnerTeamId = 'ownerTeamId',
   /** column name */
@@ -6570,9 +7941,7 @@ export enum Metric_Collections_Update_Column {
   /** column name */
   Slug = 'slug',
   /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
@@ -6648,14 +8017,11 @@ export type Metric_Current_Description = {
   __typename?: 'metric_current_description';
   /** An object relationship */
   author?: Maybe<Users>;
-  author_id?: Maybe<Scalars['Int']>;
   created_at?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "metric_current_description" */
@@ -6703,26 +8069,15 @@ export type Metric_Current_Description_Aggregate_Order_By = {
   variance?: Maybe<Metric_Current_Description_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "metric_current_description" */
-export type Metric_Current_Description_Arr_Rel_Insert_Input = {
-  data: Array<Metric_Current_Description_Insert_Input>;
-};
-
 /** aggregate avg on columns */
 export type Metric_Current_Description_Avg_Fields = {
   __typename?: 'metric_current_description_avg_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Avg_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_current_description". All fields are combined with a logical 'AND'. */
@@ -6731,246 +8086,136 @@ export type Metric_Current_Description_Bool_Exp = {
   _not?: Maybe<Metric_Current_Description_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Current_Description_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  author_id?: Maybe<Int_Comparison_Exp>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
   description?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metric_id?: Maybe<Int_Comparison_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** input type for incrementing integer column in table "metric_current_description" */
-export type Metric_Current_Description_Inc_Input = {
-  author_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "metric_current_description" */
-export type Metric_Current_Description_Insert_Input = {
-  author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  author_id?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Current_Description_Max_Fields = {
   __typename?: 'metric_current_description_max_fields';
-  author_id?: Maybe<Scalars['Int']>;
   created_at?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Max_Order_By = {
-  author_id?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Current_Description_Min_Fields = {
   __typename?: 'metric_current_description_min_fields';
-  author_id?: Maybe<Scalars['Int']>;
   created_at?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Min_Order_By = {
-  author_id?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "metric_current_description" */
-export type Metric_Current_Description_Mutation_Response = {
-  __typename?: 'metric_current_description_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Metric_Current_Description>;
-};
-
-/** input type for inserting object relation for remote table "metric_current_description" */
-export type Metric_Current_Description_Obj_Rel_Insert_Input = {
-  data: Metric_Current_Description_Insert_Input;
 };
 
 /** ordering options when selecting data from "metric_current_description" */
 export type Metric_Current_Description_Order_By = {
   author?: Maybe<Users_Order_By>;
-  author_id?: Maybe<Order_By>;
   created_at?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** select columns of table "metric_current_description" */
 export enum Metric_Current_Description_Select_Column {
   /** column name */
-  AuthorId = 'author_id',
-  /** column name */
   CreatedAt = 'created_at',
   /** column name */
   Description = 'description',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metric_id',
-  /** column name */
-  OrganizationId = 'organization_id'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_current_description" */
-export type Metric_Current_Description_Set_Input = {
-  author_id?: Maybe<Scalars['Int']>;
-  created_at?: Maybe<Scalars['timestamptz']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Current_Description_Stddev_Fields = {
   __typename?: 'metric_current_description_stddev_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Stddev_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Current_Description_Stddev_Pop_Fields = {
   __typename?: 'metric_current_description_stddev_pop_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Stddev_Pop_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Current_Description_Stddev_Samp_Fields = {
   __typename?: 'metric_current_description_stddev_samp_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Stddev_Samp_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Current_Description_Sum_Fields = {
   __typename?: 'metric_current_description_sum_fields';
-  author_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metric_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Sum_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
 export type Metric_Current_Description_Var_Pop_Fields = {
   __typename?: 'metric_current_description_var_pop_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Var_Pop_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Current_Description_Var_Samp_Fields = {
   __typename?: 'metric_current_description_var_samp_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Var_Samp_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Current_Description_Variance_Fields = {
   __typename?: 'metric_current_description_variance_fields';
-  author_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metric_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_current_description" */
 export type Metric_Current_Description_Variance_Order_By = {
-  author_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metric_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /**
@@ -6983,16 +8228,13 @@ export type Metric_Descriptions = {
   __typename?: 'metric_descriptions';
   /** An object relationship */
   author: Users;
-  authorId: Scalars['Int'];
   createdAt: Scalars['timestamptz'];
   description: Scalars['String'];
   id: Scalars['Int'];
   /** An object relationship */
   metric: Org_Metrics_Current_View;
-  metricId: Scalars['Int'];
   /** An object relationship */
   organization?: Maybe<Organizations>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "metric_descriptions" */
@@ -7043,24 +8285,17 @@ export type Metric_Descriptions_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_descriptions" */
 export type Metric_Descriptions_Arr_Rel_Insert_Input = {
   data: Array<Metric_Descriptions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_Descriptions_Avg_Fields = {
   __typename?: 'metric_descriptions_avg_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Avg_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_descriptions". All fields are combined with a logical 'AND'. */
@@ -7069,83 +8304,48 @@ export type Metric_Descriptions_Bool_Exp = {
   _not?: Maybe<Metric_Descriptions_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Descriptions_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   description?: Maybe<String_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_descriptions" */
-export enum Metric_Descriptions_Constraint {
-  /** unique or primary key constraint */
-  MetricDescriptionsPkey = 'metric_descriptions_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_descriptions" */
-export type Metric_Descriptions_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_descriptions" */
 export type Metric_Descriptions_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Descriptions_Max_Fields = {
   __typename?: 'metric_descriptions_max_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Max_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Descriptions_Min_Fields = {
   __typename?: 'metric_descriptions_min_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
   description?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Min_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_descriptions" */
@@ -7160,27 +8360,16 @@ export type Metric_Descriptions_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_descriptions" */
 export type Metric_Descriptions_Obj_Rel_Insert_Input = {
   data: Metric_Descriptions_Insert_Input;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_descriptions" */
-export type Metric_Descriptions_On_Conflict = {
-  constraint: Metric_Descriptions_Constraint;
-  update_columns: Array<Metric_Descriptions_Update_Column>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_descriptions" */
 export type Metric_Descriptions_Order_By = {
   author?: Maybe<Users_Order_By>;
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_descriptions" */
@@ -7191,162 +8380,88 @@ export type Metric_Descriptions_Pk_Columns_Input = {
 /** select columns of table "metric_descriptions" */
 export enum Metric_Descriptions_Select_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
   CreatedAt = 'createdAt',
   /** column name */
   Description = 'description',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_descriptions" */
-export type Metric_Descriptions_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  description?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Descriptions_Stddev_Fields = {
   __typename?: 'metric_descriptions_stddev_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Stddev_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Descriptions_Stddev_Pop_Fields = {
   __typename?: 'metric_descriptions_stddev_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Stddev_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Descriptions_Stddev_Samp_Fields = {
   __typename?: 'metric_descriptions_stddev_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Stddev_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Descriptions_Sum_Fields = {
   __typename?: 'metric_descriptions_sum_fields';
-  authorId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Sum_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_descriptions" */
-export enum Metric_Descriptions_Update_Column {
-  /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Description = 'description',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_Descriptions_Var_Pop_Fields = {
   __typename?: 'metric_descriptions_var_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Var_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Descriptions_Var_Samp_Fields = {
   __typename?: 'metric_descriptions_var_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Var_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Descriptions_Variance_Fields = {
   __typename?: 'metric_descriptions_variance_fields';
-  authorId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_descriptions" */
 export type Metric_Descriptions_Variance_Order_By = {
-  authorId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "metric_lineage_data_sources" */
@@ -7411,12 +8526,6 @@ export type Metric_Lineage_Data_Sources_Aggregate_Order_By = {
   variance?: Maybe<Metric_Lineage_Data_Sources_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Arr_Rel_Insert_Input = {
-  data: Array<Metric_Lineage_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Metric_Lineage_Data_Sources_Avg_Fields = {
   __typename?: 'metric_lineage_data_sources_avg_fields';
@@ -7448,35 +8557,6 @@ export type Metric_Lineage_Data_Sources_Bool_Exp = {
   organization?: Maybe<Organizations_Bool_Exp>;
   organization_id?: Maybe<Int_Comparison_Exp>;
   updated_at?: Maybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_lineage_data_sources" */
-export enum Metric_Lineage_Data_Sources_Constraint {
-  /** unique or primary key constraint */
-  MetricLineageDataSourcesMetricVersionIdDataSourceVKey = 'metric_lineage_data_sources_metric_version_id_data_source_v_key',
-  /** unique or primary key constraint */
-  MetricLineageDataSourcesPkey = 'metric_lineage_data_sources_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Inc_Input = {
-  data_source_version_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_version_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Insert_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  dataSourceVersion?: Maybe<Data_Source_Versions_Obj_Rel_Insert_Input>;
-  data_source_version_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricVersion?: Maybe<Metric_Versions_Obj_Rel_Insert_Input>;
-  metric_version_id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organization_id?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -7521,28 +8601,6 @@ export type Metric_Lineage_Data_Sources_Min_Order_By = {
   updated_at?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Mutation_Response = {
-  __typename?: 'metric_lineage_data_sources_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Metric_Lineage_Data_Sources>;
-};
-
-/** input type for inserting object relation for remote table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Obj_Rel_Insert_Input = {
-  data: Metric_Lineage_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_On_Conflict = {
-  constraint: Metric_Lineage_Data_Sources_Constraint;
-  update_columns: Array<Metric_Lineage_Data_Sources_Update_Column>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "metric_lineage_data_sources" */
 export type Metric_Lineage_Data_Sources_Order_By = {
   created_at?: Maybe<Order_By>;
@@ -7576,16 +8634,6 @@ export enum Metric_Lineage_Data_Sources_Select_Column {
   /** column name */
   UpdatedAt = 'updated_at'
 }
-
-/** input type for updating data in table "metric_lineage_data_sources" */
-export type Metric_Lineage_Data_Sources_Set_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  data_source_version_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric_version_id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  updated_at?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Lineage_Data_Sources_Stddev_Fields = {
@@ -7655,22 +8703,6 @@ export type Metric_Lineage_Data_Sources_Sum_Order_By = {
   organization_id?: Maybe<Order_By>;
 };
 
-/** update columns of table "metric_lineage_data_sources" */
-export enum Metric_Lineage_Data_Sources_Update_Column {
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  DataSourceVersionId = 'data_source_version_id',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricVersionId = 'metric_version_id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  UpdatedAt = 'updated_at'
-}
-
 /** aggregate var_pop on columns */
 export type Metric_Lineage_Data_Sources_Var_Pop_Fields = {
   __typename?: 'metric_lineage_data_sources_var_pop_fields';
@@ -7726,18 +8758,13 @@ export type Metric_Lineage_Data_Sources_Variance_Order_By = {
 export type Metric_Team_Owners = {
   __typename?: 'metric_team_owners';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   team: Teams;
-  teamId: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_team_owners" */
@@ -7788,26 +8815,17 @@ export type Metric_Team_Owners_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_team_owners" */
 export type Metric_Team_Owners_Arr_Rel_Insert_Input = {
   data: Array<Metric_Team_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_Team_Owners_Avg_Fields = {
   __typename?: 'metric_team_owners_avg_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Avg_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_team_owners". All fields are combined with a logical 'AND'. */
@@ -7816,44 +8834,15 @@ export type Metric_Team_Owners_Bool_Exp = {
   _not?: Maybe<Metric_Team_Owners_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Metric_Team_Owners_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   team?: Maybe<Teams_Bool_Exp>;
-  teamId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_team_owners" */
-export enum Metric_Team_Owners_Constraint {
-  /** unique or primary key constraint */
-  MetricTeamOwnersOrgMetricIdTeamIdKey = 'metric_team_owners_org_metric_id_team_id_key',
-  /** unique or primary key constraint */
-  MetricTeamOwnersPkey = 'metric_team_owners_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_team_owners" */
-export type Metric_Team_Owners_Inc_Input = {
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_team_owners" */
 export type Metric_Team_Owners_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   team?: Maybe<Teams_Obj_Rel_Insert_Input>;
   teamId?: Maybe<Scalars['Int']>;
 };
@@ -7862,46 +8851,26 @@ export type Metric_Team_Owners_Insert_Input = {
 export type Metric_Team_Owners_Max_Fields = {
   __typename?: 'metric_team_owners_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Metric_Team_Owners_Min_Fields = {
   __typename?: 'metric_team_owners_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_team_owners" */
@@ -7916,28 +8885,15 @@ export type Metric_Team_Owners_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_team_owners" */
 export type Metric_Team_Owners_Obj_Rel_Insert_Input = {
   data: Metric_Team_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_team_owners" */
-export type Metric_Team_Owners_On_Conflict = {
-  constraint: Metric_Team_Owners_Constraint;
-  update_columns: Array<Metric_Team_Owners_Update_Column>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_team_owners" */
 export type Metric_Team_Owners_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   team?: Maybe<Teams_Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_team_owners" */
@@ -7950,179 +8906,84 @@ export enum Metric_Team_Owners_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_team_owners" */
-export type Metric_Team_Owners_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Team_Owners_Stddev_Fields = {
   __typename?: 'metric_team_owners_stddev_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Stddev_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_Team_Owners_Stddev_Pop_Fields = {
   __typename?: 'metric_team_owners_stddev_pop_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Stddev_Pop_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_Team_Owners_Stddev_Samp_Fields = {
   __typename?: 'metric_team_owners_stddev_samp_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Stddev_Samp_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_Team_Owners_Sum_Fields = {
   __typename?: 'metric_team_owners_sum_fields';
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Sum_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_team_owners" */
-export enum Metric_Team_Owners_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metric_name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_Team_Owners_Var_Pop_Fields = {
   __typename?: 'metric_team_owners_var_pop_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Var_Pop_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_Team_Owners_Var_Samp_Fields = {
   __typename?: 'metric_team_owners_var_samp_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Var_Samp_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_Team_Owners_Variance_Fields = {
   __typename?: 'metric_team_owners_variance_fields';
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_team_owners" */
 export type Metric_Team_Owners_Variance_Order_By = {
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
 };
 
 /**
@@ -8138,13 +8999,10 @@ export type Metric_User_Owners = {
   id: Scalars['Int'];
   /** An object relationship */
   metric: Org_Metrics_Current_View;
-  metricId: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   user: Users;
-  user_id: Scalars['Int'];
 };
 
 /** aggregated selection of "metric_user_owners" */
@@ -8195,24 +9053,17 @@ export type Metric_User_Owners_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "metric_user_owners" */
 export type Metric_User_Owners_Arr_Rel_Insert_Input = {
   data: Array<Metric_User_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Metric_User_Owners_Avg_Fields = {
   __typename?: 'metric_user_owners_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_user_owners". All fields are combined with a logical 'AND'. */
@@ -8223,35 +9074,13 @@ export type Metric_User_Owners_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_user_owners" */
-export enum Metric_User_Owners_Constraint {
-  /** unique or primary key constraint */
-  MetricUserOwnersPkey = 'metric_user_owners_pkey'
-}
-
-/** input type for incrementing integer column in table "metric_user_owners" */
-export type Metric_User_Owners_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_user_owners" */
 export type Metric_User_Owners_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
   user_id?: Maybe<Scalars['Int']>;
 };
@@ -8261,18 +9090,12 @@ export type Metric_User_Owners_Max_Fields = {
   __typename?: 'metric_user_owners_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -8280,18 +9103,12 @@ export type Metric_User_Owners_Min_Fields = {
   __typename?: 'metric_user_owners_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_user_owners" */
@@ -8306,14 +9123,6 @@ export type Metric_User_Owners_Mutation_Response = {
 /** input type for inserting object relation for remote table "metric_user_owners" */
 export type Metric_User_Owners_Obj_Rel_Insert_Input = {
   data: Metric_User_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_user_owners" */
-export type Metric_User_Owners_On_Conflict = {
-  constraint: Metric_User_Owners_Constraint;
-  update_columns: Array<Metric_User_Owners_Update_Column>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "metric_user_owners" */
@@ -8321,11 +9130,8 @@ export type Metric_User_Owners_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "metric_user_owners" */
@@ -8338,155 +9144,84 @@ export enum Metric_User_Owners_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UserId = 'user_id'
+  Id = 'id'
 }
-
-/** input type for updating data in table "metric_user_owners" */
-export type Metric_User_Owners_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_User_Owners_Stddev_Fields = {
   __typename?: 'metric_user_owners_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Metric_User_Owners_Stddev_Pop_Fields = {
   __typename?: 'metric_user_owners_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Metric_User_Owners_Stddev_Samp_Fields = {
   __typename?: 'metric_user_owners_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Metric_User_Owners_Sum_Fields = {
   __typename?: 'metric_user_owners_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
-
-/** update columns of table "metric_user_owners" */
-export enum Metric_User_Owners_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UserId = 'user_id'
-}
 
 /** aggregate var_pop on columns */
 export type Metric_User_Owners_Var_Pop_Fields = {
   __typename?: 'metric_user_owners_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Metric_User_Owners_Var_Samp_Fields = {
   __typename?: 'metric_user_owners_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Metric_User_Owners_Variance_Fields = {
   __typename?: 'metric_user_owners_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_user_owners" */
 export type Metric_User_Owners_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /**
@@ -8500,7 +9235,6 @@ export type Metric_Versions = {
   createdAt: Scalars['timestamptz'];
   /** An object relationship */
   dataSource?: Maybe<Org_Data_Sources>;
-  dataSourceId?: Maybe<Scalars['Int']>;
   /** An array relationship */
   dataSources: Array<Metric_Lineage_Data_Sources>;
   /** An aggregated array relationship */
@@ -8519,7 +9253,6 @@ export type Metric_Versions = {
   organization: Organizations;
   organizationId: Scalars['Int'];
   params: Scalars['jsonb'];
-  source_data_source_versions?: Maybe<Scalars['json']>;
   tier: Scalars['Int'];
 };
 
@@ -8605,17 +9338,6 @@ export type Metric_VersionsParamsArgs = {
   path?: Maybe<Scalars['String']>;
 };
 
-
-/**
- * The exact definition from the configs a metric live here. Only updated when a definition changes, so this represents a version of a metric.
- *
- *
- * columns and relationships of "metric_versions"
- */
-export type Metric_VersionsSource_Data_Source_VersionsArgs = {
-  path?: Maybe<Scalars['String']>;
-};
-
 /** aggregated selection of "metric_versions" */
 export type Metric_Versions_Aggregate = {
   __typename?: 'metric_versions_aggregate';
@@ -8661,22 +9383,9 @@ export type Metric_Versions_Aggregate_Order_By = {
   variance?: Maybe<Metric_Versions_Variance_Order_By>;
 };
 
-/** append existing jsonb value of filtered columns with new jsonb value */
-export type Metric_Versions_Append_Input = {
-  metadata?: Maybe<Scalars['jsonb']>;
-  params?: Maybe<Scalars['jsonb']>;
-};
-
-/** input type for inserting array relation for remote table "metric_versions" */
-export type Metric_Versions_Arr_Rel_Insert_Input = {
-  data: Array<Metric_Versions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Metric_Versions_Avg_Fields = {
   __typename?: 'metric_versions_avg_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8685,7 +9394,6 @@ export type Metric_Versions_Avg_Fields = {
 
 /** order by avg() on columns of table "metric_versions" */
 export type Metric_Versions_Avg_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8699,7 +9407,6 @@ export type Metric_Versions_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Metric_Versions_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   dataSource?: Maybe<Org_Data_Sources_Bool_Exp>;
-  dataSourceId?: Maybe<Int_Comparison_Exp>;
   dataSources?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
   description?: Maybe<String_Comparison_Exp>;
   displayName?: Maybe<String_Comparison_Exp>;
@@ -8711,70 +9418,13 @@ export type Metric_Versions_Bool_Exp = {
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   params?: Maybe<Jsonb_Comparison_Exp>;
-  source_data_source_versions?: Maybe<Json_Comparison_Exp>;
   tier?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "metric_versions" */
-export enum Metric_Versions_Constraint {
-  /** unique or primary key constraint */
-  MetricVersionsHashOrganizationIdKey = 'metric_versions_hash_organization_id_key',
-  /** unique or primary key constraint */
-  MetricVersionsPkey = 'metric_versions_pkey'
-}
-
-/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
-export type Metric_Versions_Delete_At_Path_Input = {
-  metadata?: Maybe<Array<Maybe<Scalars['String']>>>;
-  params?: Maybe<Array<Maybe<Scalars['String']>>>;
-};
-
-/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
-export type Metric_Versions_Delete_Elem_Input = {
-  metadata?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['Int']>;
-};
-
-/** delete key/value pair or string element. key/value pairs are matched based on their key value */
-export type Metric_Versions_Delete_Key_Input = {
-  metadata?: Maybe<Scalars['String']>;
-  params?: Maybe<Scalars['String']>;
-};
-
-/** input type for incrementing integer column in table "metric_versions" */
-export type Metric_Versions_Inc_Input = {
-  dataSourceId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['bigint']>;
-  metricType?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  tier?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "metric_versions" */
-export type Metric_Versions_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSource?: Maybe<Org_Data_Sources_Obj_Rel_Insert_Input>;
-  dataSourceId?: Maybe<Scalars['Int']>;
-  dataSources?: Maybe<Metric_Lineage_Data_Sources_Arr_Rel_Insert_Input>;
-  description?: Maybe<Scalars['String']>;
-  displayName?: Maybe<Scalars['String']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  metadata?: Maybe<Scalars['jsonb']>;
-  metricType?: Maybe<Scalars['Int']>;
-  modelMetrics?: Maybe<Model_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['jsonb']>;
-  source_data_source_versions?: Maybe<Scalars['json']>;
-  tier?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Metric_Versions_Max_Fields = {
   __typename?: 'metric_versions_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceId?: Maybe<Scalars['Int']>;
   description?: Maybe<Scalars['String']>;
   displayName?: Maybe<Scalars['String']>;
   hash?: Maybe<Scalars['String']>;
@@ -8787,7 +9437,6 @@ export type Metric_Versions_Max_Fields = {
 /** order by max() on columns of table "metric_versions" */
 export type Metric_Versions_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dataSourceId?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   displayName?: Maybe<Order_By>;
   hash?: Maybe<Order_By>;
@@ -8801,7 +9450,6 @@ export type Metric_Versions_Max_Order_By = {
 export type Metric_Versions_Min_Fields = {
   __typename?: 'metric_versions_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceId?: Maybe<Scalars['Int']>;
   description?: Maybe<Scalars['String']>;
   displayName?: Maybe<Scalars['String']>;
   hash?: Maybe<Scalars['String']>;
@@ -8814,7 +9462,6 @@ export type Metric_Versions_Min_Fields = {
 /** order by min() on columns of table "metric_versions" */
 export type Metric_Versions_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dataSourceId?: Maybe<Order_By>;
   description?: Maybe<Order_By>;
   displayName?: Maybe<Order_By>;
   hash?: Maybe<Order_By>;
@@ -8824,33 +9471,10 @@ export type Metric_Versions_Min_Order_By = {
   tier?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "metric_versions" */
-export type Metric_Versions_Mutation_Response = {
-  __typename?: 'metric_versions_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Metric_Versions>;
-};
-
-/** input type for inserting object relation for remote table "metric_versions" */
-export type Metric_Versions_Obj_Rel_Insert_Input = {
-  data: Metric_Versions_Insert_Input;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
-/** on conflict condition type for table "metric_versions" */
-export type Metric_Versions_On_Conflict = {
-  constraint: Metric_Versions_Constraint;
-  update_columns: Array<Metric_Versions_Update_Column>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "metric_versions" */
 export type Metric_Versions_Order_By = {
   createdAt?: Maybe<Order_By>;
   dataSource?: Maybe<Org_Data_Sources_Order_By>;
-  dataSourceId?: Maybe<Order_By>;
   dataSources_aggregate?: Maybe<Metric_Lineage_Data_Sources_Aggregate_Order_By>;
   description?: Maybe<Order_By>;
   displayName?: Maybe<Order_By>;
@@ -8862,7 +9486,6 @@ export type Metric_Versions_Order_By = {
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   params?: Maybe<Order_By>;
-  source_data_source_versions?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
 };
 
@@ -8871,18 +9494,10 @@ export type Metric_Versions_Pk_Columns_Input = {
   id: Scalars['bigint'];
 };
 
-/** prepend existing jsonb value of filtered columns with new jsonb value */
-export type Metric_Versions_Prepend_Input = {
-  metadata?: Maybe<Scalars['jsonb']>;
-  params?: Maybe<Scalars['jsonb']>;
-};
-
 /** select columns of table "metric_versions" */
 export enum Metric_Versions_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
-  /** column name */
-  DataSourceId = 'dataSourceId',
   /** column name */
   Description = 'description',
   /** column name */
@@ -8900,31 +9515,12 @@ export enum Metric_Versions_Select_Column {
   /** column name */
   Params = 'params',
   /** column name */
-  SourceDataSourceVersions = 'source_data_source_versions',
-  /** column name */
   Tier = 'tier'
 }
-
-/** input type for updating data in table "metric_versions" */
-export type Metric_Versions_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSourceId?: Maybe<Scalars['Int']>;
-  description?: Maybe<Scalars['String']>;
-  displayName?: Maybe<Scalars['String']>;
-  hash?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  metadata?: Maybe<Scalars['jsonb']>;
-  metricType?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['jsonb']>;
-  source_data_source_versions?: Maybe<Scalars['json']>;
-  tier?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_Versions_Stddev_Fields = {
   __typename?: 'metric_versions_stddev_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8933,7 +9529,6 @@ export type Metric_Versions_Stddev_Fields = {
 
 /** order by stddev() on columns of table "metric_versions" */
 export type Metric_Versions_Stddev_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8943,7 +9538,6 @@ export type Metric_Versions_Stddev_Order_By = {
 /** aggregate stddev_pop on columns */
 export type Metric_Versions_Stddev_Pop_Fields = {
   __typename?: 'metric_versions_stddev_pop_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8952,7 +9546,6 @@ export type Metric_Versions_Stddev_Pop_Fields = {
 
 /** order by stddev_pop() on columns of table "metric_versions" */
 export type Metric_Versions_Stddev_Pop_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8962,7 +9555,6 @@ export type Metric_Versions_Stddev_Pop_Order_By = {
 /** aggregate stddev_samp on columns */
 export type Metric_Versions_Stddev_Samp_Fields = {
   __typename?: 'metric_versions_stddev_samp_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -8971,7 +9563,6 @@ export type Metric_Versions_Stddev_Samp_Fields = {
 
 /** order by stddev_samp() on columns of table "metric_versions" */
 export type Metric_Versions_Stddev_Samp_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -8981,7 +9572,6 @@ export type Metric_Versions_Stddev_Samp_Order_By = {
 /** aggregate sum on columns */
 export type Metric_Versions_Sum_Fields = {
   __typename?: 'metric_versions_sum_fields';
-  dataSourceId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['bigint']>;
   metricType?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
@@ -8990,45 +9580,15 @@ export type Metric_Versions_Sum_Fields = {
 
 /** order by sum() on columns of table "metric_versions" */
 export type Metric_Versions_Sum_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
 };
 
-/** update columns of table "metric_versions" */
-export enum Metric_Versions_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DataSourceId = 'dataSourceId',
-  /** column name */
-  Description = 'description',
-  /** column name */
-  DisplayName = 'displayName',
-  /** column name */
-  Hash = 'hash',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Metadata = 'metadata',
-  /** column name */
-  MetricType = 'metricType',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Params = 'params',
-  /** column name */
-  SourceDataSourceVersions = 'source_data_source_versions',
-  /** column name */
-  Tier = 'tier'
-}
-
 /** aggregate var_pop on columns */
 export type Metric_Versions_Var_Pop_Fields = {
   __typename?: 'metric_versions_var_pop_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -9037,7 +9597,6 @@ export type Metric_Versions_Var_Pop_Fields = {
 
 /** order by var_pop() on columns of table "metric_versions" */
 export type Metric_Versions_Var_Pop_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -9047,7 +9606,6 @@ export type Metric_Versions_Var_Pop_Order_By = {
 /** aggregate var_samp on columns */
 export type Metric_Versions_Var_Samp_Fields = {
   __typename?: 'metric_versions_var_samp_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -9056,7 +9614,6 @@ export type Metric_Versions_Var_Samp_Fields = {
 
 /** order by var_samp() on columns of table "metric_versions" */
 export type Metric_Versions_Var_Samp_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -9066,7 +9623,6 @@ export type Metric_Versions_Var_Samp_Order_By = {
 /** aggregate variance on columns */
 export type Metric_Versions_Variance_Fields = {
   __typename?: 'metric_versions_variance_fields';
-  dataSourceId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricType?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
@@ -9075,7 +9631,6 @@ export type Metric_Versions_Variance_Fields = {
 
 /** order by variance() on columns of table "metric_versions" */
 export type Metric_Versions_Variance_Order_By = {
-  dataSourceId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricType?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -9089,14 +9644,12 @@ export type Metric_View = {
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
   /** An object relationship */
   user: Users;
   userId: Scalars['Int'];
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "metric_view" */
@@ -9155,7 +9708,6 @@ export type Metric_View_Avg_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "metric_view" */
@@ -9163,7 +9715,6 @@ export type Metric_View_Avg_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "metric_view". All fields are combined with a logical 'AND'. */
@@ -9174,33 +9725,16 @@ export type Metric_View_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
   metricId?: Maybe<Int_Comparison_Exp>;
-  metric_name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
   userId?: Maybe<Int_Comparison_Exp>;
-  viewed_ts?: Maybe<Int_Comparison_Exp>;
-};
-
-/** input type for incrementing integer column in table "metric_view" */
-export type Metric_View_Inc_Input = {
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "metric_view" */
 export type Metric_View_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -9208,20 +9742,16 @@ export type Metric_View_Max_Fields = {
   __typename?: 'metric_view_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "metric_view" */
 export type Metric_View_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -9229,20 +9759,16 @@ export type Metric_View_Min_Fields = {
   __typename?: 'metric_view_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "metric_view" */
 export type Metric_View_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "metric_view" */
@@ -9264,12 +9790,10 @@ export type Metric_View_Order_By = {
   createdAt?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
   metricId?: Maybe<Order_By>;
-  metric_name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** select columns of table "metric_view" */
@@ -9279,24 +9803,10 @@ export enum Metric_View_Select_Column {
   /** column name */
   MetricId = 'metricId',
   /** column name */
-  MetricName = 'metric_name',
-  /** column name */
   OrganizationId = 'organizationId',
   /** column name */
-  UserId = 'userId',
-  /** column name */
-  ViewedTs = 'viewed_ts'
+  UserId = 'userId'
 }
-
-/** input type for updating data in table "metric_view" */
-export type Metric_View_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metric_name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Metric_View_Stddev_Fields = {
@@ -9304,7 +9814,6 @@ export type Metric_View_Stddev_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "metric_view" */
@@ -9312,7 +9821,6 @@ export type Metric_View_Stddev_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -9321,7 +9829,6 @@ export type Metric_View_Stddev_Pop_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "metric_view" */
@@ -9329,7 +9836,6 @@ export type Metric_View_Stddev_Pop_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -9338,7 +9844,6 @@ export type Metric_View_Stddev_Samp_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "metric_view" */
@@ -9346,7 +9851,6 @@ export type Metric_View_Stddev_Samp_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -9355,7 +9859,6 @@ export type Metric_View_Sum_Fields = {
   metricId?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  viewed_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "metric_view" */
@@ -9363,7 +9866,6 @@ export type Metric_View_Sum_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate var_pop on columns */
@@ -9372,7 +9874,6 @@ export type Metric_View_Var_Pop_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "metric_view" */
@@ -9380,7 +9881,6 @@ export type Metric_View_Var_Pop_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -9389,7 +9889,6 @@ export type Metric_View_Var_Samp_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "metric_view" */
@@ -9397,7 +9896,6 @@ export type Metric_View_Var_Samp_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -9406,7 +9904,6 @@ export type Metric_View_Variance_Fields = {
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
-  viewed_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "metric_view" */
@@ -9414,7 +9911,6 @@ export type Metric_View_Variance_Order_By = {
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
-  viewed_ts?: Maybe<Order_By>;
 };
 
 /**
@@ -9433,64 +9929,6 @@ export type Model_Current = {
   organization_id?: Maybe<Scalars['Int']>;
 };
 
-/** aggregated selection of "model_current" */
-export type Model_Current_Aggregate = {
-  __typename?: 'model_current_aggregate';
-  aggregate?: Maybe<Model_Current_Aggregate_Fields>;
-  nodes: Array<Model_Current>;
-};
-
-/** aggregate fields of "model_current" */
-export type Model_Current_Aggregate_Fields = {
-  __typename?: 'model_current_aggregate_fields';
-  avg?: Maybe<Model_Current_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Model_Current_Max_Fields>;
-  min?: Maybe<Model_Current_Min_Fields>;
-  stddev?: Maybe<Model_Current_Stddev_Fields>;
-  stddev_pop?: Maybe<Model_Current_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Model_Current_Stddev_Samp_Fields>;
-  sum?: Maybe<Model_Current_Sum_Fields>;
-  var_pop?: Maybe<Model_Current_Var_Pop_Fields>;
-  var_samp?: Maybe<Model_Current_Var_Samp_Fields>;
-  variance?: Maybe<Model_Current_Variance_Fields>;
-};
-
-
-/** aggregate fields of "model_current" */
-export type Model_Current_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Model_Current_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "model_current" */
-export type Model_Current_Aggregate_Order_By = {
-  avg?: Maybe<Model_Current_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Model_Current_Max_Order_By>;
-  min?: Maybe<Model_Current_Min_Order_By>;
-  stddev?: Maybe<Model_Current_Stddev_Order_By>;
-  stddev_pop?: Maybe<Model_Current_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Model_Current_Stddev_Samp_Order_By>;
-  sum?: Maybe<Model_Current_Sum_Order_By>;
-  var_pop?: Maybe<Model_Current_Var_Pop_Order_By>;
-  var_samp?: Maybe<Model_Current_Var_Samp_Order_By>;
-  variance?: Maybe<Model_Current_Variance_Order_By>;
-};
-
-/** aggregate avg on columns */
-export type Model_Current_Avg_Fields = {
-  __typename?: 'model_current_avg_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "model_current" */
-export type Model_Current_Avg_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
 /** Boolean expression to filter rows from the table "model_current". All fields are combined with a logical 'AND'. */
 export type Model_Current_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Model_Current_Bool_Exp>>>;
@@ -9500,32 +9938,6 @@ export type Model_Current_Bool_Exp = {
   model_id?: Maybe<Bigint_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organization_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** aggregate max on columns */
-export type Model_Current_Max_Fields = {
-  __typename?: 'model_current_max_fields';
-  model_id?: Maybe<Scalars['bigint']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "model_current" */
-export type Model_Current_Max_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Model_Current_Min_Fields = {
-  __typename?: 'model_current_min_fields';
-  model_id?: Maybe<Scalars['bigint']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "model_current" */
-export type Model_Current_Min_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
 };
 
 /** ordering options when selecting data from "model_current" */
@@ -9544,97 +9956,6 @@ export enum Model_Current_Select_Column {
   OrganizationId = 'organization_id'
 }
 
-/** aggregate stddev on columns */
-export type Model_Current_Stddev_Fields = {
-  __typename?: 'model_current_stddev_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "model_current" */
-export type Model_Current_Stddev_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Model_Current_Stddev_Pop_Fields = {
-  __typename?: 'model_current_stddev_pop_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "model_current" */
-export type Model_Current_Stddev_Pop_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Model_Current_Stddev_Samp_Fields = {
-  __typename?: 'model_current_stddev_samp_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "model_current" */
-export type Model_Current_Stddev_Samp_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Model_Current_Sum_Fields = {
-  __typename?: 'model_current_sum_fields';
-  model_id?: Maybe<Scalars['bigint']>;
-  organization_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "model_current" */
-export type Model_Current_Sum_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_pop on columns */
-export type Model_Current_Var_Pop_Fields = {
-  __typename?: 'model_current_var_pop_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "model_current" */
-export type Model_Current_Var_Pop_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Model_Current_Var_Samp_Fields = {
-  __typename?: 'model_current_var_samp_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "model_current" */
-export type Model_Current_Var_Samp_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Model_Current_Variance_Fields = {
-  __typename?: 'model_current_variance_fields';
-  model_id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "model_current" */
-export type Model_Current_Variance_Order_By = {
-  model_id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-};
-
 /**
  * Lookup table to find the data source version for a given org_data_source ID and model ID combo
  *
@@ -9651,7 +9972,6 @@ export type Model_Data_Sources = {
   modelId: Scalars['Int'];
   /** An object relationship */
   orgDataSource?: Maybe<Org_Data_Sources>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "model_data_sources" */
@@ -9699,25 +10019,17 @@ export type Model_Data_Sources_Aggregate_Order_By = {
   variance?: Maybe<Model_Data_Sources_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "model_data_sources" */
-export type Model_Data_Sources_Arr_Rel_Insert_Input = {
-  data: Array<Model_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Model_Data_Sources_Avg_Fields = {
   __typename?: 'model_data_sources_avg_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Avg_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "model_data_sources". All fields are combined with a logical 'AND'. */
@@ -9730,30 +10042,6 @@ export type Model_Data_Sources_Bool_Exp = {
   model?: Maybe<Models_Bool_Exp>;
   modelId?: Maybe<Int_Comparison_Exp>;
   orgDataSource?: Maybe<Org_Data_Sources_Bool_Exp>;
-  org_data_source_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "model_data_sources" */
-export enum Model_Data_Sources_Constraint {
-  /** unique or primary key constraint */
-  ModelDataSourcesPkey = 'model_data_sources_pkey'
-}
-
-/** input type for incrementing integer column in table "model_data_sources" */
-export type Model_Data_Sources_Inc_Input = {
-  dataSourceVersionId?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "model_data_sources" */
-export type Model_Data_Sources_Insert_Input = {
-  dataSourceVersion?: Maybe<Data_Source_Versions_Obj_Rel_Insert_Input>;
-  dataSourceVersionId?: Maybe<Scalars['Int']>;
-  model?: Maybe<Models_Obj_Rel_Insert_Input>;
-  modelId?: Maybe<Scalars['Int']>;
-  orgDataSource?: Maybe<Org_Data_Sources_Obj_Rel_Insert_Input>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -9761,14 +10049,12 @@ export type Model_Data_Sources_Max_Fields = {
   __typename?: 'model_data_sources_max_fields';
   dataSourceVersionId?: Maybe<Scalars['Int']>;
   modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Max_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -9776,36 +10062,12 @@ export type Model_Data_Sources_Min_Fields = {
   __typename?: 'model_data_sources_min_fields';
   dataSourceVersionId?: Maybe<Scalars['Int']>;
   modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Min_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "model_data_sources" */
-export type Model_Data_Sources_Mutation_Response = {
-  __typename?: 'model_data_sources_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Model_Data_Sources>;
-};
-
-/** input type for inserting object relation for remote table "model_data_sources" */
-export type Model_Data_Sources_Obj_Rel_Insert_Input = {
-  data: Model_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
-/** on conflict condition type for table "model_data_sources" */
-export type Model_Data_Sources_On_Conflict = {
-  constraint: Model_Data_Sources_Constraint;
-  update_columns: Array<Model_Data_Sources_Update_Column>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "model_data_sources" */
@@ -9815,7 +10077,6 @@ export type Model_Data_Sources_Order_By = {
   model?: Maybe<Models_Order_By>;
   modelId?: Maybe<Order_By>;
   orgDataSource?: Maybe<Org_Data_Sources_Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "model_data_sources" */
@@ -9829,31 +10090,20 @@ export enum Model_Data_Sources_Select_Column {
   /** column name */
   DataSourceVersionId = 'dataSourceVersionId',
   /** column name */
-  ModelId = 'modelId',
-  /** column name */
-  OrgDataSourceId = 'org_data_source_id'
+  ModelId = 'modelId'
 }
-
-/** input type for updating data in table "model_data_sources" */
-export type Model_Data_Sources_Set_Input = {
-  dataSourceVersionId?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Model_Data_Sources_Stddev_Fields = {
   __typename?: 'model_data_sources_stddev_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Stddev_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -9861,14 +10111,12 @@ export type Model_Data_Sources_Stddev_Pop_Fields = {
   __typename?: 'model_data_sources_stddev_pop_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Stddev_Pop_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -9876,14 +10124,12 @@ export type Model_Data_Sources_Stddev_Samp_Fields = {
   __typename?: 'model_data_sources_stddev_samp_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Stddev_Samp_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -9891,39 +10137,25 @@ export type Model_Data_Sources_Sum_Fields = {
   __typename?: 'model_data_sources_sum_fields';
   dataSourceVersionId?: Maybe<Scalars['Int']>;
   modelId?: Maybe<Scalars['Int']>;
-  org_data_source_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Sum_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
-
-/** update columns of table "model_data_sources" */
-export enum Model_Data_Sources_Update_Column {
-  /** column name */
-  DataSourceVersionId = 'dataSourceVersionId',
-  /** column name */
-  ModelId = 'modelId',
-  /** column name */
-  OrgDataSourceId = 'org_data_source_id'
-}
 
 /** aggregate var_pop on columns */
 export type Model_Data_Sources_Var_Pop_Fields = {
   __typename?: 'model_data_sources_var_pop_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Var_Pop_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -9931,14 +10163,12 @@ export type Model_Data_Sources_Var_Samp_Fields = {
   __typename?: 'model_data_sources_var_samp_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Var_Samp_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -9946,14 +10176,12 @@ export type Model_Data_Sources_Variance_Fields = {
   __typename?: 'model_data_sources_variance_fields';
   dataSourceVersionId?: Maybe<Scalars['Float']>;
   modelId?: Maybe<Scalars['Float']>;
-  org_data_source_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "model_data_sources" */
 export type Model_Data_Sources_Variance_Order_By = {
   dataSourceVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
-  org_data_source_id?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "model_metrics" */
@@ -10015,12 +10243,6 @@ export type Model_Metrics_Aggregate_Order_By = {
   variance?: Maybe<Model_Metrics_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "model_metrics" */
-export type Model_Metrics_Arr_Rel_Insert_Input = {
-  data: Array<Model_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Model_Metrics_Avg_Fields = {
   __typename?: 'model_metrics_avg_fields';
@@ -10047,31 +10269,6 @@ export type Model_Metrics_Bool_Exp = {
   metricVersionId?: Maybe<Bigint_Comparison_Exp>;
   model?: Maybe<Models_Bool_Exp>;
   modelId?: Maybe<Bigint_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "model_metrics" */
-export enum Model_Metrics_Constraint {
-  /** unique or primary key constraint */
-  ModelMetricsOrgMetricIdModelIdKey = 'model_metrics_org_metric_id_model_id_key',
-  /** unique or primary key constraint */
-  ModelMetricsPkey = 'model_metrics_pkey'
-}
-
-/** input type for incrementing integer column in table "model_metrics" */
-export type Model_Metrics_Inc_Input = {
-  metricId?: Maybe<Scalars['bigint']>;
-  metricVersionId?: Maybe<Scalars['bigint']>;
-  modelId?: Maybe<Scalars['bigint']>;
-};
-
-/** input type for inserting data into table "model_metrics" */
-export type Model_Metrics_Insert_Input = {
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
-  metricId?: Maybe<Scalars['bigint']>;
-  metricVersion?: Maybe<Metric_Versions_Obj_Rel_Insert_Input>;
-  metricVersionId?: Maybe<Scalars['bigint']>;
-  model?: Maybe<Models_Obj_Rel_Insert_Input>;
-  modelId?: Maybe<Scalars['bigint']>;
 };
 
 /** aggregate max on columns */
@@ -10104,28 +10301,6 @@ export type Model_Metrics_Min_Order_By = {
   modelId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "model_metrics" */
-export type Model_Metrics_Mutation_Response = {
-  __typename?: 'model_metrics_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Model_Metrics>;
-};
-
-/** input type for inserting object relation for remote table "model_metrics" */
-export type Model_Metrics_Obj_Rel_Insert_Input = {
-  data: Model_Metrics_Insert_Input;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
-/** on conflict condition type for table "model_metrics" */
-export type Model_Metrics_On_Conflict = {
-  constraint: Model_Metrics_Constraint;
-  update_columns: Array<Model_Metrics_Update_Column>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "model_metrics" */
 export type Model_Metrics_Order_By = {
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
@@ -10152,13 +10327,6 @@ export enum Model_Metrics_Select_Column {
   /** column name */
   ModelId = 'modelId'
 }
-
-/** input type for updating data in table "model_metrics" */
-export type Model_Metrics_Set_Input = {
-  metricId?: Maybe<Scalars['bigint']>;
-  metricVersionId?: Maybe<Scalars['bigint']>;
-  modelId?: Maybe<Scalars['bigint']>;
-};
 
 /** aggregate stddev on columns */
 export type Model_Metrics_Stddev_Fields = {
@@ -10219,16 +10387,6 @@ export type Model_Metrics_Sum_Order_By = {
   metricVersionId?: Maybe<Order_By>;
   modelId?: Maybe<Order_By>;
 };
-
-/** update columns of table "model_metrics" */
-export enum Model_Metrics_Update_Column {
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricVersionId = 'metricVersionId',
-  /** column name */
-  ModelId = 'modelId'
-}
 
 /** aggregate var_pop on columns */
 export type Model_Metrics_Var_Pop_Fields = {
@@ -10308,7 +10466,6 @@ export type Models = {
   organizationId: Scalars['Int'];
   /** An object relationship */
   uploader: Users;
-  uploaderId: Scalars['Int'];
 };
 
 
@@ -10446,25 +10603,17 @@ export type Models_Aggregate_Order_By = {
   variance?: Maybe<Models_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "models" */
-export type Models_Arr_Rel_Insert_Input = {
-  data: Array<Models_Insert_Input>;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Models_Avg_Fields = {
   __typename?: 'models_avg_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "models" */
 export type Models_Avg_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "models". All fields are combined with a logical 'AND'. */
@@ -10486,39 +10635,6 @@ export type Models_Bool_Exp = {
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   uploader?: Maybe<Users_Bool_Exp>;
-  uploaderId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "models" */
-export enum Models_Constraint {
-  /** unique or primary key constraint */
-  ModelsPkey = 'models_pkey'
-}
-
-/** input type for incrementing integer column in table "models" */
-export type Models_Inc_Input = {
-  id?: Maybe<Scalars['bigint']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "models" */
-export type Models_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dataSources?: Maybe<Model_Data_Sources_Arr_Rel_Insert_Input>;
-  executionContext?: Maybe<Scalars['String']>;
-  gitBranch?: Maybe<Scalars['String']>;
-  gitCommit?: Maybe<Scalars['String']>;
-  gitIsDirty?: Maybe<Scalars['Boolean']>;
-  gitRepo?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  isCurrent?: Maybe<Scalars['Boolean']>;
-  metrics?: Maybe<Org_Metrics_Current_View_Arr_Rel_Insert_Input>;
-  modelMetrics?: Maybe<Model_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  uploader?: Maybe<Users_Obj_Rel_Insert_Input>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -10531,7 +10647,6 @@ export type Models_Max_Fields = {
   gitRepo?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['bigint']>;
   organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "models" */
@@ -10543,7 +10658,6 @@ export type Models_Max_Order_By = {
   gitRepo?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -10556,7 +10670,6 @@ export type Models_Min_Fields = {
   gitRepo?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['bigint']>;
   organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "models" */
@@ -10568,29 +10681,6 @@ export type Models_Min_Order_By = {
   gitRepo?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "models" */
-export type Models_Mutation_Response = {
-  __typename?: 'models_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Models>;
-};
-
-/** input type for inserting object relation for remote table "models" */
-export type Models_Obj_Rel_Insert_Input = {
-  data: Models_Insert_Input;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
-/** on conflict condition type for table "models" */
-export type Models_On_Conflict = {
-  constraint: Models_Constraint;
-  update_columns: Array<Models_Update_Column>;
-  where?: Maybe<Models_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "models" */
@@ -10609,7 +10699,6 @@ export type Models_Order_By = {
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   uploader?: Maybe<Users_Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "models" */
@@ -10636,38 +10725,20 @@ export enum Models_Select_Column {
   /** column name */
   IsCurrent = 'isCurrent',
   /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UploaderId = 'uploaderId'
+  OrganizationId = 'organizationId'
 }
-
-/** input type for updating data in table "models" */
-export type Models_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  executionContext?: Maybe<Scalars['String']>;
-  gitBranch?: Maybe<Scalars['String']>;
-  gitCommit?: Maybe<Scalars['String']>;
-  gitIsDirty?: Maybe<Scalars['Boolean']>;
-  gitRepo?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['bigint']>;
-  isCurrent?: Maybe<Scalars['Boolean']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Models_Stddev_Fields = {
   __typename?: 'models_stddev_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "models" */
 export type Models_Stddev_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
@@ -10675,14 +10746,12 @@ export type Models_Stddev_Pop_Fields = {
   __typename?: 'models_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "models" */
 export type Models_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -10690,14 +10759,12 @@ export type Models_Stddev_Samp_Fields = {
   __typename?: 'models_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "models" */
 export type Models_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
@@ -10705,53 +10772,25 @@ export type Models_Sum_Fields = {
   __typename?: 'models_sum_fields';
   id?: Maybe<Scalars['bigint']>;
   organizationId?: Maybe<Scalars['Int']>;
-  uploaderId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "models" */
 export type Models_Sum_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
-
-/** update columns of table "models" */
-export enum Models_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  ExecutionContext = 'executionContext',
-  /** column name */
-  GitBranch = 'gitBranch',
-  /** column name */
-  GitCommit = 'gitCommit',
-  /** column name */
-  GitIsDirty = 'gitIsDirty',
-  /** column name */
-  GitRepo = 'gitRepo',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  IsCurrent = 'isCurrent',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UploaderId = 'uploaderId'
-}
 
 /** aggregate var_pop on columns */
 export type Models_Var_Pop_Fields = {
   __typename?: 'models_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "models" */
 export type Models_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
@@ -10759,14 +10798,12 @@ export type Models_Var_Samp_Fields = {
   __typename?: 'models_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "models" */
 export type Models_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
@@ -10774,14 +10811,12 @@ export type Models_Variance_Fields = {
   __typename?: 'models_variance_fields';
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
-  uploaderId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "models" */
 export type Models_Variance_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  uploaderId?: Maybe<Order_By>;
 };
 
 /**
@@ -10797,7 +10832,6 @@ export type Mql_Heartbeats = {
   id: Scalars['Int'];
   /** An object relationship */
   mqlServer?: Maybe<Org_Mql_Servers>;
-  mqlServerid?: Maybe<Scalars['Int']>;
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
@@ -10819,72 +10853,9 @@ export type Mql_HeartbeatsDetailsArgs = {
   path?: Maybe<Scalars['String']>;
 };
 
-/** aggregated selection of "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate = {
-  __typename?: 'mql_heartbeats_aggregate';
-  aggregate?: Maybe<Mql_Heartbeats_Aggregate_Fields>;
-  nodes: Array<Mql_Heartbeats>;
-};
-
-/** aggregate fields of "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate_Fields = {
-  __typename?: 'mql_heartbeats_aggregate_fields';
-  avg?: Maybe<Mql_Heartbeats_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Mql_Heartbeats_Max_Fields>;
-  min?: Maybe<Mql_Heartbeats_Min_Fields>;
-  stddev?: Maybe<Mql_Heartbeats_Stddev_Fields>;
-  stddev_pop?: Maybe<Mql_Heartbeats_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Mql_Heartbeats_Stddev_Samp_Fields>;
-  sum?: Maybe<Mql_Heartbeats_Sum_Fields>;
-  var_pop?: Maybe<Mql_Heartbeats_Var_Pop_Fields>;
-  var_samp?: Maybe<Mql_Heartbeats_Var_Samp_Fields>;
-  variance?: Maybe<Mql_Heartbeats_Variance_Fields>;
-};
-
-
-/** aggregate fields of "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "mql_heartbeats" */
-export type Mql_Heartbeats_Aggregate_Order_By = {
-  avg?: Maybe<Mql_Heartbeats_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Mql_Heartbeats_Max_Order_By>;
-  min?: Maybe<Mql_Heartbeats_Min_Order_By>;
-  stddev?: Maybe<Mql_Heartbeats_Stddev_Order_By>;
-  stddev_pop?: Maybe<Mql_Heartbeats_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Mql_Heartbeats_Stddev_Samp_Order_By>;
-  sum?: Maybe<Mql_Heartbeats_Sum_Order_By>;
-  var_pop?: Maybe<Mql_Heartbeats_Var_Pop_Order_By>;
-  var_samp?: Maybe<Mql_Heartbeats_Var_Samp_Order_By>;
-  variance?: Maybe<Mql_Heartbeats_Variance_Order_By>;
-};
-
 /** input type for inserting array relation for remote table "mql_heartbeats" */
 export type Mql_Heartbeats_Arr_Rel_Insert_Input = {
   data: Array<Mql_Heartbeats_Insert_Input>;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Mql_Heartbeats_Avg_Fields = {
-  __typename?: 'mql_heartbeats_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "mql_heartbeats". All fields are combined with a logical 'AND'. */
@@ -10896,7 +10867,6 @@ export type Mql_Heartbeats_Bool_Exp = {
   details?: Maybe<Json_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   mqlServer?: Maybe<Org_Mql_Servers_Bool_Exp>;
-  mqlServerid?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   status?: Maybe<String_Comparison_Exp>;
@@ -10905,79 +10875,13 @@ export type Mql_Heartbeats_Bool_Exp = {
   versionSha?: Maybe<String_Comparison_Exp>;
 };
 
-/** unique or primary key constraints on table "mql_heartbeats" */
-export enum Mql_Heartbeats_Constraint {
-  /** unique or primary key constraint */
-  MqlHeartbeatsPkey = 'mql_heartbeats_pkey'
-}
-
-/** input type for incrementing integer column in table "mql_heartbeats" */
-export type Mql_Heartbeats_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "mql_heartbeats" */
 export type Mql_Heartbeats_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   details?: Maybe<Scalars['json']>;
-  id?: Maybe<Scalars['Int']>;
   mqlServer?: Maybe<Org_Mql_Servers_Obj_Rel_Insert_Input>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   status?: Maybe<Scalars['String']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
   versionSha?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Mql_Heartbeats_Max_Fields = {
-  __typename?: 'mql_heartbeats_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  status?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
-  versionSha?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  status?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-  versionSha?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Mql_Heartbeats_Min_Fields = {
-  __typename?: 'mql_heartbeats_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  status?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
-  versionSha?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  status?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-  versionSha?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "mql_heartbeats" */
@@ -10992,14 +10896,6 @@ export type Mql_Heartbeats_Mutation_Response = {
 /** input type for inserting object relation for remote table "mql_heartbeats" */
 export type Mql_Heartbeats_Obj_Rel_Insert_Input = {
   data: Mql_Heartbeats_Insert_Input;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-/** on conflict condition type for table "mql_heartbeats" */
-export type Mql_Heartbeats_On_Conflict = {
-  constraint: Mql_Heartbeats_Constraint;
-  update_columns: Array<Mql_Heartbeats_Update_Column>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "mql_heartbeats" */
@@ -11008,7 +10904,6 @@ export type Mql_Heartbeats_Order_By = {
   details?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   mqlServer?: Maybe<Org_Mql_Servers_Order_By>;
-  mqlServerid?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   status?: Maybe<Order_By>;
@@ -11031,8 +10926,6 @@ export enum Mql_Heartbeats_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  MqlServerid = 'mqlServerid',
-  /** column name */
   OrganizationId = 'organizationId',
   /** column name */
   Status = 'status',
@@ -11041,3068 +10934,6 @@ export enum Mql_Heartbeats_Select_Column {
   /** column name */
   VersionSha = 'versionSha'
 }
-
-/** input type for updating data in table "mql_heartbeats" */
-export type Mql_Heartbeats_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  details?: Maybe<Scalars['json']>;
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  status?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['Int']>;
-  versionSha?: Maybe<Scalars['String']>;
-};
-
-/** aggregate stddev on columns */
-export type Mql_Heartbeats_Stddev_Fields = {
-  __typename?: 'mql_heartbeats_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Mql_Heartbeats_Stddev_Pop_Fields = {
-  __typename?: 'mql_heartbeats_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Mql_Heartbeats_Stddev_Samp_Fields = {
-  __typename?: 'mql_heartbeats_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Mql_Heartbeats_Sum_Fields = {
-  __typename?: 'mql_heartbeats_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  mqlServerid?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** update columns of table "mql_heartbeats" */
-export enum Mql_Heartbeats_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Details = 'details',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MqlServerid = 'mqlServerid',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Status = 'status',
-  /** column name */
-  UserId = 'userId',
-  /** column name */
-  VersionSha = 'versionSha'
-}
-
-/** aggregate var_pop on columns */
-export type Mql_Heartbeats_Var_Pop_Fields = {
-  __typename?: 'mql_heartbeats_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Mql_Heartbeats_Var_Samp_Fields = {
-  __typename?: 'mql_heartbeats_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Mql_Heartbeats_Variance_Fields = {
-  __typename?: 'mql_heartbeats_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  mqlServerid?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "mql_heartbeats" */
-export type Mql_Heartbeats_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  mqlServerid?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** mutation root */
-export type Mutation_Root = {
-  __typename?: 'mutation_root';
-  /** insert a single row into the table: "metric_collection_metrics" */
-  addMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** insert data into the table: "metric_collection_metrics" */
-  addMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
-  /** insert a single row into the table: "team_members" */
-  addTeamMember?: Maybe<Team_Members>;
-  /** insert data into the table: "team_members" */
-  addTeamMembers?: Maybe<Team_Members_Mutation_Response>;
-  /** perform the action: "addUserRole" */
-  addUserRole?: Maybe<AddUserRoleOutput>;
-  /** insert a single row into the table: "metric_approvals" */
-  approveMetric?: Maybe<Metric_Approvals>;
-  /** insert data into the table: "metric_approvals" */
-  approveMetrics?: Maybe<Metric_Approvals_Mutation_Response>;
-  /** insert a single row into the table: "user_roles" */
-  assignUserRole?: Maybe<User_Roles>;
-  /** insert data into the table: "user_roles" */
-  assignUserRoles?: Maybe<User_Roles_Mutation_Response>;
-  /** insert a single row into the table: "annotations" */
-  createAnnotation?: Maybe<Annotations>;
-  /** insert data into the table: "annotations" */
-  createAnnotations?: Maybe<Annotations_Mutation_Response>;
-  /** perform the action: "createApiKey" */
-  createApiKey?: Maybe<CreateApiKeyOutput>;
-  /** perform the action: "createApiKeyForUser" */
-  createApiKeyForUser?: Maybe<CreateApiKeyForUserOutput>;
-  /** insert a single row into the table: "dashboards" */
-  createDashboard?: Maybe<Dashboards>;
-  /** insert a single row into the table: "dashboard_item_configs" */
-  createDashboardItem?: Maybe<Dashboard_Item_Configs>;
-  /** insert data into the table: "dashboard_item_configs" */
-  createDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_sections" */
-  createDashboardSection?: Maybe<Dashboard_Sections>;
-  /** insert data into the table: "dashboard_sections" */
-  createDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
-  /** insert data into the table: "dashboards" */
-  createDashboards?: Maybe<Dashboards_Mutation_Response>;
-  /** insert a single row into the table: "features" */
-  createFeature?: Maybe<Features>;
-  /** insert data into the table: "features" */
-  createFeatures?: Maybe<Features_Mutation_Response>;
-  /** insert a single row into the table: "metric_annotations" */
-  createMetricAnnotation?: Maybe<Metric_Annotations>;
-  /** insert data into the table: "metric_annotations" */
-  createMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
-  /** insert a single row into the table: "metric_collections" */
-  createMetricCollection?: Maybe<Metric_Collections>;
-  /** insert a single row into the table: "metric_collection_view" */
-  createMetricCollectionView?: Maybe<Metric_Collection_View>;
-  /** insert data into the table: "metric_collection_view" */
-  createMetricCollectionViews?: Maybe<Metric_Collection_View_Mutation_Response>;
-  /** insert data into the table: "metric_collections" */
-  createMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
-  /** insert a single row into the table: "metric_descriptions" */
-  createMetricDescription?: Maybe<Metric_Descriptions>;
-  /** insert data into the table: "metric_descriptions" */
-  createMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
-  /** insert a single row into the table: "metric_team_owners" */
-  createMetricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** insert data into the table: "metric_team_owners" */
-  createMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
-  /** insert a single row into the table: "metric_user_owners" */
-  createMetricUserOwner?: Maybe<Metric_User_Owners>;
-  /** insert data into the table: "metric_user_owners" */
-  createMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
-  /** insert a single row into the table: "metric_view" */
-  createMetricView?: Maybe<Metric_View>;
-  /** insert data into the table: "metric_view" */
-  createMetricViews?: Maybe<Metric_View_Mutation_Response>;
-  /** insert a single row into the table: "mql_heartbeats" */
-  createMqlHeartbeat?: Maybe<Mql_Heartbeats>;
-  /** insert data into the table: "mql_heartbeats" */
-  createMqlHeartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
-  /** insert a single row into the table: "org_mql_servers" */
-  createOrgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** insert data into the table: "org_mql_servers" */
-  createOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
-  /** insert a single row into the table: "organizations" */
-  createOrganization?: Maybe<Organizations>;
-  /** insert a single row into the table: "organization_features" */
-  createOrganizationFeature?: Maybe<Organization_Features>;
-  /** insert data into the table: "organization_features" */
-  createOrganizationFeatures?: Maybe<Organization_Features_Mutation_Response>;
-  /** insert data into the table: "organizations" */
-  createOrganizations?: Maybe<Organizations_Mutation_Response>;
-  /** insert a single row into the table: "questions" */
-  createQuestion?: Maybe<Questions>;
-  /** insert data into the table: "question_replies" */
-  createQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
-  /** insert a single row into the table: "question_replies" */
-  createQuestionReply?: Maybe<Question_Replies>;
-  /** insert data into the table: "questions" */
-  createQuestions?: Maybe<Questions_Mutation_Response>;
-  /** insert data into the table: "saved_queries" */
-  createSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
-  /** insert a single row into the table: "saved_queries" */
-  createSavedQuery?: Maybe<Saved_Queries>;
-  /** insert a single row into the table: "teams" */
-  createTeam?: Maybe<Teams>;
-  /** insert a single row into the table: "team_dashboards" */
-  createTeamDashboard?: Maybe<Team_Dashboards>;
-  /** insert data into the table: "team_dashboards" */
-  createTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
-  /** insert a single row into the table: "team_views" */
-  createTeamView?: Maybe<Team_Views>;
-  /** insert data into the table: "team_views" */
-  createTeamViews?: Maybe<Team_Views_Mutation_Response>;
-  /** insert data into the table: "teams" */
-  createTeams?: Maybe<Teams_Mutation_Response>;
-  /** insert a single row into the table: "unsubscribes" */
-  createUnsubscribe?: Maybe<Unsubscribes>;
-  /** insert data into the table: "unsubscribes" */
-  createUnsubscribes?: Maybe<Unsubscribes_Mutation_Response>;
-  /** perform the action: "createUser" */
-  createUser?: Maybe<CreateUserOutput>;
-  /** insert a single row into the table: "user_dashboards" */
-  createUserDashboard?: Maybe<User_Dashboards>;
-  /** insert data into the table: "user_dashboards" */
-  createUserDashboards?: Maybe<User_Dashboards_Mutation_Response>;
-  /** insert a single row into the table: "user_features" */
-  createUserFeature?: Maybe<User_Features>;
-  /** insert data into the table: "user_features" */
-  createUserFeatures?: Maybe<User_Features_Mutation_Response>;
-  /** perform the action: "createUserForOrg" */
-  createUserForOrg?: Maybe<CreateUserOutput>;
-  /** insert a single row into the table: "user_prefs" */
-  createUserPreference?: Maybe<User_Prefs>;
-  /** insert data into the table: "user_prefs" */
-  createUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
-  /** insert a single row into the table: "saved_query_metrics" */
-  createdSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** insert data into the table: "saved_query_metrics" */
-  createdSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
-  /** perform the action: "deactivateUser" */
-  deactivateUser?: Maybe<DeactivateUserOutput>;
-  /** delete single row from the table: "annotations" */
-  deleteAnnotation?: Maybe<Annotations>;
-  /** delete data from the table: "annotations" */
-  deleteAnnotations?: Maybe<Annotations_Mutation_Response>;
-  /** delete single row from the table: "dashboard_item_configs" */
-  deleteDashboardItem?: Maybe<Dashboard_Item_Configs>;
-  /** delete data from the table: "dashboard_item_configs" */
-  deleteDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
-  /** delete single row from the table: "dashboard_sections" */
-  deleteDashboardSection?: Maybe<Dashboard_Sections>;
-  /** delete data from the table: "dashboard_sections" */
-  deleteDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
-  /** delete single row from the table: "features" */
-  deleteFeature?: Maybe<Features>;
-  /** delete data from the table: "features" */
-  deleteFeatures?: Maybe<Features_Mutation_Response>;
-  /** delete single row from the table: "metric_annotations" */
-  deleteMetricAnnotation?: Maybe<Metric_Annotations>;
-  /** delete data from the table: "metric_annotations" */
-  deleteMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
-  /** delete single row from the table: "metric_collections" */
-  deleteMetricCollection?: Maybe<Metric_Collections>;
-  /** delete data from the table: "metric_collections" */
-  deleteMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
-  /** delete single row from the table: "metric_descriptions" */
-  deleteMetricDescription?: Maybe<Metric_Descriptions>;
-  /** delete data from the table: "metric_descriptions" */
-  deleteMetricDescriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
-  /** delete single row from the table: "metric_team_owners" */
-  deleteMetricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** delete data from the table: "metric_team_owners" */
-  deleteMetricTeamOwners?: Maybe<Metric_Team_Owners_Mutation_Response>;
-  /** delete single row from the table: "metric_user_owners" */
-  deleteMetricUserOwner?: Maybe<Metric_User_Owners>;
-  /** delete data from the table: "metric_user_owners" */
-  deleteMetricUserOwners?: Maybe<Metric_User_Owners_Mutation_Response>;
-  /** delete single row from the table: "org_mql_servers" */
-  deleteOrgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** delete data from the table: "org_mql_servers" */
-  deleteOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
-  /** delete single row from the table: "organizations" */
-  deleteOrganization?: Maybe<Organizations>;
-  /** delete single row from the table: "organization_features" */
-  deleteOrganizationFeature?: Maybe<Organization_Features>;
-  /** delete data from the table: "organization_features" */
-  deleteOrganizationFeatures?: Maybe<Organization_Features_Mutation_Response>;
-  /** delete data from the table: "organizations" */
-  deleteOrganizations?: Maybe<Organizations_Mutation_Response>;
-  /** delete data from the table: "question_replies" */
-  deleteQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
-  /** delete single row from the table: "question_replies" */
-  deleteQuestionReply?: Maybe<Question_Replies>;
-  /** delete single row from the table: "saved_query_metrics" */
-  deleteSavedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** delete data from the table: "saved_query_metrics" */
-  deleteSavedQueryMetrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
-  /** delete single row from the table: "team_dashboards" */
-  deleteTeamDashboard?: Maybe<Team_Dashboards>;
-  /** delete data from the table: "team_dashboards" */
-  deleteTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
-  /** delete single row from the table: "unsubscribes" */
-  deleteUnsubscribe?: Maybe<Unsubscribes>;
-  /** delete data from the table: "unsubscribes" */
-  deleteUnsubscribes?: Maybe<Unsubscribes_Mutation_Response>;
-  /** delete single row from the table: "user_dashboards" */
-  deleteUserDashboard?: Maybe<User_Dashboards>;
-  /** delete data from the table: "user_dashboards" */
-  deleteUserDashboards?: Maybe<User_Dashboards_Mutation_Response>;
-  /** delete single row from the table: "user_features" */
-  deleteUserFeature?: Maybe<User_Features>;
-  /** delete data from the table: "user_features" */
-  deleteUserFeatures?: Maybe<User_Features_Mutation_Response>;
-  /** delete single row from the table: "user_prefs" */
-  deleteUserPreference?: Maybe<User_Prefs>;
-  /** delete data from the table: "user_prefs" */
-  deleteUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
-  /** delete single row from the table: "user_roles" */
-  deleteUserRole?: Maybe<User_Roles>;
-  /** delete data from the table: "user_roles" */
-  deleteUserRoles?: Maybe<User_Roles_Mutation_Response>;
-  /** delete data from the table: "api_keys" */
-  delete_api_keys?: Maybe<Api_Keys_Mutation_Response>;
-  /** delete single row from the table: "api_keys" */
-  delete_api_keys_by_pk?: Maybe<Api_Keys>;
-  /** delete data from the table: "branch_metadatas" */
-  delete_branch_metadatas?: Maybe<Branch_Metadatas_Mutation_Response>;
-  /** delete single row from the table: "branch_metadatas" */
-  delete_branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** delete data from the table: "dashboard_layouts" */
-  delete_dashboard_layouts?: Maybe<Dashboard_Layouts_Mutation_Response>;
-  /** delete single row from the table: "dashboard_layouts" */
-  delete_dashboard_layouts_by_pk?: Maybe<Dashboard_Layouts>;
-  /** delete data from the table: "dashboard_renderable_types" */
-  delete_dashboard_renderable_types?: Maybe<Dashboard_Renderable_Types_Mutation_Response>;
-  /** delete single row from the table: "dashboard_renderable_types" */
-  delete_dashboard_renderable_types_by_pk?: Maybe<Dashboard_Renderable_Types>;
-  /** delete data from the table: "dashboard_section_types" */
-  delete_dashboard_section_types?: Maybe<Dashboard_Section_Types_Mutation_Response>;
-  /** delete single row from the table: "dashboard_section_types" */
-  delete_dashboard_section_types_by_pk?: Maybe<Dashboard_Section_Types>;
-  /** delete data from the table: "dashboards" */
-  delete_dashboards?: Maybe<Dashboards_Mutation_Response>;
-  /** delete single row from the table: "dashboards" */
-  delete_dashboards_by_pk?: Maybe<Dashboards>;
-  /** delete data from the table: "data_source_versions" */
-  delete_data_source_versions?: Maybe<Data_Source_Versions_Mutation_Response>;
-  /** delete single row from the table: "data_source_versions" */
-  delete_data_source_versions_by_pk?: Maybe<Data_Source_Versions>;
-  /** delete data from the table: "dw_engines" */
-  delete_dw_engines?: Maybe<Dw_Engines_Mutation_Response>;
-  /** delete single row from the table: "dw_engines" */
-  delete_dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** delete data from the table: "metric_collection_view" */
-  delete_metric_collection_view?: Maybe<Metric_Collection_View_Mutation_Response>;
-  /** delete single row from the table: "metric_collection_view" */
-  delete_metric_collection_view_by_pk?: Maybe<Metric_Collection_View>;
-  /** delete data from the table: "metric_current_description" */
-  delete_metric_current_description?: Maybe<Metric_Current_Description_Mutation_Response>;
-  /** delete data from the table: "metric_lineage_data_sources" */
-  delete_metric_lineage_data_sources?: Maybe<Metric_Lineage_Data_Sources_Mutation_Response>;
-  /** delete single row from the table: "metric_lineage_data_sources" */
-  delete_metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** delete data from the table: "metric_versions" */
-  delete_metric_versions?: Maybe<Metric_Versions_Mutation_Response>;
-  /** delete single row from the table: "metric_versions" */
-  delete_metric_versions_by_pk?: Maybe<Metric_Versions>;
-  /** delete data from the table: "metric_view" */
-  delete_metric_view?: Maybe<Metric_View_Mutation_Response>;
-  /** delete data from the table: "model_data_sources" */
-  delete_model_data_sources?: Maybe<Model_Data_Sources_Mutation_Response>;
-  /** delete single row from the table: "model_data_sources" */
-  delete_model_data_sources_by_pk?: Maybe<Model_Data_Sources>;
-  /** delete data from the table: "model_metrics" */
-  delete_model_metrics?: Maybe<Model_Metrics_Mutation_Response>;
-  /** delete single row from the table: "model_metrics" */
-  delete_model_metrics_by_pk?: Maybe<Model_Metrics>;
-  /** delete data from the table: "models" */
-  delete_models?: Maybe<Models_Mutation_Response>;
-  /** delete single row from the table: "models" */
-  delete_models_by_pk?: Maybe<Models>;
-  /** delete data from the table: "mql_heartbeats" */
-  delete_mql_heartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
-  /** delete single row from the table: "mql_heartbeats" */
-  delete_mql_heartbeats_by_pk?: Maybe<Mql_Heartbeats>;
-  /** delete data from the table: "org_data_sources" */
-  delete_org_data_sources?: Maybe<Org_Data_Sources_Mutation_Response>;
-  /** delete single row from the table: "org_data_sources" */
-  delete_org_data_sources_by_pk?: Maybe<Org_Data_Sources>;
-  /** delete data from the table: "org_metrics_current_view" */
-  delete_org_metrics_current_view?: Maybe<Org_Metrics_Current_View_Mutation_Response>;
-  /** delete single row from the table: "org_metrics_current_view" */
-  delete_org_metrics_current_view_by_pk?: Maybe<Org_Metrics_Current_View>;
-  /** delete data from the table: "org_mql_server_logs_types" */
-  delete_org_mql_server_logs_types?: Maybe<Org_Mql_Server_Logs_Types_Mutation_Response>;
-  /** delete single row from the table: "org_mql_server_logs_types" */
-  delete_org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** delete data from the table: "priorities" */
-  delete_priorities?: Maybe<Priorities_Mutation_Response>;
-  /** delete single row from the table: "priorities" */
-  delete_priorities_by_pk?: Maybe<Priorities>;
-  /** delete data from the table: "questions" */
-  delete_questions?: Maybe<Questions_Mutation_Response>;
-  /** delete single row from the table: "questions" */
-  delete_questions_by_pk?: Maybe<Questions>;
-  /** delete data from the table: "saved_queries" */
-  delete_saved_queries?: Maybe<Saved_Queries_Mutation_Response>;
-  /** delete single row from the table: "saved_queries" */
-  delete_saved_queries_by_pk?: Maybe<Saved_Queries>;
-  /** delete data from the table: "team_page_theme_colors" */
-  delete_team_page_theme_colors?: Maybe<Team_Page_Theme_Colors_Mutation_Response>;
-  /** delete single row from the table: "team_page_theme_colors" */
-  delete_team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** delete data from the table: "team_views" */
-  delete_team_views?: Maybe<Team_Views_Mutation_Response>;
-  /** delete single row from the table: "team_views" */
-  delete_team_views_by_pk?: Maybe<Team_Views>;
-  /** delete data from the table: "teams" */
-  delete_teams?: Maybe<Teams_Mutation_Response>;
-  /** delete single row from the table: "teams" */
-  delete_teams_by_pk?: Maybe<Teams>;
-  /** delete data from the table: "user_role_types" */
-  delete_user_role_types?: Maybe<User_Role_Types_Mutation_Response>;
-  /** delete single row from the table: "user_role_types" */
-  delete_user_role_types_by_pk?: Maybe<User_Role_Types>;
-  /** delete data from the table: "users" */
-  delete_users?: Maybe<Users_Mutation_Response>;
-  /** delete single row from the table: "users" */
-  delete_users_by_pk?: Maybe<Users>;
-  /** insert a single row into the table: "question_directed_to" */
-  directQuestionTo?: Maybe<Question_Directed_To>;
-  /** insert data into the table: "question_directed_to" */
-  directQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
-  /** insert data into the table: "api_keys" */
-  insert_api_keys?: Maybe<Api_Keys_Mutation_Response>;
-  /** insert a single row into the table: "api_keys" */
-  insert_api_keys_one?: Maybe<Api_Keys>;
-  /** insert data into the table: "branch_metadatas" */
-  insert_branch_metadatas?: Maybe<Branch_Metadatas_Mutation_Response>;
-  /** insert a single row into the table: "branch_metadatas" */
-  insert_branch_metadatas_one?: Maybe<Branch_Metadatas>;
-  /** insert data into the table: "dashboard_layouts" */
-  insert_dashboard_layouts?: Maybe<Dashboard_Layouts_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_layouts" */
-  insert_dashboard_layouts_one?: Maybe<Dashboard_Layouts>;
-  /** insert data into the table: "dashboard_renderable_types" */
-  insert_dashboard_renderable_types?: Maybe<Dashboard_Renderable_Types_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_renderable_types" */
-  insert_dashboard_renderable_types_one?: Maybe<Dashboard_Renderable_Types>;
-  /** insert data into the table: "dashboard_section_types" */
-  insert_dashboard_section_types?: Maybe<Dashboard_Section_Types_Mutation_Response>;
-  /** insert a single row into the table: "dashboard_section_types" */
-  insert_dashboard_section_types_one?: Maybe<Dashboard_Section_Types>;
-  /** insert data into the table: "data_source_versions" */
-  insert_data_source_versions?: Maybe<Data_Source_Versions_Mutation_Response>;
-  /** insert a single row into the table: "data_source_versions" */
-  insert_data_source_versions_one?: Maybe<Data_Source_Versions>;
-  /** insert data into the table: "dw_engines" */
-  insert_dw_engines?: Maybe<Dw_Engines_Mutation_Response>;
-  /** insert a single row into the table: "dw_engines" */
-  insert_dw_engines_one?: Maybe<Dw_Engines>;
-  /** insert data into the table: "metric_current_description" */
-  insert_metric_current_description?: Maybe<Metric_Current_Description_Mutation_Response>;
-  /** insert a single row into the table: "metric_current_description" */
-  insert_metric_current_description_one?: Maybe<Metric_Current_Description>;
-  /** insert data into the table: "metric_lineage_data_sources" */
-  insert_metric_lineage_data_sources?: Maybe<Metric_Lineage_Data_Sources_Mutation_Response>;
-  /** insert a single row into the table: "metric_lineage_data_sources" */
-  insert_metric_lineage_data_sources_one?: Maybe<Metric_Lineage_Data_Sources>;
-  /** insert data into the table: "metric_versions" */
-  insert_metric_versions?: Maybe<Metric_Versions_Mutation_Response>;
-  /** insert a single row into the table: "metric_versions" */
-  insert_metric_versions_one?: Maybe<Metric_Versions>;
-  /** insert data into the table: "model_data_sources" */
-  insert_model_data_sources?: Maybe<Model_Data_Sources_Mutation_Response>;
-  /** insert a single row into the table: "model_data_sources" */
-  insert_model_data_sources_one?: Maybe<Model_Data_Sources>;
-  /** insert data into the table: "model_metrics" */
-  insert_model_metrics?: Maybe<Model_Metrics_Mutation_Response>;
-  /** insert a single row into the table: "model_metrics" */
-  insert_model_metrics_one?: Maybe<Model_Metrics>;
-  /** insert data into the table: "models" */
-  insert_models?: Maybe<Models_Mutation_Response>;
-  /** insert a single row into the table: "models" */
-  insert_models_one?: Maybe<Models>;
-  /** insert data into the table: "org_data_sources" */
-  insert_org_data_sources?: Maybe<Org_Data_Sources_Mutation_Response>;
-  /** insert a single row into the table: "org_data_sources" */
-  insert_org_data_sources_one?: Maybe<Org_Data_Sources>;
-  /** insert data into the table: "org_metrics_current_view" */
-  insert_org_metrics_current_view?: Maybe<Org_Metrics_Current_View_Mutation_Response>;
-  /** insert a single row into the table: "org_metrics_current_view" */
-  insert_org_metrics_current_view_one?: Maybe<Org_Metrics_Current_View>;
-  /** insert data into the table: "org_mql_server_logs_types" */
-  insert_org_mql_server_logs_types?: Maybe<Org_Mql_Server_Logs_Types_Mutation_Response>;
-  /** insert a single row into the table: "org_mql_server_logs_types" */
-  insert_org_mql_server_logs_types_one?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** insert data into the table: "priorities" */
-  insert_priorities?: Maybe<Priorities_Mutation_Response>;
-  /** insert a single row into the table: "priorities" */
-  insert_priorities_one?: Maybe<Priorities>;
-  /** insert data into the table: "team_page_theme_colors" */
-  insert_team_page_theme_colors?: Maybe<Team_Page_Theme_Colors_Mutation_Response>;
-  /** insert a single row into the table: "team_page_theme_colors" */
-  insert_team_page_theme_colors_one?: Maybe<Team_Page_Theme_Colors>;
-  /** insert data into the table: "user_role_types" */
-  insert_user_role_types?: Maybe<User_Role_Types_Mutation_Response>;
-  /** insert a single row into the table: "user_role_types" */
-  insert_user_role_types_one?: Maybe<User_Role_Types>;
-  /** insert data into the table: "users" */
-  insert_users?: Maybe<Users_Mutation_Response>;
-  /** insert a single row into the table: "users" */
-  insert_users_one?: Maybe<Users>;
-  /** insert a single row into the table: "question_likes" */
-  likeQuestion?: Maybe<Question_Likes>;
-  /** insert data into the table: "question_likes" */
-  likeQuestions?: Maybe<Question_Likes_Mutation_Response>;
-  logMqlLog?: Maybe<LogMqlLogs>;
-  /** perform the action: "reactivateUser" */
-  reactivateUser?: Maybe<ReactivateUserOutput>;
-  /** delete single row from the table: "question_directed_to" */
-  removeDirectQuestionTo?: Maybe<Question_Directed_To>;
-  /** delete data from the table: "question_directed_to" */
-  removeDirectQuestionToMultiple?: Maybe<Question_Directed_To_Mutation_Response>;
-  /** delete single row from the table: "metric_approvals" */
-  removeMetricApproval?: Maybe<Metric_Approvals>;
-  /** delete data from the table: "metric_approvals" */
-  removeMetricApprovals?: Maybe<Metric_Approvals_Mutation_Response>;
-  /** delete single row from the table: "metric_collection_metrics" */
-  removeMetricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** delete data from the table: "metric_collection_metrics" */
-  removeMetricCollectionMetrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
-  /** delete single row from the table: "team_members" */
-  removeTeamMember?: Maybe<Team_Members>;
-  /** delete data from the table: "team_members" */
-  removeTeamMembers?: Maybe<Team_Members_Mutation_Response>;
-  /** perform the action: "removeUserRole" */
-  removeUserRole?: Maybe<RemoveUserRoleOutput>;
-  /** delete single row from the table: "question_likes" */
-  unlikeQuestion?: Maybe<Question_Likes>;
-  /** delete data from the table: "question_likes" */
-  unlikeQuestions?: Maybe<Question_Likes_Mutation_Response>;
-  /** update single row of the table: "annotations" */
-  updateAnnotation?: Maybe<Annotations>;
-  /** update data of the table: "annotations" */
-  updateAnnotations?: Maybe<Annotations_Mutation_Response>;
-  /** update single row of the table: "api_keys" */
-  updateApiKey?: Maybe<Api_Keys>;
-  /** update data of the table: "api_keys" */
-  updateApiKeys?: Maybe<Api_Keys_Mutation_Response>;
-  /** update single row of the table: "dashboards" */
-  updateDashboard?: Maybe<Dashboards>;
-  /** update single row of the table: "dashboard_item_configs" */
-  updateDashboardItem?: Maybe<Dashboard_Item_Configs>;
-  /** update data of the table: "dashboard_item_configs" */
-  updateDashboardItems?: Maybe<Dashboard_Item_Configs_Mutation_Response>;
-  /** update single row of the table: "dashboard_sections" */
-  updateDashboardSection?: Maybe<Dashboard_Sections>;
-  /** update data of the table: "dashboard_sections" */
-  updateDashboardSections?: Maybe<Dashboard_Sections_Mutation_Response>;
-  /** update data of the table: "dashboards" */
-  updateDashboards?: Maybe<Dashboards_Mutation_Response>;
-  /** update single row of the table: "features" */
-  updateFeature?: Maybe<Features>;
-  /** update data of the table: "features" */
-  updateFeatures?: Maybe<Features_Mutation_Response>;
-  /** update single row of the table: "metric_annotations" */
-  updateMetricAnnotation?: Maybe<Metric_Annotations>;
-  /** update data of the table: "metric_annotations" */
-  updateMetricAnnotations?: Maybe<Metric_Annotations_Mutation_Response>;
-  /** update single row of the table: "metric_collections" */
-  updateMetricCollection?: Maybe<Metric_Collections>;
-  /** update data of the table: "metric_collections" */
-  updateMetricCollections?: Maybe<Metric_Collections_Mutation_Response>;
-  /** perform the action: "updateMyEmail" */
-  updateMyEmail?: Maybe<UpdateMyEmailOutput>;
-  /** update single row of the table: "org_mql_servers" */
-  updateOrgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** update data of the table: "org_mql_servers" */
-  updateOrgMqlServers?: Maybe<Org_Mql_Servers_Mutation_Response>;
-  /** update single row of the table: "organizations" */
-  updateOrganization?: Maybe<Organizations>;
-  /** update single row of the table: "organization_features" */
-  updateOrganizationFeature?: Maybe<Organization_Features>;
-  /** update data of the table: "organization_features" */
-  updateOrganizationFeatures?: Maybe<Organization_Features_Mutation_Response>;
-  /** update data of the table: "organizations" */
-  updateOrganizations?: Maybe<Organizations_Mutation_Response>;
-  /** update single row of the table: "questions" */
-  updateQuestion?: Maybe<Questions>;
-  /** update data of the table: "question_replies" */
-  updateQuestionReplies?: Maybe<Question_Replies_Mutation_Response>;
-  /** update single row of the table: "question_replies" */
-  updateQuestionReply?: Maybe<Question_Replies>;
-  /** update data of the table: "questions" */
-  updateQuestions?: Maybe<Questions_Mutation_Response>;
-  /** update data of the table: "saved_queries" */
-  updateSavedQueries?: Maybe<Saved_Queries_Mutation_Response>;
-  /** update single row of the table: "saved_queries" */
-  updateSavedQuery?: Maybe<Saved_Queries>;
-  /** update single row of the table: "teams" */
-  updateTeam?: Maybe<Teams>;
-  /** update single row of the table: "team_dashboards" */
-  updateTeamDashboard?: Maybe<Team_Dashboards>;
-  /** update data of the table: "team_dashboards" */
-  updateTeamDashboards?: Maybe<Team_Dashboards_Mutation_Response>;
-  /** update single row of the table: "team_members" */
-  updateTeamMember?: Maybe<Team_Members>;
-  /** update data of the table: "team_members" */
-  updateTeamMembers?: Maybe<Team_Members_Mutation_Response>;
-  /** update data of the table: "teams" */
-  updateTeams?: Maybe<Teams_Mutation_Response>;
-  /** update single row of the table: "users" */
-  updateUser?: Maybe<Users>;
-  /** update single row of the table: "user_dashboards" */
-  updateUserDashboard?: Maybe<User_Dashboards>;
-  /** update data of the table: "user_dashboards" */
-  updateUserDashboards?: Maybe<User_Dashboards_Mutation_Response>;
-  /** perform the action: "updateUserEmailForOrg" */
-  updateUserEmailForOrg?: Maybe<UpdateUserEmailForOrgOutput>;
-  /** update single row of the table: "user_features" */
-  updateUserFeature?: Maybe<User_Features>;
-  /** update data of the table: "user_features" */
-  updateUserFeatures?: Maybe<User_Features_Mutation_Response>;
-  /** update single row of the table: "user_prefs" */
-  updateUserPreference?: Maybe<User_Prefs>;
-  /** update data of the table: "user_prefs" */
-  updateUserPreferences?: Maybe<User_Prefs_Mutation_Response>;
-  /** update single row of the table: "user_roles" */
-  updateUserRole?: Maybe<User_Roles>;
-  /** update data of the table: "user_roles" */
-  updateUserRoles?: Maybe<User_Roles_Mutation_Response>;
-  /** update data of the table: "users" */
-  updateUsers?: Maybe<Users_Mutation_Response>;
-  /** update data of the table: "branch_metadatas" */
-  update_branch_metadatas?: Maybe<Branch_Metadatas_Mutation_Response>;
-  /** update single row of the table: "branch_metadatas" */
-  update_branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** update data of the table: "dashboard_layouts" */
-  update_dashboard_layouts?: Maybe<Dashboard_Layouts_Mutation_Response>;
-  /** update single row of the table: "dashboard_layouts" */
-  update_dashboard_layouts_by_pk?: Maybe<Dashboard_Layouts>;
-  /** update data of the table: "dashboard_renderable_types" */
-  update_dashboard_renderable_types?: Maybe<Dashboard_Renderable_Types_Mutation_Response>;
-  /** update single row of the table: "dashboard_renderable_types" */
-  update_dashboard_renderable_types_by_pk?: Maybe<Dashboard_Renderable_Types>;
-  /** update data of the table: "dashboard_section_types" */
-  update_dashboard_section_types?: Maybe<Dashboard_Section_Types_Mutation_Response>;
-  /** update single row of the table: "dashboard_section_types" */
-  update_dashboard_section_types_by_pk?: Maybe<Dashboard_Section_Types>;
-  /** update data of the table: "data_source_versions" */
-  update_data_source_versions?: Maybe<Data_Source_Versions_Mutation_Response>;
-  /** update single row of the table: "data_source_versions" */
-  update_data_source_versions_by_pk?: Maybe<Data_Source_Versions>;
-  /** update data of the table: "dw_engines" */
-  update_dw_engines?: Maybe<Dw_Engines_Mutation_Response>;
-  /** update single row of the table: "dw_engines" */
-  update_dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** update data of the table: "metric_approvals" */
-  update_metric_approvals?: Maybe<Metric_Approvals_Mutation_Response>;
-  /** update single row of the table: "metric_approvals" */
-  update_metric_approvals_by_pk?: Maybe<Metric_Approvals>;
-  /** update data of the table: "metric_collection_metrics" */
-  update_metric_collection_metrics?: Maybe<Metric_Collection_Metrics_Mutation_Response>;
-  /** update single row of the table: "metric_collection_metrics" */
-  update_metric_collection_metrics_by_pk?: Maybe<Metric_Collection_Metrics>;
-  /** update data of the table: "metric_collection_view" */
-  update_metric_collection_view?: Maybe<Metric_Collection_View_Mutation_Response>;
-  /** update single row of the table: "metric_collection_view" */
-  update_metric_collection_view_by_pk?: Maybe<Metric_Collection_View>;
-  /** update data of the table: "metric_current_description" */
-  update_metric_current_description?: Maybe<Metric_Current_Description_Mutation_Response>;
-  /** update data of the table: "metric_descriptions" */
-  update_metric_descriptions?: Maybe<Metric_Descriptions_Mutation_Response>;
-  /** update single row of the table: "metric_descriptions" */
-  update_metric_descriptions_by_pk?: Maybe<Metric_Descriptions>;
-  /** update data of the table: "metric_lineage_data_sources" */
-  update_metric_lineage_data_sources?: Maybe<Metric_Lineage_Data_Sources_Mutation_Response>;
-  /** update single row of the table: "metric_lineage_data_sources" */
-  update_metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** update data of the table: "metric_team_owners" */
-  update_metric_team_owners?: Maybe<Metric_Team_Owners_Mutation_Response>;
-  /** update single row of the table: "metric_team_owners" */
-  update_metric_team_owners_by_pk?: Maybe<Metric_Team_Owners>;
-  /** update data of the table: "metric_user_owners" */
-  update_metric_user_owners?: Maybe<Metric_User_Owners_Mutation_Response>;
-  /** update single row of the table: "metric_user_owners" */
-  update_metric_user_owners_by_pk?: Maybe<Metric_User_Owners>;
-  /** update data of the table: "metric_versions" */
-  update_metric_versions?: Maybe<Metric_Versions_Mutation_Response>;
-  /** update single row of the table: "metric_versions" */
-  update_metric_versions_by_pk?: Maybe<Metric_Versions>;
-  /** update data of the table: "metric_view" */
-  update_metric_view?: Maybe<Metric_View_Mutation_Response>;
-  /** update data of the table: "model_data_sources" */
-  update_model_data_sources?: Maybe<Model_Data_Sources_Mutation_Response>;
-  /** update single row of the table: "model_data_sources" */
-  update_model_data_sources_by_pk?: Maybe<Model_Data_Sources>;
-  /** update data of the table: "model_metrics" */
-  update_model_metrics?: Maybe<Model_Metrics_Mutation_Response>;
-  /** update single row of the table: "model_metrics" */
-  update_model_metrics_by_pk?: Maybe<Model_Metrics>;
-  /** update data of the table: "models" */
-  update_models?: Maybe<Models_Mutation_Response>;
-  /** update single row of the table: "models" */
-  update_models_by_pk?: Maybe<Models>;
-  /** update data of the table: "mql_heartbeats" */
-  update_mql_heartbeats?: Maybe<Mql_Heartbeats_Mutation_Response>;
-  /** update single row of the table: "mql_heartbeats" */
-  update_mql_heartbeats_by_pk?: Maybe<Mql_Heartbeats>;
-  /** update data of the table: "org_data_sources" */
-  update_org_data_sources?: Maybe<Org_Data_Sources_Mutation_Response>;
-  /** update single row of the table: "org_data_sources" */
-  update_org_data_sources_by_pk?: Maybe<Org_Data_Sources>;
-  /** update data of the table: "org_metrics_current_view" */
-  update_org_metrics_current_view?: Maybe<Org_Metrics_Current_View_Mutation_Response>;
-  /** update single row of the table: "org_metrics_current_view" */
-  update_org_metrics_current_view_by_pk?: Maybe<Org_Metrics_Current_View>;
-  /** update data of the table: "org_mql_server_logs_types" */
-  update_org_mql_server_logs_types?: Maybe<Org_Mql_Server_Logs_Types_Mutation_Response>;
-  /** update single row of the table: "org_mql_server_logs_types" */
-  update_org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** update data of the table: "priorities" */
-  update_priorities?: Maybe<Priorities_Mutation_Response>;
-  /** update single row of the table: "priorities" */
-  update_priorities_by_pk?: Maybe<Priorities>;
-  /** update data of the table: "question_directed_to" */
-  update_question_directed_to?: Maybe<Question_Directed_To_Mutation_Response>;
-  /** update single row of the table: "question_directed_to" */
-  update_question_directed_to_by_pk?: Maybe<Question_Directed_To>;
-  /** update data of the table: "question_likes" */
-  update_question_likes?: Maybe<Question_Likes_Mutation_Response>;
-  /** update single row of the table: "question_likes" */
-  update_question_likes_by_pk?: Maybe<Question_Likes>;
-  /** update data of the table: "saved_query_metrics" */
-  update_saved_query_metrics?: Maybe<Saved_Query_Metrics_Mutation_Response>;
-  /** update single row of the table: "saved_query_metrics" */
-  update_saved_query_metrics_by_pk?: Maybe<Saved_Query_Metrics>;
-  /** update data of the table: "team_page_theme_colors" */
-  update_team_page_theme_colors?: Maybe<Team_Page_Theme_Colors_Mutation_Response>;
-  /** update single row of the table: "team_page_theme_colors" */
-  update_team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** update data of the table: "team_views" */
-  update_team_views?: Maybe<Team_Views_Mutation_Response>;
-  /** update single row of the table: "team_views" */
-  update_team_views_by_pk?: Maybe<Team_Views>;
-  /** update data of the table: "unsubscribes" */
-  update_unsubscribes?: Maybe<Unsubscribes_Mutation_Response>;
-  /** update single row of the table: "unsubscribes" */
-  update_unsubscribes_by_pk?: Maybe<Unsubscribes>;
-  /** update data of the table: "user_role_types" */
-  update_user_role_types?: Maybe<User_Role_Types_Mutation_Response>;
-  /** update single row of the table: "user_role_types" */
-  update_user_role_types_by_pk?: Maybe<User_Role_Types>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddMetricCollectionMetricArgs = {
-  object: Metric_Collection_Metrics_Insert_Input;
-  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddMetricCollectionMetricsArgs = {
-  objects: Array<Metric_Collection_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collection_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddTeamMemberArgs = {
-  object: Team_Members_Insert_Input;
-  on_conflict?: Maybe<Team_Members_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddTeamMembersArgs = {
-  objects: Array<Team_Members_Insert_Input>;
-  on_conflict?: Maybe<Team_Members_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAddUserRoleArgs = {
-  input: AddUserRoleInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootApproveMetricArgs = {
-  object: Metric_Approvals_Insert_Input;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootApproveMetricsArgs = {
-  objects: Array<Metric_Approvals_Insert_Input>;
-  on_conflict?: Maybe<Metric_Approvals_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAssignUserRoleArgs = {
-  object: User_Roles_Insert_Input;
-  on_conflict?: Maybe<User_Roles_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootAssignUserRolesArgs = {
-  objects: Array<User_Roles_Insert_Input>;
-  on_conflict?: Maybe<User_Roles_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateAnnotationArgs = {
-  object: Annotations_Insert_Input;
-  on_conflict?: Maybe<Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateAnnotationsArgs = {
-  objects: Array<Annotations_Insert_Input>;
-  on_conflict?: Maybe<Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateApiKeyForUserArgs = {
-  input: CreateApiKeyForUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardArgs = {
-  object: Dashboards_Insert_Input;
-  on_conflict?: Maybe<Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardItemArgs = {
-  object: Dashboard_Item_Configs_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardItemsArgs = {
-  objects: Array<Dashboard_Item_Configs_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Item_Configs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardSectionArgs = {
-  object: Dashboard_Sections_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardSectionsArgs = {
-  objects: Array<Dashboard_Sections_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Sections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateDashboardsArgs = {
-  objects: Array<Dashboards_Insert_Input>;
-  on_conflict?: Maybe<Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateFeatureArgs = {
-  object: Features_Insert_Input;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateFeaturesArgs = {
-  objects: Array<Features_Insert_Input>;
-  on_conflict?: Maybe<Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricAnnotationArgs = {
-  object: Metric_Annotations_Insert_Input;
-  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricAnnotationsArgs = {
-  objects: Array<Metric_Annotations_Insert_Input>;
-  on_conflict?: Maybe<Metric_Annotations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionArgs = {
-  object: Metric_Collections_Insert_Input;
-  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionViewArgs = {
-  object: Metric_Collection_View_Insert_Input;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionViewsArgs = {
-  objects: Array<Metric_Collection_View_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collection_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricCollectionsArgs = {
-  objects: Array<Metric_Collections_Insert_Input>;
-  on_conflict?: Maybe<Metric_Collections_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricDescriptionArgs = {
-  object: Metric_Descriptions_Insert_Input;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricDescriptionsArgs = {
-  objects: Array<Metric_Descriptions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Descriptions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricTeamOwnerArgs = {
-  object: Metric_Team_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricTeamOwnersArgs = {
-  objects: Array<Metric_Team_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_Team_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricUserOwnerArgs = {
-  object: Metric_User_Owners_Insert_Input;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricUserOwnersArgs = {
-  objects: Array<Metric_User_Owners_Insert_Input>;
-  on_conflict?: Maybe<Metric_User_Owners_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricViewArgs = {
-  object: Metric_View_Insert_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMetricViewsArgs = {
-  objects: Array<Metric_View_Insert_Input>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMqlHeartbeatArgs = {
-  object: Mql_Heartbeats_Insert_Input;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateMqlHeartbeatsArgs = {
-  objects: Array<Mql_Heartbeats_Insert_Input>;
-  on_conflict?: Maybe<Mql_Heartbeats_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrgMqlServerArgs = {
-  object: Org_Mql_Servers_Insert_Input;
-  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrgMqlServersArgs = {
-  objects: Array<Org_Mql_Servers_Insert_Input>;
-  on_conflict?: Maybe<Org_Mql_Servers_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationArgs = {
-  object: Organizations_Insert_Input;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationFeatureArgs = {
-  object: Organization_Features_Insert_Input;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationFeaturesArgs = {
-  objects: Array<Organization_Features_Insert_Input>;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateOrganizationsArgs = {
-  objects: Array<Organizations_Insert_Input>;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionArgs = {
-  object: Questions_Insert_Input;
-  on_conflict?: Maybe<Questions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionRepliesArgs = {
-  objects: Array<Question_Replies_Insert_Input>;
-  on_conflict?: Maybe<Question_Replies_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionReplyArgs = {
-  object: Question_Replies_Insert_Input;
-  on_conflict?: Maybe<Question_Replies_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateQuestionsArgs = {
-  objects: Array<Questions_Insert_Input>;
-  on_conflict?: Maybe<Questions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateSavedQueriesArgs = {
-  objects: Array<Saved_Queries_Insert_Input>;
-  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateSavedQueryArgs = {
-  object: Saved_Queries_Insert_Input;
-  on_conflict?: Maybe<Saved_Queries_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamArgs = {
-  object: Teams_Insert_Input;
-  on_conflict?: Maybe<Teams_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamDashboardArgs = {
-  object: Team_Dashboards_Insert_Input;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamDashboardsArgs = {
-  objects: Array<Team_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamViewArgs = {
-  object: Team_Views_Insert_Input;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamViewsArgs = {
-  objects: Array<Team_Views_Insert_Input>;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateTeamsArgs = {
-  objects: Array<Teams_Insert_Input>;
-  on_conflict?: Maybe<Teams_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUnsubscribeArgs = {
-  object: Unsubscribes_Insert_Input;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUnsubscribesArgs = {
-  objects: Array<Unsubscribes_Insert_Input>;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserArgs = {
-  input: CreateUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserDashboardArgs = {
-  object: User_Dashboards_Insert_Input;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserDashboardsArgs = {
-  objects: Array<User_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserFeatureArgs = {
-  object: User_Features_Insert_Input;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserFeaturesArgs = {
-  objects: Array<User_Features_Insert_Input>;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserForOrgArgs = {
-  input: CreateUserForOrgInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserPreferenceArgs = {
-  object: User_Prefs_Insert_Input;
-  on_conflict?: Maybe<User_Prefs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreateUserPreferencesArgs = {
-  objects: Array<User_Prefs_Insert_Input>;
-  on_conflict?: Maybe<User_Prefs_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreatedSavedQueryMetricArgs = {
-  object: Saved_Query_Metrics_Insert_Input;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootCreatedSavedQueryMetricsArgs = {
-  objects: Array<Saved_Query_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeactivateUserArgs = {
-  input: DeactivateUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteAnnotationsArgs = {
-  where: Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardItemArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardItemsArgs = {
-  where: Dashboard_Item_Configs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardSectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteDashboardSectionsArgs = {
-  where: Dashboard_Sections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteFeatureArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteFeaturesArgs = {
-  where: Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricAnnotationsArgs = {
-  where: Metric_Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricCollectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricCollectionsArgs = {
-  where: Metric_Collections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricDescriptionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricDescriptionsArgs = {
-  where: Metric_Descriptions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricTeamOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricTeamOwnersArgs = {
-  where: Metric_Team_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricUserOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteMetricUserOwnersArgs = {
-  where: Metric_User_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrgMqlServerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrgMqlServersArgs = {
-  where: Org_Mql_Servers_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationFeatureArgs = {
-  featureId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationFeaturesArgs = {
-  where: Organization_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteOrganizationsArgs = {
-  where: Organizations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteQuestionRepliesArgs = {
-  where: Question_Replies_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteQuestionReplyArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteSavedQueryMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteSavedQueryMetricsArgs = {
-  where: Saved_Query_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteTeamDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  team_id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteTeamDashboardsArgs = {
-  where: Team_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUnsubscribeArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUnsubscribesArgs = {
-  where: Unsubscribes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserDashboardsArgs = {
-  where: User_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserFeatureArgs = {
-  featureId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserFeaturesArgs = {
-  where: User_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserPreferenceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserPreferencesArgs = {
-  where: User_Prefs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserRoleArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDeleteUserRolesArgs = {
-  where: User_Roles_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Api_KeysArgs = {
-  where: Api_Keys_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Api_Keys_By_PkArgs = {
-  prefix: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Branch_MetadatasArgs = {
-  where: Branch_Metadatas_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Branch_Metadatas_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_LayoutsArgs = {
-  where: Dashboard_Layouts_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Layouts_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Renderable_TypesArgs = {
-  where: Dashboard_Renderable_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Renderable_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Section_TypesArgs = {
-  where: Dashboard_Section_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboard_Section_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_DashboardsArgs = {
-  where: Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dashboards_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Data_Source_VersionsArgs = {
-  where: Data_Source_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Data_Source_Versions_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dw_EnginesArgs = {
-  where: Dw_Engines_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Dw_Engines_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Collection_ViewArgs = {
-  where: Metric_Collection_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Collection_View_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Current_DescriptionArgs = {
-  where: Metric_Current_Description_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Lineage_Data_SourcesArgs = {
-  where: Metric_Lineage_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Lineage_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_VersionsArgs = {
-  where: Metric_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_Versions_By_PkArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Metric_ViewArgs = {
-  where: Metric_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_Data_SourcesArgs = {
-  where: Model_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_Data_Sources_By_PkArgs = {
-  dataSourceVersionId: Scalars['Int'];
-  modelId: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_MetricsArgs = {
-  where: Model_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Model_Metrics_By_PkArgs = {
-  metricId: Scalars['bigint'];
-  metricVersionId: Scalars['bigint'];
-  modelId: Scalars['bigint'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_ModelsArgs = {
-  where: Models_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Models_By_PkArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Mql_HeartbeatsArgs = {
-  where: Mql_Heartbeats_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Mql_Heartbeats_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Data_SourcesArgs = {
-  where: Org_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Metrics_Current_ViewArgs = {
-  where: Org_Metrics_Current_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Metrics_Current_View_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Mql_Server_Logs_TypesArgs = {
-  where: Org_Mql_Server_Logs_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Org_Mql_Server_Logs_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_PrioritiesArgs = {
-  where: Priorities_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Priorities_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_QuestionsArgs = {
-  where: Questions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Questions_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Saved_QueriesArgs = {
-  where: Saved_Queries_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Saved_Queries_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_Page_Theme_ColorsArgs = {
-  where: Team_Page_Theme_Colors_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_Page_Theme_Colors_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_ViewsArgs = {
-  where: Team_Views_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Team_Views_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_TeamsArgs = {
-  where: Teams_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Teams_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_User_Role_TypesArgs = {
-  where: User_Role_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_User_Role_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_UsersArgs = {
-  where: Users_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootDelete_Users_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootDirectQuestionToArgs = {
-  object: Question_Directed_To_Insert_Input;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootDirectQuestionToMultipleArgs = {
-  objects: Array<Question_Directed_To_Insert_Input>;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Api_KeysArgs = {
-  objects: Array<Api_Keys_Insert_Input>;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Api_Keys_OneArgs = {
-  object: Api_Keys_Insert_Input;
-  on_conflict?: Maybe<Api_Keys_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Branch_MetadatasArgs = {
-  objects: Array<Branch_Metadatas_Insert_Input>;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Branch_Metadatas_OneArgs = {
-  object: Branch_Metadatas_Insert_Input;
-  on_conflict?: Maybe<Branch_Metadatas_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_LayoutsArgs = {
-  objects: Array<Dashboard_Layouts_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Layouts_OneArgs = {
-  object: Dashboard_Layouts_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Layouts_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Renderable_TypesArgs = {
-  objects: Array<Dashboard_Renderable_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Renderable_Types_OneArgs = {
-  object: Dashboard_Renderable_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Renderable_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Section_TypesArgs = {
-  objects: Array<Dashboard_Section_Types_Insert_Input>;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dashboard_Section_Types_OneArgs = {
-  object: Dashboard_Section_Types_Insert_Input;
-  on_conflict?: Maybe<Dashboard_Section_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Data_Source_VersionsArgs = {
-  objects: Array<Data_Source_Versions_Insert_Input>;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Data_Source_Versions_OneArgs = {
-  object: Data_Source_Versions_Insert_Input;
-  on_conflict?: Maybe<Data_Source_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dw_EnginesArgs = {
-  objects: Array<Dw_Engines_Insert_Input>;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Dw_Engines_OneArgs = {
-  object: Dw_Engines_Insert_Input;
-  on_conflict?: Maybe<Dw_Engines_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Current_DescriptionArgs = {
-  objects: Array<Metric_Current_Description_Insert_Input>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Current_Description_OneArgs = {
-  object: Metric_Current_Description_Insert_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Lineage_Data_SourcesArgs = {
-  objects: Array<Metric_Lineage_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Lineage_Data_Sources_OneArgs = {
-  object: Metric_Lineage_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Metric_Lineage_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_VersionsArgs = {
-  objects: Array<Metric_Versions_Insert_Input>;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Metric_Versions_OneArgs = {
-  object: Metric_Versions_Insert_Input;
-  on_conflict?: Maybe<Metric_Versions_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_Data_SourcesArgs = {
-  objects: Array<Model_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_Data_Sources_OneArgs = {
-  object: Model_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Model_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_MetricsArgs = {
-  objects: Array<Model_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Model_Metrics_OneArgs = {
-  object: Model_Metrics_Insert_Input;
-  on_conflict?: Maybe<Model_Metrics_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_ModelsArgs = {
-  objects: Array<Models_Insert_Input>;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Models_OneArgs = {
-  object: Models_Insert_Input;
-  on_conflict?: Maybe<Models_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Data_SourcesArgs = {
-  objects: Array<Org_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Data_Sources_OneArgs = {
-  object: Org_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Metrics_Current_ViewArgs = {
-  objects: Array<Org_Metrics_Current_View_Insert_Input>;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Metrics_Current_View_OneArgs = {
-  object: Org_Metrics_Current_View_Insert_Input;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Mql_Server_Logs_TypesArgs = {
-  objects: Array<Org_Mql_Server_Logs_Types_Insert_Input>;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Org_Mql_Server_Logs_Types_OneArgs = {
-  object: Org_Mql_Server_Logs_Types_Insert_Input;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_PrioritiesArgs = {
-  objects: Array<Priorities_Insert_Input>;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Priorities_OneArgs = {
-  object: Priorities_Insert_Input;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Team_Page_Theme_ColorsArgs = {
-  objects: Array<Team_Page_Theme_Colors_Insert_Input>;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Team_Page_Theme_Colors_OneArgs = {
-  object: Team_Page_Theme_Colors_Insert_Input;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_User_Role_TypesArgs = {
-  objects: Array<User_Role_Types_Insert_Input>;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_User_Role_Types_OneArgs = {
-  object: User_Role_Types_Insert_Input;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_UsersArgs = {
-  objects: Array<Users_Insert_Input>;
-  on_conflict?: Maybe<Users_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootInsert_Users_OneArgs = {
-  object: Users_Insert_Input;
-  on_conflict?: Maybe<Users_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootLikeQuestionArgs = {
-  object: Question_Likes_Insert_Input;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootLikeQuestionsArgs = {
-  objects: Array<Question_Likes_Insert_Input>;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
-};
-
-
-/** mutation root */
-export type Mutation_RootLogMqlLogArgs = {
-  level?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<Scalars['String']>>;
-};
-
-
-/** mutation root */
-export type Mutation_RootReactivateUserArgs = {
-  input: ReactivateUserInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveDirectQuestionToArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveDirectQuestionToMultipleArgs = {
-  where: Question_Directed_To_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricApprovalArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricApprovalsArgs = {
-  where: Metric_Approvals_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricCollectionMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveMetricCollectionMetricsArgs = {
-  where: Metric_Collection_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveTeamMemberArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveTeamMembersArgs = {
-  where: Team_Members_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootRemoveUserRoleArgs = {
-  input: RemoveUserRoleInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootUnlikeQuestionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** mutation root */
-export type Mutation_RootUnlikeQuestionsArgs = {
-  where: Question_Likes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateAnnotationArgs = {
-  _inc?: Maybe<Annotations_Inc_Input>;
-  _set?: Maybe<Annotations_Set_Input>;
-  pk_columns: Annotations_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateAnnotationsArgs = {
-  _inc?: Maybe<Annotations_Inc_Input>;
-  _set?: Maybe<Annotations_Set_Input>;
-  where: Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateApiKeyArgs = {
-  _inc?: Maybe<Api_Keys_Inc_Input>;
-  _set?: Maybe<Api_Keys_Set_Input>;
-  pk_columns: Api_Keys_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateApiKeysArgs = {
-  _inc?: Maybe<Api_Keys_Inc_Input>;
-  _set?: Maybe<Api_Keys_Set_Input>;
-  where: Api_Keys_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardArgs = {
-  _inc?: Maybe<Dashboards_Inc_Input>;
-  _set?: Maybe<Dashboards_Set_Input>;
-  pk_columns: Dashboards_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardItemArgs = {
-  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
-  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
-  pk_columns: Dashboard_Item_Configs_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardItemsArgs = {
-  _inc?: Maybe<Dashboard_Item_Configs_Inc_Input>;
-  _set?: Maybe<Dashboard_Item_Configs_Set_Input>;
-  where: Dashboard_Item_Configs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardSectionArgs = {
-  _inc?: Maybe<Dashboard_Sections_Inc_Input>;
-  _set?: Maybe<Dashboard_Sections_Set_Input>;
-  pk_columns: Dashboard_Sections_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardSectionsArgs = {
-  _inc?: Maybe<Dashboard_Sections_Inc_Input>;
-  _set?: Maybe<Dashboard_Sections_Set_Input>;
-  where: Dashboard_Sections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateDashboardsArgs = {
-  _inc?: Maybe<Dashboards_Inc_Input>;
-  _set?: Maybe<Dashboards_Set_Input>;
-  where: Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateFeatureArgs = {
-  _inc?: Maybe<Features_Inc_Input>;
-  _set?: Maybe<Features_Set_Input>;
-  pk_columns: Features_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateFeaturesArgs = {
-  _inc?: Maybe<Features_Inc_Input>;
-  _set?: Maybe<Features_Set_Input>;
-  where: Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricAnnotationArgs = {
-  _inc?: Maybe<Metric_Annotations_Inc_Input>;
-  _set?: Maybe<Metric_Annotations_Set_Input>;
-  pk_columns: Metric_Annotations_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricAnnotationsArgs = {
-  _inc?: Maybe<Metric_Annotations_Inc_Input>;
-  _set?: Maybe<Metric_Annotations_Set_Input>;
-  where: Metric_Annotations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricCollectionArgs = {
-  _inc?: Maybe<Metric_Collections_Inc_Input>;
-  _set?: Maybe<Metric_Collections_Set_Input>;
-  pk_columns: Metric_Collections_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMetricCollectionsArgs = {
-  _inc?: Maybe<Metric_Collections_Inc_Input>;
-  _set?: Maybe<Metric_Collections_Set_Input>;
-  where: Metric_Collections_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateMyEmailArgs = {
-  input: UpdateMyEmailInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrgMqlServerArgs = {
-  _inc?: Maybe<Org_Mql_Servers_Inc_Input>;
-  _set?: Maybe<Org_Mql_Servers_Set_Input>;
-  pk_columns: Org_Mql_Servers_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrgMqlServersArgs = {
-  _inc?: Maybe<Org_Mql_Servers_Inc_Input>;
-  _set?: Maybe<Org_Mql_Servers_Set_Input>;
-  where: Org_Mql_Servers_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationArgs = {
-  _inc?: Maybe<Organizations_Inc_Input>;
-  _set?: Maybe<Organizations_Set_Input>;
-  pk_columns: Organizations_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationFeatureArgs = {
-  _inc?: Maybe<Organization_Features_Inc_Input>;
-  _set?: Maybe<Organization_Features_Set_Input>;
-  pk_columns: Organization_Features_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationFeaturesArgs = {
-  _inc?: Maybe<Organization_Features_Inc_Input>;
-  _set?: Maybe<Organization_Features_Set_Input>;
-  where: Organization_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateOrganizationsArgs = {
-  _inc?: Maybe<Organizations_Inc_Input>;
-  _set?: Maybe<Organizations_Set_Input>;
-  where: Organizations_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionArgs = {
-  _inc?: Maybe<Questions_Inc_Input>;
-  _set?: Maybe<Questions_Set_Input>;
-  pk_columns: Questions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionRepliesArgs = {
-  _inc?: Maybe<Question_Replies_Inc_Input>;
-  _set?: Maybe<Question_Replies_Set_Input>;
-  where: Question_Replies_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionReplyArgs = {
-  _inc?: Maybe<Question_Replies_Inc_Input>;
-  _set?: Maybe<Question_Replies_Set_Input>;
-  pk_columns: Question_Replies_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateQuestionsArgs = {
-  _inc?: Maybe<Questions_Inc_Input>;
-  _set?: Maybe<Questions_Set_Input>;
-  where: Questions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateSavedQueriesArgs = {
-  _inc?: Maybe<Saved_Queries_Inc_Input>;
-  _set?: Maybe<Saved_Queries_Set_Input>;
-  where: Saved_Queries_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateSavedQueryArgs = {
-  _inc?: Maybe<Saved_Queries_Inc_Input>;
-  _set?: Maybe<Saved_Queries_Set_Input>;
-  pk_columns: Saved_Queries_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamArgs = {
-  _inc?: Maybe<Teams_Inc_Input>;
-  _set?: Maybe<Teams_Set_Input>;
-  pk_columns: Teams_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamDashboardArgs = {
-  _inc?: Maybe<Team_Dashboards_Inc_Input>;
-  _set?: Maybe<Team_Dashboards_Set_Input>;
-  pk_columns: Team_Dashboards_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamDashboardsArgs = {
-  _inc?: Maybe<Team_Dashboards_Inc_Input>;
-  _set?: Maybe<Team_Dashboards_Set_Input>;
-  where: Team_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamMemberArgs = {
-  _inc?: Maybe<Team_Members_Inc_Input>;
-  _set?: Maybe<Team_Members_Set_Input>;
-  pk_columns: Team_Members_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamMembersArgs = {
-  _inc?: Maybe<Team_Members_Inc_Input>;
-  _set?: Maybe<Team_Members_Set_Input>;
-  where: Team_Members_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateTeamsArgs = {
-  _inc?: Maybe<Teams_Inc_Input>;
-  _set?: Maybe<Teams_Set_Input>;
-  where: Teams_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserArgs = {
-  _inc?: Maybe<Users_Inc_Input>;
-  _set?: Maybe<Users_Set_Input>;
-  pk_columns: Users_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserDashboardArgs = {
-  _inc?: Maybe<User_Dashboards_Inc_Input>;
-  _set?: Maybe<User_Dashboards_Set_Input>;
-  pk_columns: User_Dashboards_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserDashboardsArgs = {
-  _inc?: Maybe<User_Dashboards_Inc_Input>;
-  _set?: Maybe<User_Dashboards_Set_Input>;
-  where: User_Dashboards_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserEmailForOrgArgs = {
-  input: UpdateUserEmailForOrgInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserFeatureArgs = {
-  _inc?: Maybe<User_Features_Inc_Input>;
-  _set?: Maybe<User_Features_Set_Input>;
-  pk_columns: User_Features_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserFeaturesArgs = {
-  _inc?: Maybe<User_Features_Inc_Input>;
-  _set?: Maybe<User_Features_Set_Input>;
-  where: User_Features_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserPreferenceArgs = {
-  _inc?: Maybe<User_Prefs_Inc_Input>;
-  _set?: Maybe<User_Prefs_Set_Input>;
-  pk_columns: User_Prefs_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserPreferencesArgs = {
-  _inc?: Maybe<User_Prefs_Inc_Input>;
-  _set?: Maybe<User_Prefs_Set_Input>;
-  where: User_Prefs_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserRoleArgs = {
-  _inc?: Maybe<User_Roles_Inc_Input>;
-  _set?: Maybe<User_Roles_Set_Input>;
-  pk_columns: User_Roles_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUserRolesArgs = {
-  _inc?: Maybe<User_Roles_Inc_Input>;
-  _set?: Maybe<User_Roles_Set_Input>;
-  where: User_Roles_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdateUsersArgs = {
-  _inc?: Maybe<Users_Inc_Input>;
-  _set?: Maybe<Users_Set_Input>;
-  where: Users_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Branch_MetadatasArgs = {
-  _inc?: Maybe<Branch_Metadatas_Inc_Input>;
-  _set?: Maybe<Branch_Metadatas_Set_Input>;
-  where: Branch_Metadatas_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Branch_Metadatas_By_PkArgs = {
-  _inc?: Maybe<Branch_Metadatas_Inc_Input>;
-  _set?: Maybe<Branch_Metadatas_Set_Input>;
-  pk_columns: Branch_Metadatas_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_LayoutsArgs = {
-  _set?: Maybe<Dashboard_Layouts_Set_Input>;
-  where: Dashboard_Layouts_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Layouts_By_PkArgs = {
-  _set?: Maybe<Dashboard_Layouts_Set_Input>;
-  pk_columns: Dashboard_Layouts_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Renderable_TypesArgs = {
-  _set?: Maybe<Dashboard_Renderable_Types_Set_Input>;
-  where: Dashboard_Renderable_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Renderable_Types_By_PkArgs = {
-  _set?: Maybe<Dashboard_Renderable_Types_Set_Input>;
-  pk_columns: Dashboard_Renderable_Types_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Section_TypesArgs = {
-  _set?: Maybe<Dashboard_Section_Types_Set_Input>;
-  where: Dashboard_Section_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dashboard_Section_Types_By_PkArgs = {
-  _set?: Maybe<Dashboard_Section_Types_Set_Input>;
-  pk_columns: Dashboard_Section_Types_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Data_Source_VersionsArgs = {
-  _inc?: Maybe<Data_Source_Versions_Inc_Input>;
-  _set?: Maybe<Data_Source_Versions_Set_Input>;
-  where: Data_Source_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Data_Source_Versions_By_PkArgs = {
-  _inc?: Maybe<Data_Source_Versions_Inc_Input>;
-  _set?: Maybe<Data_Source_Versions_Set_Input>;
-  pk_columns: Data_Source_Versions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dw_EnginesArgs = {
-  _set?: Maybe<Dw_Engines_Set_Input>;
-  where: Dw_Engines_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Dw_Engines_By_PkArgs = {
-  _set?: Maybe<Dw_Engines_Set_Input>;
-  pk_columns: Dw_Engines_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_ApprovalsArgs = {
-  _inc?: Maybe<Metric_Approvals_Inc_Input>;
-  _set?: Maybe<Metric_Approvals_Set_Input>;
-  where: Metric_Approvals_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Approvals_By_PkArgs = {
-  _inc?: Maybe<Metric_Approvals_Inc_Input>;
-  _set?: Maybe<Metric_Approvals_Set_Input>;
-  pk_columns: Metric_Approvals_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_MetricsArgs = {
-  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
-  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
-  where: Metric_Collection_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_Metrics_By_PkArgs = {
-  _inc?: Maybe<Metric_Collection_Metrics_Inc_Input>;
-  _set?: Maybe<Metric_Collection_Metrics_Set_Input>;
-  pk_columns: Metric_Collection_Metrics_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_ViewArgs = {
-  _inc?: Maybe<Metric_Collection_View_Inc_Input>;
-  _set?: Maybe<Metric_Collection_View_Set_Input>;
-  where: Metric_Collection_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Collection_View_By_PkArgs = {
-  _inc?: Maybe<Metric_Collection_View_Inc_Input>;
-  _set?: Maybe<Metric_Collection_View_Set_Input>;
-  pk_columns: Metric_Collection_View_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Current_DescriptionArgs = {
-  _inc?: Maybe<Metric_Current_Description_Inc_Input>;
-  _set?: Maybe<Metric_Current_Description_Set_Input>;
-  where: Metric_Current_Description_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_DescriptionsArgs = {
-  _inc?: Maybe<Metric_Descriptions_Inc_Input>;
-  _set?: Maybe<Metric_Descriptions_Set_Input>;
-  where: Metric_Descriptions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Descriptions_By_PkArgs = {
-  _inc?: Maybe<Metric_Descriptions_Inc_Input>;
-  _set?: Maybe<Metric_Descriptions_Set_Input>;
-  pk_columns: Metric_Descriptions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Lineage_Data_SourcesArgs = {
-  _inc?: Maybe<Metric_Lineage_Data_Sources_Inc_Input>;
-  _set?: Maybe<Metric_Lineage_Data_Sources_Set_Input>;
-  where: Metric_Lineage_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Lineage_Data_Sources_By_PkArgs = {
-  _inc?: Maybe<Metric_Lineage_Data_Sources_Inc_Input>;
-  _set?: Maybe<Metric_Lineage_Data_Sources_Set_Input>;
-  pk_columns: Metric_Lineage_Data_Sources_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Team_OwnersArgs = {
-  _inc?: Maybe<Metric_Team_Owners_Inc_Input>;
-  _set?: Maybe<Metric_Team_Owners_Set_Input>;
-  where: Metric_Team_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Team_Owners_By_PkArgs = {
-  _inc?: Maybe<Metric_Team_Owners_Inc_Input>;
-  _set?: Maybe<Metric_Team_Owners_Set_Input>;
-  pk_columns: Metric_Team_Owners_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_User_OwnersArgs = {
-  _inc?: Maybe<Metric_User_Owners_Inc_Input>;
-  _set?: Maybe<Metric_User_Owners_Set_Input>;
-  where: Metric_User_Owners_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_User_Owners_By_PkArgs = {
-  _inc?: Maybe<Metric_User_Owners_Inc_Input>;
-  _set?: Maybe<Metric_User_Owners_Set_Input>;
-  pk_columns: Metric_User_Owners_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_VersionsArgs = {
-  _append?: Maybe<Metric_Versions_Append_Input>;
-  _delete_at_path?: Maybe<Metric_Versions_Delete_At_Path_Input>;
-  _delete_elem?: Maybe<Metric_Versions_Delete_Elem_Input>;
-  _delete_key?: Maybe<Metric_Versions_Delete_Key_Input>;
-  _inc?: Maybe<Metric_Versions_Inc_Input>;
-  _prepend?: Maybe<Metric_Versions_Prepend_Input>;
-  _set?: Maybe<Metric_Versions_Set_Input>;
-  where: Metric_Versions_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_Versions_By_PkArgs = {
-  _append?: Maybe<Metric_Versions_Append_Input>;
-  _delete_at_path?: Maybe<Metric_Versions_Delete_At_Path_Input>;
-  _delete_elem?: Maybe<Metric_Versions_Delete_Elem_Input>;
-  _delete_key?: Maybe<Metric_Versions_Delete_Key_Input>;
-  _inc?: Maybe<Metric_Versions_Inc_Input>;
-  _prepend?: Maybe<Metric_Versions_Prepend_Input>;
-  _set?: Maybe<Metric_Versions_Set_Input>;
-  pk_columns: Metric_Versions_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Metric_ViewArgs = {
-  _inc?: Maybe<Metric_View_Inc_Input>;
-  _set?: Maybe<Metric_View_Set_Input>;
-  where: Metric_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_Data_SourcesArgs = {
-  _inc?: Maybe<Model_Data_Sources_Inc_Input>;
-  _set?: Maybe<Model_Data_Sources_Set_Input>;
-  where: Model_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_Data_Sources_By_PkArgs = {
-  _inc?: Maybe<Model_Data_Sources_Inc_Input>;
-  _set?: Maybe<Model_Data_Sources_Set_Input>;
-  pk_columns: Model_Data_Sources_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_MetricsArgs = {
-  _inc?: Maybe<Model_Metrics_Inc_Input>;
-  _set?: Maybe<Model_Metrics_Set_Input>;
-  where: Model_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Model_Metrics_By_PkArgs = {
-  _inc?: Maybe<Model_Metrics_Inc_Input>;
-  _set?: Maybe<Model_Metrics_Set_Input>;
-  pk_columns: Model_Metrics_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_ModelsArgs = {
-  _inc?: Maybe<Models_Inc_Input>;
-  _set?: Maybe<Models_Set_Input>;
-  where: Models_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Models_By_PkArgs = {
-  _inc?: Maybe<Models_Inc_Input>;
-  _set?: Maybe<Models_Set_Input>;
-  pk_columns: Models_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Mql_HeartbeatsArgs = {
-  _inc?: Maybe<Mql_Heartbeats_Inc_Input>;
-  _set?: Maybe<Mql_Heartbeats_Set_Input>;
-  where: Mql_Heartbeats_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Mql_Heartbeats_By_PkArgs = {
-  _inc?: Maybe<Mql_Heartbeats_Inc_Input>;
-  _set?: Maybe<Mql_Heartbeats_Set_Input>;
-  pk_columns: Mql_Heartbeats_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Data_SourcesArgs = {
-  _inc?: Maybe<Org_Data_Sources_Inc_Input>;
-  _set?: Maybe<Org_Data_Sources_Set_Input>;
-  where: Org_Data_Sources_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Data_Sources_By_PkArgs = {
-  _inc?: Maybe<Org_Data_Sources_Inc_Input>;
-  _set?: Maybe<Org_Data_Sources_Set_Input>;
-  pk_columns: Org_Data_Sources_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Metrics_Current_ViewArgs = {
-  _inc?: Maybe<Org_Metrics_Current_View_Inc_Input>;
-  _set?: Maybe<Org_Metrics_Current_View_Set_Input>;
-  where: Org_Metrics_Current_View_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Metrics_Current_View_By_PkArgs = {
-  _inc?: Maybe<Org_Metrics_Current_View_Inc_Input>;
-  _set?: Maybe<Org_Metrics_Current_View_Set_Input>;
-  pk_columns: Org_Metrics_Current_View_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Mql_Server_Logs_TypesArgs = {
-  _set?: Maybe<Org_Mql_Server_Logs_Types_Set_Input>;
-  where: Org_Mql_Server_Logs_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Org_Mql_Server_Logs_Types_By_PkArgs = {
-  _set?: Maybe<Org_Mql_Server_Logs_Types_Set_Input>;
-  pk_columns: Org_Mql_Server_Logs_Types_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_PrioritiesArgs = {
-  _set?: Maybe<Priorities_Set_Input>;
-  where: Priorities_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Priorities_By_PkArgs = {
-  _set?: Maybe<Priorities_Set_Input>;
-  pk_columns: Priorities_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_Directed_ToArgs = {
-  _inc?: Maybe<Question_Directed_To_Inc_Input>;
-  _set?: Maybe<Question_Directed_To_Set_Input>;
-  where: Question_Directed_To_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_Directed_To_By_PkArgs = {
-  _inc?: Maybe<Question_Directed_To_Inc_Input>;
-  _set?: Maybe<Question_Directed_To_Set_Input>;
-  pk_columns: Question_Directed_To_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_LikesArgs = {
-  _inc?: Maybe<Question_Likes_Inc_Input>;
-  _set?: Maybe<Question_Likes_Set_Input>;
-  where: Question_Likes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Question_Likes_By_PkArgs = {
-  _inc?: Maybe<Question_Likes_Inc_Input>;
-  _set?: Maybe<Question_Likes_Set_Input>;
-  pk_columns: Question_Likes_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Saved_Query_MetricsArgs = {
-  _inc?: Maybe<Saved_Query_Metrics_Inc_Input>;
-  _set?: Maybe<Saved_Query_Metrics_Set_Input>;
-  where: Saved_Query_Metrics_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Saved_Query_Metrics_By_PkArgs = {
-  _inc?: Maybe<Saved_Query_Metrics_Inc_Input>;
-  _set?: Maybe<Saved_Query_Metrics_Set_Input>;
-  pk_columns: Saved_Query_Metrics_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_Page_Theme_ColorsArgs = {
-  _set?: Maybe<Team_Page_Theme_Colors_Set_Input>;
-  where: Team_Page_Theme_Colors_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_Page_Theme_Colors_By_PkArgs = {
-  _set?: Maybe<Team_Page_Theme_Colors_Set_Input>;
-  pk_columns: Team_Page_Theme_Colors_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_ViewsArgs = {
-  _inc?: Maybe<Team_Views_Inc_Input>;
-  _set?: Maybe<Team_Views_Set_Input>;
-  where: Team_Views_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Team_Views_By_PkArgs = {
-  _inc?: Maybe<Team_Views_Inc_Input>;
-  _set?: Maybe<Team_Views_Set_Input>;
-  pk_columns: Team_Views_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_UnsubscribesArgs = {
-  _inc?: Maybe<Unsubscribes_Inc_Input>;
-  _set?: Maybe<Unsubscribes_Set_Input>;
-  where: Unsubscribes_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_Unsubscribes_By_PkArgs = {
-  _inc?: Maybe<Unsubscribes_Inc_Input>;
-  _set?: Maybe<Unsubscribes_Set_Input>;
-  pk_columns: Unsubscribes_Pk_Columns_Input;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_User_Role_TypesArgs = {
-  _set?: Maybe<User_Role_Types_Set_Input>;
-  where: User_Role_Types_Bool_Exp;
-};
-
-
-/** mutation root */
-export type Mutation_RootUpdate_User_Role_Types_By_PkArgs = {
-  _set?: Maybe<User_Role_Types_Set_Input>;
-  pk_columns: User_Role_Types_Pk_Columns_Input;
-};
 
 /** column ordering options */
 export enum Order_By {
@@ -14249,12 +11080,6 @@ export type Org_Data_Sources_Aggregate_Order_By = {
   variance?: Maybe<Org_Data_Sources_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "org_data_sources" */
-export type Org_Data_Sources_Arr_Rel_Insert_Input = {
-  data: Array<Org_Data_Sources_Insert_Input>;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Org_Data_Sources_Avg_Fields = {
   __typename?: 'org_data_sources_avg_fields';
@@ -14280,29 +11105,6 @@ export type Org_Data_Sources_Bool_Exp = {
   name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "org_data_sources" */
-export enum Org_Data_Sources_Constraint {
-  /** unique or primary key constraint */
-  OrgDataSourcesPkey = 'org_data_sources_pkey'
-}
-
-/** input type for incrementing integer column in table "org_data_sources" */
-export type Org_Data_Sources_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "org_data_sources" */
-export type Org_Data_Sources_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metricVersions?: Maybe<Metric_Versions_Arr_Rel_Insert_Input>;
-  modelDataSources?: Maybe<Model_Data_Sources_Arr_Rel_Insert_Input>;
-  name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -14339,28 +11141,6 @@ export type Org_Data_Sources_Min_Order_By = {
   organizationId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "org_data_sources" */
-export type Org_Data_Sources_Mutation_Response = {
-  __typename?: 'org_data_sources_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Org_Data_Sources>;
-};
-
-/** input type for inserting object relation for remote table "org_data_sources" */
-export type Org_Data_Sources_Obj_Rel_Insert_Input = {
-  data: Org_Data_Sources_Insert_Input;
-  on_conflict?: Maybe<Org_Data_Sources_On_Conflict>;
-};
-
-/** on conflict condition type for table "org_data_sources" */
-export type Org_Data_Sources_On_Conflict = {
-  constraint: Org_Data_Sources_Constraint;
-  update_columns: Array<Org_Data_Sources_Update_Column>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "org_data_sources" */
 export type Org_Data_Sources_Order_By = {
   createdAt?: Maybe<Order_By>;
@@ -14388,14 +11168,6 @@ export enum Org_Data_Sources_Select_Column {
   /** column name */
   OrganizationId = 'organizationId'
 }
-
-/** input type for updating data in table "org_data_sources" */
-export type Org_Data_Sources_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Org_Data_Sources_Stddev_Fields = {
@@ -14448,18 +11220,6 @@ export type Org_Data_Sources_Sum_Order_By = {
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "org_data_sources" */
-export enum Org_Data_Sources_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Org_Data_Sources_Var_Pop_Fields = {
@@ -14546,7 +11306,6 @@ export type Org_Metrics_Current_View = {
   questions: Array<Questions>;
   /** An aggregated array relationship */
   questions_aggregate: Questions_Aggregate;
-  removedAt?: Maybe<Scalars['timestamptz']>;
   /** An array relationship */
   savedQueries: Array<Saved_Query_Metrics>;
   /** An aggregated array relationship */
@@ -14904,12 +11663,6 @@ export type Org_Metrics_Current_View_Aggregate_Order_By = {
   variance?: Maybe<Org_Metrics_Current_View_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Arr_Rel_Insert_Input = {
-  data: Array<Org_Metrics_Current_View_Insert_Input>;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Org_Metrics_Current_View_Avg_Fields = {
   __typename?: 'org_metrics_current_view_avg_fields';
@@ -14953,60 +11706,12 @@ export type Org_Metrics_Current_View_Bool_Exp = {
   organizationId?: Maybe<Int_Comparison_Exp>;
   params?: Maybe<Json_Comparison_Exp>;
   questions?: Maybe<Questions_Bool_Exp>;
-  removedAt?: Maybe<Timestamptz_Comparison_Exp>;
   savedQueries?: Maybe<Saved_Query_Metrics_Bool_Exp>;
   teamOwners?: Maybe<Metric_Team_Owners_Bool_Exp>;
   tier?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   userOwners?: Maybe<Metric_User_Owners_Bool_Exp>;
   views?: Maybe<Metric_View_Bool_Exp>;
-};
-
-/** unique or primary key constraints on table "org_metrics_current_view" */
-export enum Org_Metrics_Current_View_Constraint {
-  /** unique or primary key constraint */
-  OrgMetricsCurrentViewOrganizationIdNameKey = 'org_metrics_current_view_organization_id_name_key',
-  /** unique or primary key constraint */
-  OrgMetricsCurrentViewPkey = 'org_metrics_current_view_pkey'
-}
-
-/** input type for incrementing integer column in table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metricType?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  tier?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Insert_Input = {
-  annotations?: Maybe<Metric_Annotations_Arr_Rel_Insert_Input>;
-  approvals?: Maybe<Metric_Approvals_Arr_Rel_Insert_Input>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  currentDescription?: Maybe<Metric_Current_Description_Obj_Rel_Insert_Input>;
-  currentModelMetric?: Maybe<Model_Metrics_Obj_Rel_Insert_Input>;
-  definition?: Maybe<Scalars['String']>;
-  descriptions?: Maybe<Metric_Descriptions_Arr_Rel_Insert_Input>;
-  displayName?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metadata?: Maybe<Scalars['json']>;
-  metricCollections?: Maybe<Metric_Collection_Metrics_Arr_Rel_Insert_Input>;
-  metricType?: Maybe<Scalars['Int']>;
-  model?: Maybe<Models_Obj_Rel_Insert_Input>;
-  modelId?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['json']>;
-  questions?: Maybe<Questions_Arr_Rel_Insert_Input>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
-  savedQueries?: Maybe<Saved_Query_Metrics_Arr_Rel_Insert_Input>;
-  teamOwners?: Maybe<Metric_Team_Owners_Arr_Rel_Insert_Input>;
-  tier?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userOwners?: Maybe<Metric_User_Owners_Arr_Rel_Insert_Input>;
-  views?: Maybe<Metric_View_Arr_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -15020,7 +11725,6 @@ export type Org_Metrics_Current_View_Max_Fields = {
   modelId?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
   tier?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -15035,7 +11739,6 @@ export type Org_Metrics_Current_View_Max_Order_By = {
   modelId?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  removedAt?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -15051,7 +11754,6 @@ export type Org_Metrics_Current_View_Min_Fields = {
   modelId?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
   organizationId?: Maybe<Scalars['Int']>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
   tier?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -15066,31 +11768,8 @@ export type Org_Metrics_Current_View_Min_Order_By = {
   modelId?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
-  removedAt?: Maybe<Order_By>;
   tier?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Mutation_Response = {
-  __typename?: 'org_metrics_current_view_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Org_Metrics_Current_View>;
-};
-
-/** input type for inserting object relation for remote table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Obj_Rel_Insert_Input = {
-  data: Org_Metrics_Current_View_Insert_Input;
-  on_conflict?: Maybe<Org_Metrics_Current_View_On_Conflict>;
-};
-
-/** on conflict condition type for table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_On_Conflict = {
-  constraint: Org_Metrics_Current_View_Constraint;
-  update_columns: Array<Org_Metrics_Current_View_Update_Column>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "org_metrics_current_view" */
@@ -15114,7 +11793,6 @@ export type Org_Metrics_Current_View_Order_By = {
   organizationId?: Maybe<Order_By>;
   params?: Maybe<Order_By>;
   questions_aggregate?: Maybe<Questions_Aggregate_Order_By>;
-  removedAt?: Maybe<Order_By>;
   savedQueries_aggregate?: Maybe<Saved_Query_Metrics_Aggregate_Order_By>;
   teamOwners_aggregate?: Maybe<Metric_Team_Owners_Aggregate_Order_By>;
   tier?: Maybe<Order_By>;
@@ -15151,29 +11829,10 @@ export enum Org_Metrics_Current_View_Select_Column {
   /** column name */
   Params = 'params',
   /** column name */
-  RemovedAt = 'removedAt',
-  /** column name */
   Tier = 'tier',
   /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "org_metrics_current_view" */
-export type Org_Metrics_Current_View_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  definition?: Maybe<Scalars['String']>;
-  displayName?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  metadata?: Maybe<Scalars['json']>;
-  metricType?: Maybe<Scalars['Int']>;
-  modelId?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  params?: Maybe<Scalars['json']>;
-  removedAt?: Maybe<Scalars['timestamptz']>;
-  tier?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Org_Metrics_Current_View_Stddev_Fields = {
@@ -15251,36 +11910,6 @@ export type Org_Metrics_Current_View_Sum_Order_By = {
   tier?: Maybe<Order_By>;
 };
 
-/** update columns of table "org_metrics_current_view" */
-export enum Org_Metrics_Current_View_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Definition = 'definition',
-  /** column name */
-  DisplayName = 'displayName',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  Metadata = 'metadata',
-  /** column name */
-  MetricType = 'metricType',
-  /** column name */
-  ModelId = 'modelId',
-  /** column name */
-  Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Params = 'params',
-  /** column name */
-  RemovedAt = 'removedAt',
-  /** column name */
-  Tier = 'tier',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
-
 /** aggregate var_pop on columns */
 export type Org_Metrics_Current_View_Var_Pop_Fields = {
   __typename?: 'org_metrics_current_view_var_pop_fields';
@@ -15338,68 +11967,6 @@ export type Org_Metrics_Current_View_Variance_Order_By = {
   tier?: Maybe<Order_By>;
 };
 
-/**
- * Contains options what we do with an org's MQL server logs
- *
- *
- * columns and relationships of "org_mql_server_logs_types"
- */
-export type Org_Mql_Server_Logs_Types = {
-  __typename?: 'org_mql_server_logs_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate = {
-  __typename?: 'org_mql_server_logs_types_aggregate';
-  aggregate?: Maybe<Org_Mql_Server_Logs_Types_Aggregate_Fields>;
-  nodes: Array<Org_Mql_Server_Logs_Types>;
-};
-
-/** aggregate fields of "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate_Fields = {
-  __typename?: 'org_mql_server_logs_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Org_Mql_Server_Logs_Types_Max_Fields>;
-  min?: Maybe<Org_Mql_Server_Logs_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Org_Mql_Server_Logs_Types_Max_Order_By>;
-  min?: Maybe<Org_Mql_Server_Logs_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Arr_Rel_Insert_Input = {
-  data: Array<Org_Mql_Server_Logs_Types_Insert_Input>;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "org_mql_server_logs_types". All fields are combined with a logical 'AND'. */
-export type Org_Mql_Server_Logs_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>>>;
-  _not?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "org_mql_server_logs_types" */
-export enum Org_Mql_Server_Logs_Types_Constraint {
-  /** unique or primary key constraint */
-  OrgMqlServerLogsTypesPkey = 'org_mql_server_logs_types_pkey'
-}
-
 export enum Org_Mql_Server_Logs_Types_Enum {
   /** stream MQL logs back to transform backend */
   Always = 'ALWAYS',
@@ -15418,93 +11985,6 @@ export type Org_Mql_Server_Logs_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Org_Mql_Server_Logs_Types_Enum>>;
 };
 
-/** input type for inserting data into table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Org_Mql_Server_Logs_Types_Max_Fields = {
-  __typename?: 'org_mql_server_logs_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Org_Mql_Server_Logs_Types_Min_Fields = {
-  __typename?: 'org_mql_server_logs_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Mutation_Response = {
-  __typename?: 'org_mql_server_logs_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Org_Mql_Server_Logs_Types>;
-};
-
-/** input type for inserting object relation for remote table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Obj_Rel_Insert_Input = {
-  data: Org_Mql_Server_Logs_Types_Insert_Input;
-  on_conflict?: Maybe<Org_Mql_Server_Logs_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_On_Conflict = {
-  constraint: Org_Mql_Server_Logs_Types_Constraint;
-  update_columns: Array<Org_Mql_Server_Logs_Types_Update_Column>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "org_mql_server_logs_types" */
-export enum Org_Mql_Server_Logs_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "org_mql_server_logs_types" */
-export type Org_Mql_Server_Logs_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "org_mql_server_logs_types" */
-export enum Org_Mql_Server_Logs_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
 /**
  * Allowing for multiple MQL Servers for an Organization enables the use of development environments and other non-production applications.
  *
@@ -15515,11 +11995,8 @@ export type Org_Mql_Servers = {
   __typename?: 'org_mql_servers';
   configSecret?: Maybe<Scalars['String']>;
   createdAt: Scalars['timestamptz'];
-  dw_engine?: Maybe<Dw_Engines_Enum>;
   /** An array relationship */
   heartbeats: Array<Mql_Heartbeats>;
-  /** An aggregated array relationship */
-  heartbeats_aggregate: Mql_Heartbeats_Aggregate;
   id: Scalars['Int'];
   isOrgDefault: Scalars['Boolean'];
   name: Scalars['String'];
@@ -15538,21 +12015,6 @@ export type Org_Mql_Servers = {
  * columns and relationships of "org_mql_servers"
  */
 export type Org_Mql_ServersHeartbeatsArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/**
- * Allowing for multiple MQL Servers for an Organization enables the use of development environments and other non-production applications.
- *
- *
- * columns and relationships of "org_mql_servers"
- */
-export type Org_Mql_ServersHeartbeats_AggregateArgs = {
   distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
   limit?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
@@ -15631,7 +12093,6 @@ export type Org_Mql_Servers_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Org_Mql_Servers_Bool_Exp>>>;
   configSecret?: Maybe<String_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dw_engine?: Maybe<Dw_Engines_Enum_Comparison_Exp>;
   heartbeats?: Maybe<Mql_Heartbeats_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   isOrgDefault?: Maybe<Boolean_Comparison_Exp>;
@@ -15650,24 +12111,12 @@ export enum Org_Mql_Servers_Constraint {
   OrgMqlServersPkey = 'org_mql_servers_pkey'
 }
 
-/** input type for incrementing integer column in table "org_mql_servers" */
-export type Org_Mql_Servers_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "org_mql_servers" */
 export type Org_Mql_Servers_Insert_Input = {
   configSecret?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dw_engine?: Maybe<Dw_Engines_Enum>;
   heartbeats?: Maybe<Mql_Heartbeats_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars['Int']>;
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   url?: Maybe<Scalars['String']>;
 };
 
@@ -15743,8 +12192,6 @@ export type Org_Mql_Servers_On_Conflict = {
 export type Org_Mql_Servers_Order_By = {
   configSecret?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  dw_engine?: Maybe<Order_By>;
-  heartbeats_aggregate?: Maybe<Mql_Heartbeats_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
   isOrgDefault?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
@@ -15766,8 +12213,6 @@ export enum Org_Mql_Servers_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DwEngine = 'dw_engine',
-  /** column name */
   Id = 'id',
   /** column name */
   IsOrgDefault = 'isOrgDefault',
@@ -15784,13 +12229,8 @@ export enum Org_Mql_Servers_Select_Column {
 /** input type for updating data in table "org_mql_servers" */
 export type Org_Mql_Servers_Set_Input = {
   configSecret?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dw_engine?: Maybe<Dw_Engines_Enum>;
-  id?: Maybe<Scalars['Int']>;
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   url?: Maybe<Scalars['String']>;
 };
 
@@ -15851,19 +12291,9 @@ export enum Org_Mql_Servers_Update_Column {
   /** column name */
   ConfigSecret = 'configSecret',
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DwEngine = 'dw_engine',
-  /** column name */
-  Id = 'id',
-  /** column name */
   IsOrgDefault = 'isOrgDefault',
   /** column name */
   Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
   /** column name */
   Url = 'url'
 }
@@ -15963,12 +12393,6 @@ export type Organization_Features_Aggregate_Order_By = {
   variance?: Maybe<Organization_Features_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "organization_features" */
-export type Organization_Features_Arr_Rel_Insert_Input = {
-  data: Array<Organization_Features_Insert_Input>;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type Organization_Features_Avg_Fields = {
   __typename?: 'organization_features_avg_fields';
@@ -15991,26 +12415,6 @@ export type Organization_Features_Bool_Exp = {
   featureId?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "organization_features" */
-export enum Organization_Features_Constraint {
-  /** unique or primary key constraint */
-  OrganizationFeaturesPkey = 'organization_features_pkey'
-}
-
-/** input type for incrementing integer column in table "organization_features" */
-export type Organization_Features_Inc_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "organization_features" */
-export type Organization_Features_Insert_Input = {
-  feature?: Maybe<Features_Obj_Rel_Insert_Input>;
-  featureId?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -16039,28 +12443,6 @@ export type Organization_Features_Min_Order_By = {
   organizationId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "organization_features" */
-export type Organization_Features_Mutation_Response = {
-  __typename?: 'organization_features_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Organization_Features>;
-};
-
-/** input type for inserting object relation for remote table "organization_features" */
-export type Organization_Features_Obj_Rel_Insert_Input = {
-  data: Organization_Features_Insert_Input;
-  on_conflict?: Maybe<Organization_Features_On_Conflict>;
-};
-
-/** on conflict condition type for table "organization_features" */
-export type Organization_Features_On_Conflict = {
-  constraint: Organization_Features_Constraint;
-  update_columns: Array<Organization_Features_Update_Column>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "organization_features" */
 export type Organization_Features_Order_By = {
   feature?: Maybe<Features_Order_By>;
@@ -16082,12 +12464,6 @@ export enum Organization_Features_Select_Column {
   /** column name */
   OrganizationId = 'organizationId'
 }
-
-/** input type for updating data in table "organization_features" */
-export type Organization_Features_Set_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Organization_Features_Stddev_Fields = {
@@ -16140,14 +12516,6 @@ export type Organization_Features_Sum_Order_By = {
   featureId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
 };
-
-/** update columns of table "organization_features" */
-export enum Organization_Features_Update_Column {
-  /** column name */
-  FeatureId = 'featureId',
-  /** column name */
-  OrganizationId = 'organizationId'
-}
 
 /** aggregate var_pop on columns */
 export type Organization_Features_Var_Pop_Fields = {
@@ -16216,11 +12584,8 @@ export type Organizations = {
   dataSources: Array<Org_Data_Sources>;
   /** An aggregated array relationship */
   dataSources_aggregate: Org_Data_Sources_Aggregate;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
   /** This is a soft delete for the Organization model. If the Organization has been deactivated, this value will reflect the timestamp of that operation. If the Organization is active, this value will be null. */
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
   /** An array relationship */
   features: Array<Organization_Features>;
   /** An aggregated array relationship */
@@ -16260,8 +12625,6 @@ export type Organizations = {
   models_aggregate: Models_Aggregate;
   /** An array relationship */
   mqlHeartbeats: Array<Mql_Heartbeats>;
-  /** An aggregated array relationship */
-  mqlHeartbeats_aggregate: Mql_Heartbeats_Aggregate;
   mqlServerLogs?: Maybe<Org_Mql_Server_Logs_Types_Enum>;
   /** The URL of your MQL Server */
   mqlServerUrl?: Maybe<Scalars['String']>;
@@ -16296,8 +12659,6 @@ export type Organizations = {
   /** An aggregated array relationship */
   savedQueries_aggregate: Saved_Queries_Aggregate;
   shardId?: Maybe<Scalars['Int']>;
-  /** The slug is a URL-friendly string used to identify an organization in the App */
-  slug?: Maybe<Scalars['String']>;
   /** The URL of your source control system, used for generating links to config files */
   sourceControlUrl?: Maybe<Scalars['String']>;
   /** An array relationship */
@@ -16708,21 +13069,6 @@ export type OrganizationsMqlHeartbeatsArgs = {
  *
  * columns and relationships of "organizations"
  */
-export type OrganizationsMqlHeartbeats_AggregateArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/**
- * An Organization is a company that is a customer of Transform
- *
- *
- * columns and relationships of "organizations"
- */
 export type OrganizationsMqlServersArgs = {
   distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
   limit?: Maybe<Scalars['Int']>;
@@ -17046,74 +13392,6 @@ export type OrganizationsUsers_AggregateArgs = {
   where?: Maybe<Users_Bool_Exp>;
 };
 
-/** aggregated selection of "organizations" */
-export type Organizations_Aggregate = {
-  __typename?: 'organizations_aggregate';
-  aggregate?: Maybe<Organizations_Aggregate_Fields>;
-  nodes: Array<Organizations>;
-};
-
-/** aggregate fields of "organizations" */
-export type Organizations_Aggregate_Fields = {
-  __typename?: 'organizations_aggregate_fields';
-  avg?: Maybe<Organizations_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Organizations_Max_Fields>;
-  min?: Maybe<Organizations_Min_Fields>;
-  stddev?: Maybe<Organizations_Stddev_Fields>;
-  stddev_pop?: Maybe<Organizations_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Organizations_Stddev_Samp_Fields>;
-  sum?: Maybe<Organizations_Sum_Fields>;
-  var_pop?: Maybe<Organizations_Var_Pop_Fields>;
-  var_samp?: Maybe<Organizations_Var_Samp_Fields>;
-  variance?: Maybe<Organizations_Variance_Fields>;
-};
-
-
-/** aggregate fields of "organizations" */
-export type Organizations_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Organizations_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "organizations" */
-export type Organizations_Aggregate_Order_By = {
-  avg?: Maybe<Organizations_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Organizations_Max_Order_By>;
-  min?: Maybe<Organizations_Min_Order_By>;
-  stddev?: Maybe<Organizations_Stddev_Order_By>;
-  stddev_pop?: Maybe<Organizations_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Organizations_Stddev_Samp_Order_By>;
-  sum?: Maybe<Organizations_Sum_Order_By>;
-  var_pop?: Maybe<Organizations_Var_Pop_Order_By>;
-  var_samp?: Maybe<Organizations_Var_Samp_Order_By>;
-  variance?: Maybe<Organizations_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "organizations" */
-export type Organizations_Arr_Rel_Insert_Input = {
-  data: Array<Organizations_Insert_Input>;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Organizations_Avg_Fields = {
-  __typename?: 'organizations_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "organizations" */
-export type Organizations_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
 /** Boolean expression to filter rows from the table "organizations". All fields are combined with a logical 'AND'. */
 export type Organizations_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Organizations_Bool_Exp>>>;
@@ -17125,10 +13403,7 @@ export type Organizations_Bool_Exp = {
   currentModel?: Maybe<Model_Current_Bool_Exp>;
   dashboards?: Maybe<Dashboards_Bool_Exp>;
   dataSources?: Maybe<Org_Data_Sources_Bool_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
-  date_delete?: Maybe<Int_Comparison_Exp>;
   deactivatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  domain?: Maybe<String_Comparison_Exp>;
   features?: Maybe<Organization_Features_Bool_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   isHosted?: Maybe<Boolean_Comparison_Exp>;
@@ -17153,7 +13428,6 @@ export type Organizations_Bool_Exp = {
   questions?: Maybe<Questions_Bool_Exp>;
   savedQueries?: Maybe<Saved_Queries_Bool_Exp>;
   shardId?: Maybe<Int_Comparison_Exp>;
-  slug?: Maybe<String_Comparison_Exp>;
   sourceControlUrl?: Maybe<String_Comparison_Exp>;
   team_members?: Maybe<Team_Members_Bool_Exp>;
   teams?: Maybe<Teams_Bool_Exp>;
@@ -17169,137 +13443,6 @@ export enum Organizations_Constraint {
   OrganizationsPkey = 'organizations_pkey'
 }
 
-/** input type for incrementing integer column in table "organizations" */
-export type Organizations_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  shardId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "organizations" */
-export type Organizations_Insert_Input = {
-  annotations?: Maybe<Annotations_Arr_Rel_Insert_Input>;
-  api_keys?: Maybe<Api_Keys_Arr_Rel_Insert_Input>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboards?: Maybe<Dashboards_Arr_Rel_Insert_Input>;
-  dataSources?: Maybe<Org_Data_Sources_Arr_Rel_Insert_Input>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  features?: Maybe<Organization_Features_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars['Int']>;
-  isHosted?: Maybe<Scalars['Boolean']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  metricCollections?: Maybe<Metric_Collections_Arr_Rel_Insert_Input>;
-  metric_annotations?: Maybe<Metric_Annotations_Arr_Rel_Insert_Input>;
-  metric_approvals?: Maybe<Metric_Approvals_Arr_Rel_Insert_Input>;
-  metric_team_owners?: Maybe<Metric_Team_Owners_Arr_Rel_Insert_Input>;
-  metric_views?: Maybe<Metric_View_Arr_Rel_Insert_Input>;
-  metrics?: Maybe<Org_Metrics_Current_View_Arr_Rel_Insert_Input>;
-  models?: Maybe<Models_Arr_Rel_Insert_Input>;
-  mqlHeartbeats?: Maybe<Mql_Heartbeats_Arr_Rel_Insert_Input>;
-  mqlServerLogs?: Maybe<Org_Mql_Server_Logs_Types_Enum>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  mqlServers?: Maybe<Org_Mql_Servers_Arr_Rel_Insert_Input>;
-  name?: Maybe<Scalars['String']>;
-  primaryConfigBranch?: Maybe<Scalars['String']>;
-  primaryConfigRepo?: Maybe<Scalars['String']>;
-  question_directed_tos?: Maybe<Question_Directed_To_Arr_Rel_Insert_Input>;
-  question_likes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
-  question_replies?: Maybe<Question_Replies_Arr_Rel_Insert_Input>;
-  questions?: Maybe<Questions_Arr_Rel_Insert_Input>;
-  savedQueries?: Maybe<Saved_Queries_Arr_Rel_Insert_Input>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
-  sourceControlUrl?: Maybe<Scalars['String']>;
-  team_members?: Maybe<Team_Members_Arr_Rel_Insert_Input>;
-  teams?: Maybe<Teams_Arr_Rel_Insert_Input>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  user_prefs?: Maybe<User_Prefs_Arr_Rel_Insert_Input>;
-  user_roles?: Maybe<User_Roles_Arr_Rel_Insert_Input>;
-  users?: Maybe<Users_Arr_Rel_Insert_Input>;
-};
-
-/** aggregate max on columns */
-export type Organizations_Max_Fields = {
-  __typename?: 'organizations_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  primaryConfigBranch?: Maybe<Scalars['String']>;
-  primaryConfigRepo?: Maybe<Scalars['String']>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
-  sourceControlUrl?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** order by max() on columns of table "organizations" */
-export type Organizations_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  domain?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  logoUrl?: Maybe<Order_By>;
-  mqlServerUrl?: Maybe<Order_By>;
-  name?: Maybe<Order_By>;
-  primaryConfigBranch?: Maybe<Order_By>;
-  primaryConfigRepo?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-  slug?: Maybe<Order_By>;
-  sourceControlUrl?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Organizations_Min_Fields = {
-  __typename?: 'organizations_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  logoUrl?: Maybe<Scalars['String']>;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  primaryConfigBranch?: Maybe<Scalars['String']>;
-  primaryConfigRepo?: Maybe<Scalars['String']>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
-  sourceControlUrl?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** order by min() on columns of table "organizations" */
-export type Organizations_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  domain?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  logoUrl?: Maybe<Order_By>;
-  mqlServerUrl?: Maybe<Order_By>;
-  name?: Maybe<Order_By>;
-  primaryConfigBranch?: Maybe<Order_By>;
-  primaryConfigRepo?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-  slug?: Maybe<Order_By>;
-  sourceControlUrl?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-};
-
 /** response of any mutation on the table "organizations" */
 export type Organizations_Mutation_Response = {
   __typename?: 'organizations_mutation_response';
@@ -17307,12 +13450,6 @@ export type Organizations_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data of the affected rows by the mutation */
   returning: Array<Organizations>;
-};
-
-/** input type for inserting object relation for remote table "organizations" */
-export type Organizations_Obj_Rel_Insert_Input = {
-  data: Organizations_Insert_Input;
-  on_conflict?: Maybe<Organizations_On_Conflict>;
 };
 
 /** on conflict condition type for table "organizations" */
@@ -17330,10 +13467,7 @@ export type Organizations_Order_By = {
   currentModel?: Maybe<Model_Current_Order_By>;
   dashboards_aggregate?: Maybe<Dashboards_Aggregate_Order_By>;
   dataSources_aggregate?: Maybe<Org_Data_Sources_Aggregate_Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
-  domain?: Maybe<Order_By>;
   features_aggregate?: Maybe<Organization_Features_Aggregate_Order_By>;
   id?: Maybe<Order_By>;
   isHosted?: Maybe<Order_By>;
@@ -17345,7 +13479,6 @@ export type Organizations_Order_By = {
   metric_views_aggregate?: Maybe<Metric_View_Aggregate_Order_By>;
   metrics_aggregate?: Maybe<Org_Metrics_Current_View_Aggregate_Order_By>;
   models_aggregate?: Maybe<Models_Aggregate_Order_By>;
-  mqlHeartbeats_aggregate?: Maybe<Mql_Heartbeats_Aggregate_Order_By>;
   mqlServerLogs?: Maybe<Order_By>;
   mqlServerUrl?: Maybe<Order_By>;
   mqlServers_aggregate?: Maybe<Org_Mql_Servers_Aggregate_Order_By>;
@@ -17358,7 +13491,6 @@ export type Organizations_Order_By = {
   questions_aggregate?: Maybe<Questions_Aggregate_Order_By>;
   savedQueries_aggregate?: Maybe<Saved_Queries_Aggregate_Order_By>;
   shardId?: Maybe<Order_By>;
-  slug?: Maybe<Order_By>;
   sourceControlUrl?: Maybe<Order_By>;
   team_members_aggregate?: Maybe<Team_Members_Aggregate_Order_By>;
   teams_aggregate?: Maybe<Teams_Aggregate_Order_By>;
@@ -17379,13 +13511,7 @@ export enum Organizations_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDelete = 'date_delete',
-  /** column name */
   DeactivatedAt = 'deactivatedAt',
-  /** column name */
-  Domain = 'domain',
   /** column name */
   Id = 'id',
   /** column name */
@@ -17404,8 +13530,6 @@ export enum Organizations_Select_Column {
   PrimaryConfigRepo = 'primaryConfigRepo',
   /** column name */
   ShardId = 'shardId',
-  /** column name */
-  Slug = 'slug',
   /** column name */
   SourceControlUrl = 'sourceControlUrl',
   /** column name */
@@ -17414,113 +13538,18 @@ export enum Organizations_Select_Column {
 
 /** input type for updating data in table "organizations" */
 export type Organizations_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  domain?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  isHosted?: Maybe<Scalars['Boolean']>;
   logoUrl?: Maybe<Scalars['String']>;
-  mqlServerLogs?: Maybe<Org_Mql_Server_Logs_Types_Enum>;
   mqlServerUrl?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   primaryConfigBranch?: Maybe<Scalars['String']>;
   primaryConfigRepo?: Maybe<Scalars['String']>;
-  shardId?: Maybe<Scalars['Int']>;
-  slug?: Maybe<Scalars['String']>;
   sourceControlUrl?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** aggregate stddev on columns */
-export type Organizations_Stddev_Fields = {
-  __typename?: 'organizations_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "organizations" */
-export type Organizations_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Organizations_Stddev_Pop_Fields = {
-  __typename?: 'organizations_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "organizations" */
-export type Organizations_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Organizations_Stddev_Samp_Fields = {
-  __typename?: 'organizations_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "organizations" */
-export type Organizations_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Organizations_Sum_Fields = {
-  __typename?: 'organizations_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
-  date_delete?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  shardId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "organizations" */
-export type Organizations_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
 };
 
 /** update columns of table "organizations" */
 export enum Organizations_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDelete = 'date_delete',
-  /** column name */
-  DeactivatedAt = 'deactivatedAt',
-  /** column name */
-  Domain = 'domain',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  IsHosted = 'isHosted',
-  /** column name */
   LogoUrl = 'logoUrl',
-  /** column name */
-  MqlServerLogs = 'mqlServerLogs',
   /** column name */
   MqlServerUrl = 'mqlServerUrl',
   /** column name */
@@ -17530,106 +13559,13 @@ export enum Organizations_Update_Column {
   /** column name */
   PrimaryConfigRepo = 'primaryConfigRepo',
   /** column name */
-  ShardId = 'shardId',
-  /** column name */
-  Slug = 'slug',
-  /** column name */
-  SourceControlUrl = 'sourceControlUrl',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  SourceControlUrl = 'sourceControlUrl'
 }
-
-/** aggregate var_pop on columns */
-export type Organizations_Var_Pop_Fields = {
-  __typename?: 'organizations_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "organizations" */
-export type Organizations_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Organizations_Var_Samp_Fields = {
-  __typename?: 'organizations_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "organizations" */
-export type Organizations_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Organizations_Variance_Fields = {
-  __typename?: 'organizations_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_delete?: Maybe<Scalars['Float']>;
-  id?: Maybe<Scalars['Float']>;
-  shardId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "organizations" */
-export type Organizations_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_delete?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  shardId?: Maybe<Order_By>;
-};
 
 /** columns and relationships of "priorities" */
 export type Priorities = {
   __typename?: 'priorities';
-  comment?: Maybe<Scalars['String']>;
   value: Scalars['String'];
-};
-
-/** aggregated selection of "priorities" */
-export type Priorities_Aggregate = {
-  __typename?: 'priorities_aggregate';
-  aggregate?: Maybe<Priorities_Aggregate_Fields>;
-  nodes: Array<Priorities>;
-};
-
-/** aggregate fields of "priorities" */
-export type Priorities_Aggregate_Fields = {
-  __typename?: 'priorities_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Priorities_Max_Fields>;
-  min?: Maybe<Priorities_Min_Fields>;
-};
-
-
-/** aggregate fields of "priorities" */
-export type Priorities_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Priorities_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "priorities" */
-export type Priorities_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Priorities_Max_Order_By>;
-  min?: Maybe<Priorities_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "priorities" */
-export type Priorities_Arr_Rel_Insert_Input = {
-  data: Array<Priorities_Insert_Input>;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
 };
 
 /** Boolean expression to filter rows from the table "priorities". All fields are combined with a logical 'AND'. */
@@ -17637,17 +13573,8 @@ export type Priorities_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Priorities_Bool_Exp>>>;
   _not?: Maybe<Priorities_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Priorities_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
   value?: Maybe<String_Comparison_Exp>;
 };
-
-/** unique or primary key constraints on table "priorities" */
-export enum Priorities_Constraint {
-  /** unique or primary key constraint */
-  PrioritiesNameKey = 'priorities_name_key',
-  /** unique or primary key constraint */
-  PrioritiesPkey = 'priorities_pkey'
-}
 
 export enum Priorities_Enum {
   Critical = 'CRITICAL',
@@ -17666,63 +13593,8 @@ export type Priorities_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<Priorities_Enum>>;
 };
 
-/** input type for inserting data into table "priorities" */
-export type Priorities_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Priorities_Max_Fields = {
-  __typename?: 'priorities_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "priorities" */
-export type Priorities_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Priorities_Min_Fields = {
-  __typename?: 'priorities_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "priorities" */
-export type Priorities_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "priorities" */
-export type Priorities_Mutation_Response = {
-  __typename?: 'priorities_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Priorities>;
-};
-
-/** input type for inserting object relation for remote table "priorities" */
-export type Priorities_Obj_Rel_Insert_Input = {
-  data: Priorities_Insert_Input;
-  on_conflict?: Maybe<Priorities_On_Conflict>;
-};
-
-/** on conflict condition type for table "priorities" */
-export type Priorities_On_Conflict = {
-  constraint: Priorities_Constraint;
-  update_columns: Array<Priorities_Update_Column>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "priorities" */
 export type Priorities_Order_By = {
-  comment?: Maybe<Order_By>;
   value?: Maybe<Order_By>;
 };
 
@@ -17734,1821 +13606,8 @@ export type Priorities_Pk_Columns_Input = {
 /** select columns of table "priorities" */
 export enum Priorities_Select_Column {
   /** column name */
-  Comment = 'comment',
-  /** column name */
   Value = 'value'
 }
-
-/** input type for updating data in table "priorities" */
-export type Priorities_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "priorities" */
-export enum Priorities_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** query root */
-export type Query_Root = {
-  __typename?: 'query_root';
-  /** fetch data from the table: "annotations" using primary key columns */
-  annotation?: Maybe<Annotations>;
-  /** fetch data from the table: "annotations" */
-  annotations: Array<Annotations>;
-  /** fetch aggregated fields from the table: "annotations" */
-  annotationsAggregate: Annotations_Aggregate;
-  /** fetch data from the table: "api_keys" using primary key columns */
-  apiKey?: Maybe<Api_Keys>;
-  /** fetch data from the table: "api_keys" */
-  apiKeys: Array<Api_Keys>;
-  /** fetch aggregated fields from the table: "api_keys" */
-  apiKeysAggregate: Api_Keys_Aggregate;
-  auth0Profile?: Maybe<Auth0Profile>;
-  /** fetch data from the table: "branch_metadatas" */
-  branch_metadatas: Array<Branch_Metadatas>;
-  /** fetch aggregated fields from the table: "branch_metadatas" */
-  branch_metadatas_aggregate: Branch_Metadatas_Aggregate;
-  /** fetch data from the table: "branch_metadatas" using primary key columns */
-  branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** fetch data from the table: "dashboards" using primary key columns */
-  dashboard?: Maybe<Dashboards>;
-  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
-  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
-  /** fetch data from the table: "dashboard_item_configs" */
-  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
-  /** fetch aggregated fields from the table: "dashboard_item_configs" */
-  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
-  /** fetch data from the table: "dashboard_layouts" using primary key columns */
-  dashboardLayout?: Maybe<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_layouts" */
-  dashboardLayouts: Array<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_renderable_types" using primary key columns */
-  dashboardRenderableType?: Maybe<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_renderable_types" */
-  dashboardRenderableTypes: Array<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_sections" using primary key columns */
-  dashboardSection?: Maybe<Dashboard_Sections>;
-  /** fetch data from the table: "dashboard_section_types" using primary key columns */
-  dashboardSectionType?: Maybe<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_section_types" */
-  dashboardSectionTypes: Array<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_sections" */
-  dashboardSections: Array<Dashboard_Sections>;
-  /** fetch aggregated fields from the table: "dashboard_sections" */
-  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_layouts" */
-  dashboard_layouts_aggregate: Dashboard_Layouts_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_renderable_types" */
-  dashboard_renderable_types_aggregate: Dashboard_Renderable_Types_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_section_types" */
-  dashboard_section_types_aggregate: Dashboard_Section_Types_Aggregate;
-  /** fetch data from the table: "dashboards" */
-  dashboards: Array<Dashboards>;
-  /** fetch aggregated fields from the table: "dashboards" */
-  dashboardsAggregate: Dashboards_Aggregate;
-  /** fetch data from the table: "org_data_sources" using primary key columns */
-  dataSource?: Maybe<Org_Data_Sources>;
-  /** fetch data from the table: "data_source_versions" using primary key columns */
-  dataSourceVersion?: Maybe<Data_Source_Versions>;
-  /** fetch data from the table: "data_source_versions" */
-  dataSourceVersions: Array<Data_Source_Versions>;
-  /** fetch aggregated fields from the table: "data_source_versions" */
-  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
-  /** fetch data from the table: "org_data_sources" */
-  dataSources: Array<Org_Data_Sources>;
-  /** fetch aggregated fields from the table: "org_data_sources" */
-  dataSourcesAggregate: Org_Data_Sources_Aggregate;
-  /** fetch data from the table: "dw_engines" */
-  dw_engines: Array<Dw_Engines>;
-  /** fetch aggregated fields from the table: "dw_engines" */
-  dw_engines_aggregate: Dw_Engines_Aggregate;
-  /** fetch data from the table: "dw_engines" using primary key columns */
-  dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** fetch data from the table: "features" using primary key columns */
-  feature?: Maybe<Features>;
-  /** fetch data from the table: "features" */
-  features: Array<Features>;
-  /** fetch aggregated fields from the table: "features" */
-  featuresAggregate: Features_Aggregate;
-  latestMqlServer?: Maybe<MqlServerVersion>;
-  /** execute function "me" which returns "users" */
-  me: Array<Users>;
-  /** execute function "me" and query aggregates on result of table type "users" */
-  me_aggregate: Users_Aggregate;
-  /** fetch data from the table: "metric_annotations" using primary key columns */
-  metricAnnotation?: Maybe<Metric_Annotations>;
-  /** fetch data from the table: "metric_annotations" */
-  metricAnnotations: Array<Metric_Annotations>;
-  /** fetch aggregated fields from the table: "metric_annotations" */
-  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
-  /** fetch data from the table: "metric_approvals" using primary key columns */
-  metricApproval?: Maybe<Metric_Approvals>;
-  /** fetch data from the table: "metric_approvals" */
-  metricApprovals: Array<Metric_Approvals>;
-  /** fetch aggregated fields from the table: "metric_approvals" */
-  metricApprovalsAggregate: Metric_Approvals_Aggregate;
-  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
-  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
-  /** fetch data from the table: "metric_collections" using primary key columns */
-  metricCollection?: Maybe<Metric_Collections>;
-  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
-  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** fetch data from the table: "metric_collection_metrics" */
-  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
-  /** fetch aggregated fields from the table: "metric_collection_metrics" */
-  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
-  /** fetch data from the table: "metric_collection_view" using primary key columns */
-  metricCollectionView?: Maybe<Metric_Collection_View>;
-  /** fetch aggregated fields from the table: "metric_collection_view" */
-  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
-  /** fetch data from the table: "metric_collection_view" */
-  metricCollectionViews: Array<Metric_Collection_View>;
-  /** fetch data from the table: "metric_collections" */
-  metricCollections: Array<Metric_Collections>;
-  /** fetch aggregated fields from the table: "metric_collections" */
-  metricCollectionsAggregate: Metric_Collections_Aggregate;
-  /** fetch data from the table: "metric_current_description" */
-  metricCurrentDescriptions: Array<Metric_Current_Description>;
-  /** fetch data from the table: "metric_descriptions" using primary key columns */
-  metricDescription?: Maybe<Metric_Descriptions>;
-  /** fetch data from the table: "metric_descriptions" */
-  metricDescriptions: Array<Metric_Descriptions>;
-  /** fetch aggregated fields from the table: "metric_descriptions" */
-  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
-  /** fetch data from the table: "metric_team_owners" using primary key columns */
-  metricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** fetch data from the table: "metric_team_owners" */
-  metricTeamOwners: Array<Metric_Team_Owners>;
-  /** fetch aggregated fields from the table: "metric_team_owners" */
-  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
-  /** fetch data from the table: "metric_user_owners" using primary key columns */
-  metricUserOwner?: Maybe<Metric_User_Owners>;
-  /** fetch data from the table: "metric_user_owners" */
-  metricUserOwners: Array<Metric_User_Owners>;
-  /** fetch aggregated fields from the table: "metric_user_owners" */
-  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
-  /** fetch data from the table: "metric_versions" using primary key columns */
-  metricVersion?: Maybe<Metric_Versions>;
-  /** fetch data from the table: "metric_versions" */
-  metricVersions: Array<Metric_Versions>;
-  /** fetch aggregated fields from the table: "metric_versions" */
-  metricVersionsAggregate: Metric_Versions_Aggregate;
-  /** fetch data from the table: "metric_view" */
-  metricViews: Array<Metric_View>;
-  /** fetch aggregated fields from the table: "metric_view" */
-  metricViewsAggregate: Metric_View_Aggregate;
-  /** fetch aggregated fields from the table: "metric_current_description" */
-  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
-  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
-  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** fetch data from the table: "org_metrics_current_view" */
-  metrics: Array<Org_Metrics_Current_View>;
-  /** fetch aggregated fields from the table: "org_metrics_current_view" */
-  metricsAggregate: Org_Metrics_Current_View_Aggregate;
-  /** fetch data from the table: "models" using primary key columns */
-  model?: Maybe<Models>;
-  /** fetch data from the table: "model_data_sources" using primary key columns */
-  modelDataSource?: Maybe<Model_Data_Sources>;
-  /** fetch data from the table: "model_data_sources" */
-  modelDataSources: Array<Model_Data_Sources>;
-  /** fetch aggregated fields from the table: "model_data_sources" */
-  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
-  /** fetch data from the table: "model_metrics" using primary key columns */
-  modelMetric?: Maybe<Model_Metrics>;
-  /** fetch data from the table: "model_metrics" */
-  modelMetrics: Array<Model_Metrics>;
-  /** fetch aggregated fields from the table: "model_metrics" */
-  modelMetricsAggregate: Model_Metrics_Aggregate;
-  /** fetch data from the table: "model_current" */
-  model_current: Array<Model_Current>;
-  /** fetch aggregated fields from the table: "model_current" */
-  model_current_aggregate: Model_Current_Aggregate;
-  /** fetch data from the table: "models" */
-  models: Array<Models>;
-  /** fetch aggregated fields from the table: "models" */
-  modelsAggregate: Models_Aggregate;
-  /** fetch data from the table: "mql_heartbeats" using primary key columns */
-  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
-  /** fetch data from the table: "mql_heartbeats" */
-  mqlHeartbeats: Array<Mql_Heartbeats>;
-  /** fetch aggregated fields from the table: "mql_heartbeats" */
-  mqlHeartbeatsAggregate: Mql_Heartbeats_Aggregate;
-  mqlServerUrl?: Maybe<Scalars['String']>;
-  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
-  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
-  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
-  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
-  /** execute function "my_org" which returns "organizations" */
-  my_org: Array<Organizations>;
-  /** execute function "my_org" and query aggregates on result of table type "organizations" */
-  my_org_aggregate: Organizations_Aggregate;
-  /** fetch data from the table: "org_mql_servers" using primary key columns */
-  orgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** fetch data from the table: "org_mql_servers" */
-  orgMqlServers: Array<Org_Mql_Servers>;
-  /** fetch aggregated fields from the table: "org_mql_servers" */
-  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types: Array<Org_Mql_Server_Logs_Types>;
-  /** fetch aggregated fields from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types_aggregate: Org_Mql_Server_Logs_Types_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" using primary key columns */
-  org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** fetch data from the table: "organizations" using primary key columns */
-  organization?: Maybe<Organizations>;
-  /** fetch data from the table: "organization_features" using primary key columns */
-  organizationFeature?: Maybe<Organization_Features>;
-  /** fetch data from the table: "organization_features" */
-  organizationFeatures: Array<Organization_Features>;
-  /** fetch aggregated fields from the table: "organization_features" */
-  organizationFeaturesAggregate: Organization_Features_Aggregate;
-  /** fetch data from the table: "organizations" */
-  organizations: Array<Organizations>;
-  /** fetch aggregated fields from the table: "organizations" */
-  organizationsAggregate: Organizations_Aggregate;
-  /** fetch data from the table: "priorities" */
-  priorities: Array<Priorities>;
-  /** fetch aggregated fields from the table: "priorities" */
-  priorities_aggregate: Priorities_Aggregate;
-  /** fetch data from the table: "priorities" using primary key columns */
-  priorities_by_pk?: Maybe<Priorities>;
-  /** fetch data from the table: "questions" using primary key columns */
-  question?: Maybe<Questions>;
-  /** fetch data from the table: "question_directed_to" */
-  questionDirectedTo: Array<Question_Directed_To>;
-  /** fetch aggregated fields from the table: "question_directed_to" */
-  questionDirectedToAggregate: Question_Directed_To_Aggregate;
-  /** fetch data from the table: "question_directed_to" using primary key columns */
-  questionDirectedToByPK?: Maybe<Question_Directed_To>;
-  /** fetch data from the table: "question_likes" using primary key columns */
-  questionLike?: Maybe<Question_Likes>;
-  /** fetch data from the table: "question_likes" */
-  questionLikes: Array<Question_Likes>;
-  /** fetch aggregated fields from the table: "question_likes" */
-  questionLikesAggregate: Question_Likes_Aggregate;
-  /** fetch data from the table: "question_replies" */
-  questionReplies: Array<Question_Replies>;
-  /** fetch aggregated fields from the table: "question_replies" */
-  questionRepliesAggregate: Question_Replies_Aggregate;
-  /** fetch data from the table: "question_replies" using primary key columns */
-  questionReply?: Maybe<Question_Replies>;
-  /** fetch data from the table: "questions" */
-  questions: Array<Questions>;
-  /** fetch aggregated fields from the table: "questions" */
-  questionsAggregate: Questions_Aggregate;
-  /** fetch data from the table: "saved_queries" */
-  savedQueries: Array<Saved_Queries>;
-  /** fetch aggregated fields from the table: "saved_queries" */
-  savedQueriesAggregate: Saved_Queries_Aggregate;
-  /** fetch data from the table: "saved_queries" using primary key columns */
-  savedQuery?: Maybe<Saved_Queries>;
-  /** fetch data from the table: "saved_query_metrics" using primary key columns */
-  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** fetch data from the table: "saved_query_metrics" */
-  savedQueryMetrics: Array<Saved_Query_Metrics>;
-  /** fetch aggregated fields from the table: "saved_query_metrics" */
-  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
-  /** fetch data from the table: "teams" using primary key columns */
-  team?: Maybe<Teams>;
-  /** fetch data from the table: "team_dashboards" using primary key columns */
-  teamDashboard?: Maybe<Team_Dashboards>;
-  /** fetch data from the table: "team_dashboards" */
-  teamDashboards: Array<Team_Dashboards>;
-  /** fetch aggregated fields from the table: "team_dashboards" */
-  teamDashboardsAggregate: Team_Dashboards_Aggregate;
-  /** fetch data from the table: "team_members" using primary key columns */
-  teamMember?: Maybe<Team_Members>;
-  /** fetch data from the table: "team_members" */
-  teamMembers: Array<Team_Members>;
-  /** fetch aggregated fields from the table: "team_members" */
-  teamMembersAggregate: Team_Members_Aggregate;
-  /** fetch aggregated fields from the table: "team_views" */
-  teamViewsAggregate: Team_Views_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" */
-  team_page_theme_colors: Array<Team_Page_Theme_Colors>;
-  /** fetch aggregated fields from the table: "team_page_theme_colors" */
-  team_page_theme_colors_aggregate: Team_Page_Theme_Colors_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" using primary key columns */
-  team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** fetch data from the table: "team_views" */
-  team_views: Array<Team_Views>;
-  /** fetch data from the table: "team_views" using primary key columns */
-  team_views_by_pk?: Maybe<Team_Views>;
-  /** fetch data from the table: "teams" */
-  teams: Array<Teams>;
-  /** fetch aggregated fields from the table: "teams" */
-  teamsAggregate: Teams_Aggregate;
-  /** fetch data from the table: "unsubscribes" */
-  unsubscribes: Array<Unsubscribes>;
-  /** fetch aggregated fields from the table: "unsubscribes" */
-  unsubscribes_aggregate: Unsubscribes_Aggregate;
-  /** fetch data from the table: "unsubscribes" using primary key columns */
-  unsubscribes_by_pk?: Maybe<Unsubscribes>;
-  /** fetch data from the table: "users" using primary key columns */
-  user?: Maybe<Users>;
-  /** fetch data from the table: "user_dashboards" using primary key columns */
-  userDashboard?: Maybe<User_Dashboards>;
-  /** fetch data from the table: "user_dashboards" */
-  userDashboards: Array<User_Dashboards>;
-  /** fetch aggregated fields from the table: "user_dashboards" */
-  userDashboardsAggregate: User_Dashboards_Aggregate;
-  /** fetch data from the table: "user_features" using primary key columns */
-  userFeature?: Maybe<User_Features>;
-  /** fetch data from the table: "user_features" */
-  userFeatures: Array<User_Features>;
-  /** fetch aggregated fields from the table: "user_features" */
-  userFeaturesAggregate: User_Features_Aggregate;
-  /** fetch data from the table: "user_prefs" using primary key columns */
-  userPreference?: Maybe<User_Prefs>;
-  /** fetch data from the table: "user_prefs" */
-  userPreferences: Array<User_Prefs>;
-  /** fetch aggregated fields from the table: "user_prefs" */
-  userPreferencesAggregate: User_Prefs_Aggregate;
-  /** fetch data from the table: "user_roles" using primary key columns */
-  userRole?: Maybe<User_Roles>;
-  /** fetch data from the table: "user_roles" */
-  userRoles: Array<User_Roles>;
-  /** fetch aggregated fields from the table: "user_roles" */
-  userRolesAggregate: User_Roles_Aggregate;
-  /** fetch data from the table: "user_role_types" */
-  user_role_types: Array<User_Role_Types>;
-  /** fetch aggregated fields from the table: "user_role_types" */
-  user_role_types_aggregate: User_Role_Types_Aggregate;
-  /** fetch data from the table: "user_role_types" using primary key columns */
-  user_role_types_by_pk?: Maybe<User_Role_Types>;
-  /** fetch data from the table: "users" */
-  users: Array<Users>;
-  /** fetch aggregated fields from the table: "users" */
-  usersAggregate: Users_Aggregate;
-};
-
-
-/** query root */
-export type Query_RootAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootApiKeyArgs = {
-  prefix: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootApiKeysArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootApiKeysAggregateArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootAuth0ProfileArgs = {
-  auth0Id: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootBranch_MetadatasArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootBranch_Metadatas_AggregateArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootBranch_Metadatas_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardItemConfigArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardItemConfigsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardItemConfigsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardLayoutArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootDashboardLayoutsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardRenderableTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootDashboardRenderableTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardSectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboard_Layouts_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboard_Renderable_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboard_Section_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardsArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDataSourceVersionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootDataSourceVersionsArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourceVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDw_EnginesArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDw_Engines_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootDw_Engines_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootFeatureArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootFeaturesArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMeArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMe_AggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricApprovalArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricApprovalsArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricApprovalsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricByIdTempArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionMetricsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionViewArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionViewAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCollectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricCurrentDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricDescriptionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricDescriptionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricTeamOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricTeamOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricTeamOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricUserOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricUserOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricUserOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricVersionArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** query root */
-export type Query_RootMetricVersionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Current_Description_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Lineage_Data_SourcesArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Lineage_Data_Sources_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetric_Lineage_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** query root */
-export type Query_RootModelDataSourceArgs = {
-  dataSourceVersionId: Scalars['Int'];
-  modelId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootModelDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelMetricArgs = {
-  metricId: Scalars['bigint'];
-  metricVersionId: Scalars['bigint'];
-  modelId: Scalars['bigint'];
-};
-
-
-/** query root */
-export type Query_RootModelMetricsArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModel_CurrentArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModel_Current_AggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelsArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootModelsAggregateArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMqlHeartbeatArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootMqlHeartbeatsArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMqlHeartbeatsAggregateArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_Most_Viewed_MetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_Most_Viewed_Metrics_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_OrgArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootMy_Org_AggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrgMqlServerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootOrgMqlServersArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrgMqlServersAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrg_Mql_Server_Logs_TypesArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrg_Mql_Server_Logs_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrg_Mql_Server_Logs_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootOrganizationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootOrganizationFeatureArgs = {
-  featureId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootOrganizationFeaturesArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrganizationFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrganizationsArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootOrganizationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootPrioritiesArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootPriorities_AggregateArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootPriorities_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootQuestionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionDirectedToArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionDirectedToAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionDirectedToByPkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionLikeArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionLikesArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionLikesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionRepliesArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionRepliesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionReplyArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootQuestionsArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootQuestionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueriesArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueriesAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueryArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootSavedQueryMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootSavedQueryMetricsArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootSavedQueryMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  team_id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamDashboardsArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamMemberArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamMembersArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamMembersAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Page_Theme_ColorsArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Page_Theme_Colors_AggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Page_Theme_Colors_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootTeam_ViewsArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeam_Views_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootTeamsArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootTeamsAggregateArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUnsubscribesArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUnsubscribes_AggregateArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUnsubscribes_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserDashboardsArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserFeatureArgs = {
-  featureId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserFeaturesArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserPreferenceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserPreferencesArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserPreferencesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserRoleArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** query root */
-export type Query_RootUserRolesArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUserRolesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUser_Role_TypesArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUser_Role_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUser_Role_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** query root */
-export type Query_RootUsersArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** query root */
-export type Query_RootUsersAggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
 
 /**
  * Indicates to which User or Team a Question is directed.
@@ -19560,22 +13619,16 @@ export type Question_Directed_To = {
   __typename?: 'question_directed_to';
   /** Timestamp indicated when a Question Directed To entry was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
-  entity_type?: Maybe<Scalars['entity']>;
   /** Unique identifier for a target to whom the Question is directed */
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   question: Questions;
-  questionid: Scalars['Int'];
   /** An object relationship */
   team?: Maybe<Teams>;
-  teamId?: Maybe<Scalars['Int']>;
   /** An object relationship */
   user?: Maybe<Users>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregated selection of "question_directed_to" */
@@ -19626,28 +13679,17 @@ export type Question_Directed_To_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "question_directed_to" */
 export type Question_Directed_To_Arr_Rel_Insert_Input = {
   data: Array<Question_Directed_To_Insert_Input>;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Question_Directed_To_Avg_Fields = {
   __typename?: 'question_directed_to_avg_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "question_directed_to" */
 export type Question_Directed_To_Avg_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "question_directed_to". All fields are combined with a logical 'AND'. */
@@ -19656,45 +13698,15 @@ export type Question_Directed_To_Bool_Exp = {
   _not?: Maybe<Question_Directed_To_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Question_Directed_To_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  entity_id?: Maybe<Int_Comparison_Exp>;
-  entity_type?: Maybe<Entity_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<Questions_Bool_Exp>;
-  questionid?: Maybe<Int_Comparison_Exp>;
   team?: Maybe<Teams_Bool_Exp>;
-  teamId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "question_directed_to" */
-export enum Question_Directed_To_Constraint {
-  /** unique or primary key constraint */
-  QuestionDirectedToIdKey = 'question_directed_to_id_key',
-  /** unique or primary key constraint */
-  QuestionDirectedToPkey = 'question_directed_to_pkey'
-}
-
-/** input type for incrementing integer column in table "question_directed_to" */
-export type Question_Directed_To_Inc_Input = {
-  entity_id?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "question_directed_to" */
 export type Question_Directed_To_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
-  entity_type?: Maybe<Scalars['entity']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   question?: Maybe<Questions_Obj_Rel_Insert_Input>;
   questionid?: Maybe<Scalars['Int']>;
   team?: Maybe<Teams_Obj_Rel_Insert_Input>;
@@ -19707,46 +13719,26 @@ export type Question_Directed_To_Insert_Input = {
 export type Question_Directed_To_Max_Fields = {
   __typename?: 'question_directed_to_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "question_directed_to" */
 export type Question_Directed_To_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Question_Directed_To_Min_Fields = {
   __typename?: 'question_directed_to_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "question_directed_to" */
 export type Question_Directed_To_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "question_directed_to" */
@@ -19761,30 +13753,16 @@ export type Question_Directed_To_Mutation_Response = {
 /** input type for inserting object relation for remote table "question_directed_to" */
 export type Question_Directed_To_Obj_Rel_Insert_Input = {
   data: Question_Directed_To_Insert_Input;
-  on_conflict?: Maybe<Question_Directed_To_On_Conflict>;
-};
-
-/** on conflict condition type for table "question_directed_to" */
-export type Question_Directed_To_On_Conflict = {
-  constraint: Question_Directed_To_Constraint;
-  update_columns: Array<Question_Directed_To_Update_Column>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "question_directed_to" */
 export type Question_Directed_To_Order_By = {
   createdAt?: Maybe<Order_By>;
-  entity_id?: Maybe<Order_By>;
-  entity_type?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   question?: Maybe<Questions_Order_By>;
-  questionid?: Maybe<Order_By>;
   team?: Maybe<Teams_Order_By>;
-  teamId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "question_directed_to" */
@@ -19798,198 +13776,84 @@ export enum Question_Directed_To_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  EntityId = 'entity_id',
-  /** column name */
-  EntityType = 'entity_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Questionid = 'questionid',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'userId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "question_directed_to" */
-export type Question_Directed_To_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  entity_id?: Maybe<Scalars['Int']>;
-  entity_type?: Maybe<Scalars['entity']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Question_Directed_To_Stddev_Fields = {
   __typename?: 'question_directed_to_stddev_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "question_directed_to" */
 export type Question_Directed_To_Stddev_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Question_Directed_To_Stddev_Pop_Fields = {
   __typename?: 'question_directed_to_stddev_pop_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "question_directed_to" */
 export type Question_Directed_To_Stddev_Pop_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Question_Directed_To_Stddev_Samp_Fields = {
   __typename?: 'question_directed_to_stddev_samp_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "question_directed_to" */
 export type Question_Directed_To_Stddev_Samp_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Question_Directed_To_Sum_Fields = {
   __typename?: 'question_directed_to_sum_fields';
-  entity_id?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionid?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "question_directed_to" */
 export type Question_Directed_To_Sum_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
-
-/** update columns of table "question_directed_to" */
-export enum Question_Directed_To_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  EntityId = 'entity_id',
-  /** column name */
-  EntityType = 'entity_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  Questionid = 'questionid',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'userId'
-}
 
 /** aggregate var_pop on columns */
 export type Question_Directed_To_Var_Pop_Fields = {
   __typename?: 'question_directed_to_var_pop_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "question_directed_to" */
 export type Question_Directed_To_Var_Pop_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Question_Directed_To_Var_Samp_Fields = {
   __typename?: 'question_directed_to_var_samp_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "question_directed_to" */
 export type Question_Directed_To_Var_Samp_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Question_Directed_To_Variance_Fields = {
   __typename?: 'question_directed_to_variance_fields';
-  entity_id?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionid?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "question_directed_to" */
 export type Question_Directed_To_Variance_Order_By = {
-  entity_id?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionid?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /**
@@ -20000,24 +13864,16 @@ export type Question_Directed_To_Variance_Order_By = {
  */
 export type Question_Likes = {
   __typename?: 'question_likes';
-  /** Timestamp indicating when the Question was liked */
-  createdAt?: Maybe<Scalars['timestamptz']>;
   /** A primary identifier for the Question Like */
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   question?: Maybe<Questions>;
-  questionId?: Maybe<Scalars['Int']>;
   /** An object relationship */
   questionReply?: Maybe<Question_Replies>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply?: Maybe<Scalars['questionorreply']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
   /** An object relationship */
   user: Users;
-  userId: Scalars['Int'];
 };
 
 /** aggregated selection of "question_likes" */
@@ -20068,28 +13924,17 @@ export type Question_Likes_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "question_likes" */
 export type Question_Likes_Arr_Rel_Insert_Input = {
   data: Array<Question_Likes_Insert_Input>;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Question_Likes_Avg_Fields = {
   __typename?: 'question_likes_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "question_likes" */
 export type Question_Likes_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "question_likes". All fields are combined with a logical 'AND'. */
@@ -20097,102 +13942,42 @@ export type Question_Likes_Bool_Exp = {
   _and?: Maybe<Array<Maybe<Question_Likes_Bool_Exp>>>;
   _not?: Maybe<Question_Likes_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Question_Likes_Bool_Exp>>>;
-  createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<Questions_Bool_Exp>;
-  questionId?: Maybe<Int_Comparison_Exp>;
   questionReply?: Maybe<Question_Replies_Bool_Exp>;
-  questionReplyId?: Maybe<Int_Comparison_Exp>;
-  question_or_reply?: Maybe<Questionorreply_Comparison_Exp>;
-  question_or_reply_id?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "question_likes" */
-export enum Question_Likes_Constraint {
-  /** unique or primary key constraint */
-  QuestionLikesIdKey = 'question_likes_id_key',
-  /** unique or primary key constraint */
-  QuestionLikesPkey = 'question_likes_pkey',
-  /** unique or primary key constraint */
-  QuestionLikesUserIdQuestionIdKey = 'question_likes_user_id_question_id_key',
-  /** unique or primary key constraint */
-  QuestionLikesUserIdQuestionReplyIdKey = 'question_likes_user_id_question_reply_id_key'
-}
-
-/** input type for incrementing integer column in table "question_likes" */
-export type Question_Likes_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "question_likes" */
 export type Question_Likes_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   question?: Maybe<Questions_Obj_Rel_Insert_Input>;
   questionId?: Maybe<Scalars['Int']>;
   questionReply?: Maybe<Question_Replies_Obj_Rel_Insert_Input>;
   questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply?: Maybe<Scalars['questionorreply']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type Question_Likes_Max_Fields = {
   __typename?: 'question_likes_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "question_likes" */
 export type Question_Likes_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
 export type Question_Likes_Min_Fields = {
   __typename?: 'question_likes_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "question_likes" */
 export type Question_Likes_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "question_likes" */
@@ -20207,30 +13992,15 @@ export type Question_Likes_Mutation_Response = {
 /** input type for inserting object relation for remote table "question_likes" */
 export type Question_Likes_Obj_Rel_Insert_Input = {
   data: Question_Likes_Insert_Input;
-  on_conflict?: Maybe<Question_Likes_On_Conflict>;
-};
-
-/** on conflict condition type for table "question_likes" */
-export type Question_Likes_On_Conflict = {
-  constraint: Question_Likes_Constraint;
-  update_columns: Array<Question_Likes_Update_Column>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "question_likes" */
 export type Question_Likes_Order_By = {
-  createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   question?: Maybe<Questions_Order_By>;
-  questionId?: Maybe<Order_By>;
   questionReply?: Maybe<Question_Replies_Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "question_likes" */
@@ -20242,200 +14012,84 @@ export type Question_Likes_Pk_Columns_Input = {
 /** select columns of table "question_likes" */
 export enum Question_Likes_Select_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
-  /** column name */
-  QuestionReplyId = 'questionReplyId',
-  /** column name */
-  QuestionOrReply = 'question_or_reply',
-  /** column name */
-  QuestionOrReplyId = 'question_or_reply_id',
-  /** column name */
-  UserId = 'userId'
+  Id = 'id'
 }
-
-/** input type for updating data in table "question_likes" */
-export type Question_Likes_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply?: Maybe<Scalars['questionorreply']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type Question_Likes_Stddev_Fields = {
   __typename?: 'question_likes_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "question_likes" */
 export type Question_Likes_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Question_Likes_Stddev_Pop_Fields = {
   __typename?: 'question_likes_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "question_likes" */
 export type Question_Likes_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Question_Likes_Stddev_Samp_Fields = {
   __typename?: 'question_likes_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "question_likes" */
 export type Question_Likes_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Question_Likes_Sum_Fields = {
   __typename?: 'question_likes_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-  questionReplyId?: Maybe<Scalars['Int']>;
-  question_or_reply_id?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "question_likes" */
 export type Question_Likes_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
-
-/** update columns of table "question_likes" */
-export enum Question_Likes_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
-  /** column name */
-  QuestionReplyId = 'questionReplyId',
-  /** column name */
-  QuestionOrReply = 'question_or_reply',
-  /** column name */
-  QuestionOrReplyId = 'question_or_reply_id',
-  /** column name */
-  UserId = 'userId'
-}
 
 /** aggregate var_pop on columns */
 export type Question_Likes_Var_Pop_Fields = {
   __typename?: 'question_likes_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "question_likes" */
 export type Question_Likes_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Question_Likes_Var_Samp_Fields = {
   __typename?: 'question_likes_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "question_likes" */
 export type Question_Likes_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Question_Likes_Variance_Fields = {
   __typename?: 'question_likes_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
-  questionReplyId?: Maybe<Scalars['Float']>;
-  question_or_reply_id?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "question_likes" */
 export type Question_Likes_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-  questionReplyId?: Maybe<Order_By>;
-  question_or_reply_id?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /**
@@ -20448,18 +14102,14 @@ export type Question_Replies = {
   __typename?: 'question_replies';
   /** An object relationship */
   author: Users;
-  authorId: Scalars['Int'];
   /** Timestamp indicating when the Question Reply was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   /** A unique identifier for the Question Reply */
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   question: Questions;
-  questionId: Scalars['Int'];
   /** An array relationship */
   questionLikes: Array<Question_Likes>;
   /** An aggregated array relationship */
@@ -20556,20 +14206,12 @@ export type Question_Replies_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Question_Replies_Avg_Fields = {
   __typename?: 'question_replies_avg_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "question_replies" */
 export type Question_Replies_Avg_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "question_replies". All fields are combined with a logical 'AND'. */
@@ -20578,14 +14220,10 @@ export type Question_Replies_Bool_Exp = {
   _not?: Maybe<Question_Replies_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Question_Replies_Bool_Exp>>>;
   author?: Maybe<Users_Bool_Exp>;
-  authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<Questions_Bool_Exp>;
-  questionId?: Maybe<Int_Comparison_Exp>;
   questionLikes?: Maybe<Question_Likes_Bool_Exp>;
   text?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -20597,52 +14235,28 @@ export enum Question_Replies_Constraint {
   QuestionRepliesPkey = 'question_replies_pkey'
 }
 
-/** input type for incrementing integer column in table "question_replies" */
-export type Question_Replies_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "question_replies" */
 export type Question_Replies_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   question?: Maybe<Questions_Obj_Rel_Insert_Input>;
   questionId?: Maybe<Scalars['Int']>;
   questionLikes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Question_Replies_Max_Fields = {
   __typename?: 'question_replies_max_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "question_replies" */
 export type Question_Replies_Max_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -20650,24 +14264,16 @@ export type Question_Replies_Max_Order_By = {
 /** aggregate min on columns */
 export type Question_Replies_Min_Fields = {
   __typename?: 'question_replies_min_fields';
-  authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "question_replies" */
 export type Question_Replies_Min_Order_By = {
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -20697,14 +14303,10 @@ export type Question_Replies_On_Conflict = {
 /** ordering options when selecting data from "question_replies" */
 export type Question_Replies_Order_By = {
   author?: Maybe<Users_Order_By>;
-  authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   question?: Maybe<Questions_Order_By>;
-  questionId?: Maybe<Order_By>;
   questionLikes_aggregate?: Maybe<Question_Likes_Aggregate_Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -20719,17 +14321,9 @@ export type Question_Replies_Pk_Columns_Input = {
 /** select columns of table "question_replies" */
 export enum Question_Replies_Select_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
   /** column name */
   Text = 'text',
   /** column name */
@@ -20738,181 +14332,90 @@ export enum Question_Replies_Select_Column {
 
 /** input type for updating data in table "question_replies" */
 export type Question_Replies_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Question_Replies_Stddev_Fields = {
   __typename?: 'question_replies_stddev_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "question_replies" */
 export type Question_Replies_Stddev_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Question_Replies_Stddev_Pop_Fields = {
   __typename?: 'question_replies_stddev_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "question_replies" */
 export type Question_Replies_Stddev_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Question_Replies_Stddev_Samp_Fields = {
   __typename?: 'question_replies_stddev_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "question_replies" */
 export type Question_Replies_Stddev_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Question_Replies_Sum_Fields = {
   __typename?: 'question_replies_sum_fields';
-  authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  questionId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "question_replies" */
 export type Question_Replies_Sum_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** update columns of table "question_replies" */
 export enum Question_Replies_Update_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  QuestionId = 'questionId',
-  /** column name */
-  Text = 'text',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Text = 'text'
 }
 
 /** aggregate var_pop on columns */
 export type Question_Replies_Var_Pop_Fields = {
   __typename?: 'question_replies_var_pop_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "question_replies" */
 export type Question_Replies_Var_Pop_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Question_Replies_Var_Samp_Fields = {
   __typename?: 'question_replies_var_samp_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "question_replies" */
 export type Question_Replies_Var_Samp_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Question_Replies_Variance_Fields = {
   __typename?: 'question_replies_variance_fields';
-  authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  questionId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "question_replies" */
 export type Question_Replies_Variance_Order_By = {
-  authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  questionId?: Maybe<Order_By>;
-};
-
-
-/** expression to compare columns of type questionorreply. All fields are combined with logical 'AND'. */
-export type Questionorreply_Comparison_Exp = {
-  _eq?: Maybe<Scalars['questionorreply']>;
-  _gt?: Maybe<Scalars['questionorreply']>;
-  _gte?: Maybe<Scalars['questionorreply']>;
-  _in?: Maybe<Array<Scalars['questionorreply']>>;
-  _is_null?: Maybe<Scalars['Boolean']>;
-  _lt?: Maybe<Scalars['questionorreply']>;
-  _lte?: Maybe<Scalars['questionorreply']>;
-  _neq?: Maybe<Scalars['questionorreply']>;
-  _nin?: Maybe<Array<Scalars['questionorreply']>>;
 };
 
 /**
@@ -20928,14 +14431,12 @@ export type Questions = {
   authorId: Scalars['Int'];
   /** Timestamp indicating when the `Question` was created. */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   /** The primary key for the `Question` */
   id: Scalars['Int'];
   /** An object relationship */
   metric?: Maybe<Org_Metrics_Current_View>;
   metricId?: Maybe<Scalars['Int']>;
   metricName: Scalars['String'];
-  notified_at?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   organization: Organizations;
   organizationId: Scalars['Int'];
@@ -20952,11 +14453,9 @@ export type Questions = {
   questionReplies: Array<Question_Replies>;
   /** An aggregated array relationship */
   questionReplies_aggregate: Question_Replies_Aggregate;
-  resolved?: Maybe<Scalars['Boolean']>;
   /** Timestamp indicating when the `Question` was resolved. */
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text: Scalars['String'];
   /** Timestamp indicating the last time the `Question` was updated */
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -21111,23 +14610,19 @@ export type Questions_Arr_Rel_Insert_Input = {
 export type Questions_Avg_Fields = {
   __typename?: 'questions_avg_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "questions" */
 export type Questions_Avg_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "questions". All fields are combined with a logical 'AND'. */
@@ -21138,22 +14633,18 @@ export type Questions_Bool_Exp = {
   author?: Maybe<Users_Bool_Exp>;
   authorId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
   metricId?: Maybe<Int_Comparison_Exp>;
   metricName?: Maybe<String_Comparison_Exp>;
-  notified_at?: Maybe<Timestamptz_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
   priority?: Maybe<Priorities_Enum_Comparison_Exp>;
   questionDirectedTos?: Maybe<Question_Directed_To_Bool_Exp>;
   questionLikes?: Maybe<Question_Likes_Bool_Exp>;
   questionReplies?: Maybe<Question_Replies_Bool_Exp>;
-  resolved?: Maybe<Boolean_Comparison_Exp>;
   resolvedAt?: Maybe<Timestamptz_Comparison_Exp>;
   resolvedBy?: Maybe<Int_Comparison_Exp>;
-  resolved_ts?: Maybe<Int_Comparison_Exp>;
   text?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   userByResolvedBy?: Maybe<Users_Bool_Exp>;
@@ -21169,38 +14660,20 @@ export enum Questions_Constraint {
 
 /** input type for incrementing integer column in table "questions" */
 export type Questions_Inc_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "questions" */
 export type Questions_Insert_Input = {
   author?: Maybe<Users_Obj_Rel_Insert_Input>;
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
   metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
   questionDirectedTos?: Maybe<Question_Directed_To_Arr_Rel_Insert_Input>;
   questionLikes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
   questionReplies?: Maybe<Question_Replies_Arr_Rel_Insert_Input>;
-  resolved?: Maybe<Scalars['Boolean']>;
-  resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   userByResolvedBy?: Maybe<Users_Obj_Rel_Insert_Input>;
 };
 
@@ -21209,15 +14682,12 @@ export type Questions_Max_Fields = {
   __typename?: 'questions_max_fields';
   authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
   organizationId?: Maybe<Scalars['Int']>;
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21226,15 +14696,12 @@ export type Questions_Max_Fields = {
 export type Questions_Max_Order_By = {
   authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   metricName?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedAt?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21244,15 +14711,12 @@ export type Questions_Min_Fields = {
   __typename?: 'questions_min_fields';
   authorId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
   organizationId?: Maybe<Scalars['Int']>;
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21261,15 +14725,12 @@ export type Questions_Min_Fields = {
 export type Questions_Min_Order_By = {
   authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   metricName?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedAt?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21301,22 +14762,18 @@ export type Questions_Order_By = {
   author?: Maybe<Users_Order_By>;
   authorId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
   metricId?: Maybe<Order_By>;
   metricName?: Maybe<Order_By>;
-  notified_at?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
   priority?: Maybe<Order_By>;
   questionDirectedTos_aggregate?: Maybe<Question_Directed_To_Aggregate_Order_By>;
   questionLikes_aggregate?: Maybe<Question_Likes_Aggregate_Order_By>;
   questionReplies_aggregate?: Maybe<Question_Replies_Aggregate_Order_By>;
-  resolved?: Maybe<Order_By>;
   resolvedAt?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
   text?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userByResolvedBy?: Maybe<Users_Order_By>;
@@ -21335,27 +14792,19 @@ export enum Questions_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
   Id = 'id',
   /** column name */
   MetricId = 'metricId',
   /** column name */
   MetricName = 'metricName',
   /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
   OrganizationId = 'organizationId',
   /** column name */
   Priority = 'priority',
   /** column name */
-  Resolved = 'resolved',
-  /** column name */
   ResolvedAt = 'resolvedAt',
   /** column name */
   ResolvedBy = 'resolvedBy',
-  /** column name */
-  ResolvedTs = 'resolved_ts',
   /** column name */
   Text = 'text',
   /** column name */
@@ -21364,216 +14813,155 @@ export enum Questions_Select_Column {
 
 /** input type for updating data in table "questions" */
 export type Questions_Set_Input = {
-  authorId?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  metricName?: Maybe<Scalars['String']>;
-  notified_at?: Maybe<Scalars['timestamptz']>;
-  organizationId?: Maybe<Scalars['Int']>;
   priority?: Maybe<Priorities_Enum>;
-  resolved?: Maybe<Scalars['Boolean']>;
   resolvedAt?: Maybe<Scalars['timestamptz']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
   text?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Questions_Stddev_Fields = {
   __typename?: 'questions_stddev_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "questions" */
 export type Questions_Stddev_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Questions_Stddev_Pop_Fields = {
   __typename?: 'questions_stddev_pop_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "questions" */
 export type Questions_Stddev_Pop_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Questions_Stddev_Samp_Fields = {
   __typename?: 'questions_stddev_samp_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "questions" */
 export type Questions_Stddev_Samp_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Questions_Sum_Fields = {
   __typename?: 'questions_sum_fields';
   authorId?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   metricId?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   resolvedBy?: Maybe<Scalars['Int']>;
-  resolved_ts?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "questions" */
 export type Questions_Sum_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** update columns of table "questions" */
 export enum Questions_Update_Column {
   /** column name */
-  AuthorId = 'authorId',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  MetricName = 'metricName',
-  /** column name */
-  NotifiedAt = 'notified_at',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   Priority = 'priority',
-  /** column name */
-  Resolved = 'resolved',
   /** column name */
   ResolvedAt = 'resolvedAt',
   /** column name */
   ResolvedBy = 'resolvedBy',
   /** column name */
-  ResolvedTs = 'resolved_ts',
-  /** column name */
-  Text = 'text',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Text = 'text'
 }
 
 /** aggregate var_pop on columns */
 export type Questions_Var_Pop_Fields = {
   __typename?: 'questions_var_pop_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "questions" */
 export type Questions_Var_Pop_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Questions_Var_Samp_Fields = {
   __typename?: 'questions_var_samp_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "questions" */
 export type Questions_Var_Samp_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Questions_Variance_Fields = {
   __typename?: 'questions_variance_fields';
   authorId?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   metricId?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   resolvedBy?: Maybe<Scalars['Float']>;
-  resolved_ts?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "questions" */
 export type Questions_Variance_Order_By = {
   authorId?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricId?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   resolvedBy?: Maybe<Order_By>;
-  resolved_ts?: Maybe<Order_By>;
 };
 
 /**
@@ -21585,11 +14973,8 @@ export type Questions_Variance_Order_By = {
 export type Saved_Queries = {
   __typename?: 'saved_queries';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  /** User ID for the creator of the query */
-  createdBy: Scalars['Int'];
   /** An object relationship */
   createdByUser: Users;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id: Scalars['Int'];
   /** An array relationship */
   metrics: Array<Saved_Query_Metrics>;
@@ -21597,11 +14982,8 @@ export type Saved_Queries = {
   metrics_aggregate: Saved_Query_Metrics_Aggregate;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   ownerTeam?: Maybe<Teams>;
-  /** Team ID for the team that owns the query if a team owns the query */
-  ownerTeamId?: Maybe<Scalars['Int']>;
   /** JSON representative of the full query */
   serializedQuery: Scalars['json'];
   title: Scalars['String'];
@@ -21703,18 +15085,12 @@ export type Saved_Queries_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Saved_Queries_Avg_Fields = {
   __typename?: 'saved_queries_avg_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "saved_queries" */
 export type Saved_Queries_Avg_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "saved_queries". All fields are combined with a logical 'AND'. */
@@ -21723,15 +15099,11 @@ export type Saved_Queries_Bool_Exp = {
   _not?: Maybe<Saved_Queries_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Saved_Queries_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  createdBy?: Maybe<Int_Comparison_Exp>;
   createdByUser?: Maybe<Users_Bool_Exp>;
-  deletedAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metrics?: Maybe<Saved_Query_Metrics_Bool_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   ownerTeam?: Maybe<Teams_Bool_Exp>;
-  ownerTeamId?: Maybe<Int_Comparison_Exp>;
   serializedQuery?: Maybe<Json_Comparison_Exp>;
   title?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -21745,38 +15117,24 @@ export enum Saved_Queries_Constraint {
 
 /** input type for incrementing integer column in table "saved_queries" */
 export type Saved_Queries_Inc_Input = {
-  createdBy?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "saved_queries" */
 export type Saved_Queries_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   createdByUser?: Maybe<Users_Obj_Rel_Insert_Input>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
   metrics?: Maybe<Saved_Query_Metrics_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeam?: Maybe<Teams_Obj_Rel_Insert_Input>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   serializedQuery?: Maybe<Scalars['json']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Saved_Queries_Max_Fields = {
   __typename?: 'saved_queries_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  ownerTeamId?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21784,11 +15142,7 @@ export type Saved_Queries_Max_Fields = {
 /** order by max() on columns of table "saved_queries" */
 export type Saved_Queries_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  createdBy?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21797,11 +15151,7 @@ export type Saved_Queries_Max_Order_By = {
 export type Saved_Queries_Min_Fields = {
   __typename?: 'saved_queries_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
-  deletedAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  ownerTeamId?: Maybe<Scalars['Int']>;
   title?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
@@ -21809,11 +15159,7 @@ export type Saved_Queries_Min_Fields = {
 /** order by min() on columns of table "saved_queries" */
 export type Saved_Queries_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  createdBy?: Maybe<Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
@@ -21843,15 +15189,11 @@ export type Saved_Queries_On_Conflict = {
 /** ordering options when selecting data from "saved_queries" */
 export type Saved_Queries_Order_By = {
   createdAt?: Maybe<Order_By>;
-  createdBy?: Maybe<Order_By>;
   createdByUser?: Maybe<Users_Order_By>;
-  deletedAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metrics_aggregate?: Maybe<Saved_Query_Metrics_Aggregate_Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   ownerTeam?: Maybe<Teams_Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
   serializedQuery?: Maybe<Order_By>;
   title?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -21867,15 +15209,7 @@ export enum Saved_Queries_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedBy = 'createdBy',
-  /** column name */
-  DeletedAt = 'deletedAt',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  OwnerTeamId = 'ownerTeamId',
   /** column name */
   SerializedQuery = 'serializedQuery',
   /** column name */
@@ -21886,156 +15220,99 @@ export enum Saved_Queries_Select_Column {
 
 /** input type for updating data in table "saved_queries" */
 export type Saved_Queries_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  createdBy?: Maybe<Scalars['Int']>;
   deletedAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   ownerTeamId?: Maybe<Scalars['Int']>;
   serializedQuery?: Maybe<Scalars['json']>;
   title?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Saved_Queries_Stddev_Fields = {
   __typename?: 'saved_queries_stddev_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "saved_queries" */
 export type Saved_Queries_Stddev_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Saved_Queries_Stddev_Pop_Fields = {
   __typename?: 'saved_queries_stddev_pop_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "saved_queries" */
 export type Saved_Queries_Stddev_Pop_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Saved_Queries_Stddev_Samp_Fields = {
   __typename?: 'saved_queries_stddev_samp_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "saved_queries" */
 export type Saved_Queries_Stddev_Samp_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Saved_Queries_Sum_Fields = {
   __typename?: 'saved_queries_sum_fields';
-  createdBy?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  ownerTeamId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "saved_queries" */
 export type Saved_Queries_Sum_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** update columns of table "saved_queries" */
 export enum Saved_Queries_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedBy = 'createdBy',
-  /** column name */
   DeletedAt = 'deletedAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   OwnerTeamId = 'ownerTeamId',
   /** column name */
   SerializedQuery = 'serializedQuery',
   /** column name */
-  Title = 'title',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Title = 'title'
 }
 
 /** aggregate var_pop on columns */
 export type Saved_Queries_Var_Pop_Fields = {
   __typename?: 'saved_queries_var_pop_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "saved_queries" */
 export type Saved_Queries_Var_Pop_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Saved_Queries_Var_Samp_Fields = {
   __typename?: 'saved_queries_var_samp_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "saved_queries" */
 export type Saved_Queries_Var_Samp_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Saved_Queries_Variance_Fields = {
   __typename?: 'saved_queries_variance_fields';
-  createdBy?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  ownerTeamId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "saved_queries" */
 export type Saved_Queries_Variance_Order_By = {
-  createdBy?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  ownerTeamId?: Maybe<Order_By>;
 };
 
 /**
@@ -22050,10 +15327,8 @@ export type Saved_Query_Metrics = {
   id: Scalars['Int'];
   /** An object relationship */
   metric: Org_Metrics_Current_View;
-  metricId: Scalars['Int'];
   /** An object relationship */
   savedQuery: Saved_Queries;
-  savedQueryId: Scalars['Int'];
   updatedAt: Scalars['timestamptz'];
 };
 
@@ -22105,22 +15380,17 @@ export type Saved_Query_Metrics_Aggregate_Order_By = {
 /** input type for inserting array relation for remote table "saved_query_metrics" */
 export type Saved_Query_Metrics_Arr_Rel_Insert_Input = {
   data: Array<Saved_Query_Metrics_Insert_Input>;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
 };
 
 /** aggregate avg on columns */
 export type Saved_Query_Metrics_Avg_Fields = {
   __typename?: 'saved_query_metrics_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "saved_query_metrics". All fields are combined with a logical 'AND'. */
@@ -22131,36 +15401,15 @@ export type Saved_Query_Metrics_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metric?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-  metricId?: Maybe<Int_Comparison_Exp>;
   savedQuery?: Maybe<Saved_Queries_Bool_Exp>;
-  savedQueryId?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "saved_query_metrics" */
-export enum Saved_Query_Metrics_Constraint {
-  /** unique or primary key constraint */
-  SavedQueryMetricsMetricIdSavedQueryIdKey = 'saved_query_metrics_metric_id_saved_query_id_key',
-  /** unique or primary key constraint */
-  SavedQueryMetricsPkey = 'saved_query_metrics_pkey'
-}
-
-/** input type for incrementing integer column in table "saved_query_metrics" */
-export type Saved_Query_Metrics_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "saved_query_metrics" */
 export type Saved_Query_Metrics_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metric?: Maybe<Org_Metrics_Current_View_Obj_Rel_Insert_Input>;
   metricId?: Maybe<Scalars['Int']>;
   savedQuery?: Maybe<Saved_Queries_Obj_Rel_Insert_Input>;
   savedQueryId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
@@ -22168,8 +15417,6 @@ export type Saved_Query_Metrics_Max_Fields = {
   __typename?: 'saved_query_metrics_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
@@ -22177,8 +15424,6 @@ export type Saved_Query_Metrics_Max_Fields = {
 export type Saved_Query_Metrics_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -22187,8 +15432,6 @@ export type Saved_Query_Metrics_Min_Fields = {
   __typename?: 'saved_query_metrics_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
@@ -22196,8 +15439,6 @@ export type Saved_Query_Metrics_Min_Fields = {
 export type Saved_Query_Metrics_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -22213,14 +15454,6 @@ export type Saved_Query_Metrics_Mutation_Response = {
 /** input type for inserting object relation for remote table "saved_query_metrics" */
 export type Saved_Query_Metrics_Obj_Rel_Insert_Input = {
   data: Saved_Query_Metrics_Insert_Input;
-  on_conflict?: Maybe<Saved_Query_Metrics_On_Conflict>;
-};
-
-/** on conflict condition type for table "saved_query_metrics" */
-export type Saved_Query_Metrics_On_Conflict = {
-  constraint: Saved_Query_Metrics_Constraint;
-  update_columns: Array<Saved_Query_Metrics_Update_Column>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "saved_query_metrics" */
@@ -22228,9 +15461,7 @@ export type Saved_Query_Metrics_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metric?: Maybe<Org_Metrics_Current_View_Order_By>;
-  metricId?: Maybe<Order_By>;
   savedQuery?: Maybe<Saved_Queries_Order_By>;
-  savedQueryId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -22246,1936 +15477,90 @@ export enum Saved_Query_Metrics_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  SavedQueryId = 'savedQueryId',
-  /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "saved_query_metrics" */
-export type Saved_Query_Metrics_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
 
 /** aggregate stddev on columns */
 export type Saved_Query_Metrics_Stddev_Fields = {
   __typename?: 'saved_query_metrics_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Saved_Query_Metrics_Stddev_Pop_Fields = {
   __typename?: 'saved_query_metrics_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Saved_Query_Metrics_Stddev_Samp_Fields = {
   __typename?: 'saved_query_metrics_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Saved_Query_Metrics_Sum_Fields = {
   __typename?: 'saved_query_metrics_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  metricId?: Maybe<Scalars['Int']>;
-  savedQueryId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
-
-/** update columns of table "saved_query_metrics" */
-export enum Saved_Query_Metrics_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  MetricId = 'metricId',
-  /** column name */
-  SavedQueryId = 'savedQueryId',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
 
 /** aggregate var_pop on columns */
 export type Saved_Query_Metrics_Var_Pop_Fields = {
   __typename?: 'saved_query_metrics_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Saved_Query_Metrics_Var_Samp_Fields = {
   __typename?: 'saved_query_metrics_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Saved_Query_Metrics_Variance_Fields = {
   __typename?: 'saved_query_metrics_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  metricId?: Maybe<Scalars['Float']>;
-  savedQueryId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "saved_query_metrics" */
 export type Saved_Query_Metrics_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  metricId?: Maybe<Order_By>;
-  savedQueryId?: Maybe<Order_By>;
-};
-
-/** subscription root */
-export type Subscription_Root = {
-  __typename?: 'subscription_root';
-  /** fetch data from the table: "annotations" using primary key columns */
-  annotation?: Maybe<Annotations>;
-  /** fetch data from the table: "annotations" */
-  annotations: Array<Annotations>;
-  /** fetch aggregated fields from the table: "annotations" */
-  annotationsAggregate: Annotations_Aggregate;
-  /** fetch data from the table: "api_keys" using primary key columns */
-  apiKey?: Maybe<Api_Keys>;
-  /** fetch data from the table: "api_keys" */
-  apiKeys: Array<Api_Keys>;
-  /** fetch aggregated fields from the table: "api_keys" */
-  apiKeysAggregate: Api_Keys_Aggregate;
-  /** fetch data from the table: "branch_metadatas" */
-  branch_metadatas: Array<Branch_Metadatas>;
-  /** fetch aggregated fields from the table: "branch_metadatas" */
-  branch_metadatas_aggregate: Branch_Metadatas_Aggregate;
-  /** fetch data from the table: "branch_metadatas" using primary key columns */
-  branch_metadatas_by_pk?: Maybe<Branch_Metadatas>;
-  /** fetch data from the table: "dashboards" using primary key columns */
-  dashboard?: Maybe<Dashboards>;
-  /** fetch data from the table: "dashboard_item_configs" using primary key columns */
-  dashboardItemConfig?: Maybe<Dashboard_Item_Configs>;
-  /** fetch data from the table: "dashboard_item_configs" */
-  dashboardItemConfigs: Array<Dashboard_Item_Configs>;
-  /** fetch aggregated fields from the table: "dashboard_item_configs" */
-  dashboardItemConfigsAggregate: Dashboard_Item_Configs_Aggregate;
-  /** fetch data from the table: "dashboard_layouts" using primary key columns */
-  dashboardLayout?: Maybe<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_layouts" */
-  dashboardLayouts: Array<Dashboard_Layouts>;
-  /** fetch data from the table: "dashboard_renderable_types" using primary key columns */
-  dashboardRenderableType?: Maybe<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_renderable_types" */
-  dashboardRenderableTypes: Array<Dashboard_Renderable_Types>;
-  /** fetch data from the table: "dashboard_sections" using primary key columns */
-  dashboardSection?: Maybe<Dashboard_Sections>;
-  /** fetch data from the table: "dashboard_section_types" using primary key columns */
-  dashboardSectionType?: Maybe<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_section_types" */
-  dashboardSectionTypes: Array<Dashboard_Section_Types>;
-  /** fetch data from the table: "dashboard_sections" */
-  dashboardSections: Array<Dashboard_Sections>;
-  /** fetch aggregated fields from the table: "dashboard_sections" */
-  dashboardSectionsAggregate: Dashboard_Sections_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_layouts" */
-  dashboard_layouts_aggregate: Dashboard_Layouts_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_renderable_types" */
-  dashboard_renderable_types_aggregate: Dashboard_Renderable_Types_Aggregate;
-  /** fetch aggregated fields from the table: "dashboard_section_types" */
-  dashboard_section_types_aggregate: Dashboard_Section_Types_Aggregate;
-  /** fetch data from the table: "dashboards" */
-  dashboards: Array<Dashboards>;
-  /** fetch aggregated fields from the table: "dashboards" */
-  dashboardsAggregate: Dashboards_Aggregate;
-  /** fetch data from the table: "org_data_sources" using primary key columns */
-  dataSource?: Maybe<Org_Data_Sources>;
-  /** fetch data from the table: "data_source_versions" using primary key columns */
-  dataSourceVersion?: Maybe<Data_Source_Versions>;
-  /** fetch data from the table: "data_source_versions" */
-  dataSourceVersions: Array<Data_Source_Versions>;
-  /** fetch aggregated fields from the table: "data_source_versions" */
-  dataSourceVersionsAggregate: Data_Source_Versions_Aggregate;
-  /** fetch data from the table: "org_data_sources" */
-  dataSources: Array<Org_Data_Sources>;
-  /** fetch aggregated fields from the table: "org_data_sources" */
-  dataSourcesAggregate: Org_Data_Sources_Aggregate;
-  /** fetch data from the table: "dw_engines" */
-  dw_engines: Array<Dw_Engines>;
-  /** fetch aggregated fields from the table: "dw_engines" */
-  dw_engines_aggregate: Dw_Engines_Aggregate;
-  /** fetch data from the table: "dw_engines" using primary key columns */
-  dw_engines_by_pk?: Maybe<Dw_Engines>;
-  /** fetch data from the table: "features" using primary key columns */
-  feature?: Maybe<Features>;
-  /** fetch data from the table: "features" */
-  features: Array<Features>;
-  /** fetch aggregated fields from the table: "features" */
-  featuresAggregate: Features_Aggregate;
-  /** execute function "me" which returns "users" */
-  me: Array<Users>;
-  /** execute function "me" and query aggregates on result of table type "users" */
-  me_aggregate: Users_Aggregate;
-  /** fetch data from the table: "metric_annotations" using primary key columns */
-  metricAnnotation?: Maybe<Metric_Annotations>;
-  /** fetch data from the table: "metric_annotations" */
-  metricAnnotations: Array<Metric_Annotations>;
-  /** fetch aggregated fields from the table: "metric_annotations" */
-  metricAnnotationsAggregate: Metric_Annotations_Aggregate;
-  /** fetch data from the table: "metric_approvals" using primary key columns */
-  metricApproval?: Maybe<Metric_Approvals>;
-  /** fetch data from the table: "metric_approvals" */
-  metricApprovals: Array<Metric_Approvals>;
-  /** fetch aggregated fields from the table: "metric_approvals" */
-  metricApprovalsAggregate: Metric_Approvals_Aggregate;
-  /** fetch data from the table: "org_metrics_current_view" using primary key columns */
-  metricByIdTemp?: Maybe<Org_Metrics_Current_View>;
-  /** fetch data from the table: "metric_collections" using primary key columns */
-  metricCollection?: Maybe<Metric_Collections>;
-  /** fetch data from the table: "metric_collection_metrics" using primary key columns */
-  metricCollectionMetric?: Maybe<Metric_Collection_Metrics>;
-  /** fetch data from the table: "metric_collection_metrics" */
-  metricCollectionMetrics: Array<Metric_Collection_Metrics>;
-  /** fetch aggregated fields from the table: "metric_collection_metrics" */
-  metricCollectionMetricsAggregate: Metric_Collection_Metrics_Aggregate;
-  /** fetch data from the table: "metric_collection_view" using primary key columns */
-  metricCollectionView?: Maybe<Metric_Collection_View>;
-  /** fetch aggregated fields from the table: "metric_collection_view" */
-  metricCollectionViewAggregate: Metric_Collection_View_Aggregate;
-  /** fetch data from the table: "metric_collection_view" */
-  metricCollectionViews: Array<Metric_Collection_View>;
-  /** fetch data from the table: "metric_collections" */
-  metricCollections: Array<Metric_Collections>;
-  /** fetch aggregated fields from the table: "metric_collections" */
-  metricCollectionsAggregate: Metric_Collections_Aggregate;
-  /** fetch data from the table: "metric_current_description" */
-  metricCurrentDescriptions: Array<Metric_Current_Description>;
-  /** fetch data from the table: "metric_descriptions" using primary key columns */
-  metricDescription?: Maybe<Metric_Descriptions>;
-  /** fetch data from the table: "metric_descriptions" */
-  metricDescriptions: Array<Metric_Descriptions>;
-  /** fetch aggregated fields from the table: "metric_descriptions" */
-  metricDescriptionsAggregate: Metric_Descriptions_Aggregate;
-  /** fetch data from the table: "metric_team_owners" using primary key columns */
-  metricTeamOwner?: Maybe<Metric_Team_Owners>;
-  /** fetch data from the table: "metric_team_owners" */
-  metricTeamOwners: Array<Metric_Team_Owners>;
-  /** fetch aggregated fields from the table: "metric_team_owners" */
-  metricTeamOwnersAggregate: Metric_Team_Owners_Aggregate;
-  /** fetch data from the table: "metric_user_owners" using primary key columns */
-  metricUserOwner?: Maybe<Metric_User_Owners>;
-  /** fetch data from the table: "metric_user_owners" */
-  metricUserOwners: Array<Metric_User_Owners>;
-  /** fetch aggregated fields from the table: "metric_user_owners" */
-  metricUserOwnersAggregate: Metric_User_Owners_Aggregate;
-  /** fetch data from the table: "metric_versions" using primary key columns */
-  metricVersion?: Maybe<Metric_Versions>;
-  /** fetch data from the table: "metric_versions" */
-  metricVersions: Array<Metric_Versions>;
-  /** fetch aggregated fields from the table: "metric_versions" */
-  metricVersionsAggregate: Metric_Versions_Aggregate;
-  /** fetch data from the table: "metric_view" */
-  metricViews: Array<Metric_View>;
-  /** fetch aggregated fields from the table: "metric_view" */
-  metricViewsAggregate: Metric_View_Aggregate;
-  /** fetch aggregated fields from the table: "metric_current_description" */
-  metric_current_description_aggregate: Metric_Current_Description_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources: Array<Metric_Lineage_Data_Sources>;
-  /** fetch aggregated fields from the table: "metric_lineage_data_sources" */
-  metric_lineage_data_sources_aggregate: Metric_Lineage_Data_Sources_Aggregate;
-  /** fetch data from the table: "metric_lineage_data_sources" using primary key columns */
-  metric_lineage_data_sources_by_pk?: Maybe<Metric_Lineage_Data_Sources>;
-  /** fetch data from the table: "org_metrics_current_view" */
-  metrics: Array<Org_Metrics_Current_View>;
-  /** fetch aggregated fields from the table: "org_metrics_current_view" */
-  metricsAggregate: Org_Metrics_Current_View_Aggregate;
-  /** fetch data from the table: "models" using primary key columns */
-  model?: Maybe<Models>;
-  /** fetch data from the table: "model_data_sources" using primary key columns */
-  modelDataSource?: Maybe<Model_Data_Sources>;
-  /** fetch data from the table: "model_data_sources" */
-  modelDataSources: Array<Model_Data_Sources>;
-  /** fetch aggregated fields from the table: "model_data_sources" */
-  modelDataSourcesAggregate: Model_Data_Sources_Aggregate;
-  /** fetch data from the table: "model_metrics" using primary key columns */
-  modelMetric?: Maybe<Model_Metrics>;
-  /** fetch data from the table: "model_metrics" */
-  modelMetrics: Array<Model_Metrics>;
-  /** fetch aggregated fields from the table: "model_metrics" */
-  modelMetricsAggregate: Model_Metrics_Aggregate;
-  /** fetch data from the table: "model_current" */
-  model_current: Array<Model_Current>;
-  /** fetch aggregated fields from the table: "model_current" */
-  model_current_aggregate: Model_Current_Aggregate;
-  /** fetch data from the table: "models" */
-  models: Array<Models>;
-  /** fetch aggregated fields from the table: "models" */
-  modelsAggregate: Models_Aggregate;
-  /** fetch data from the table: "mql_heartbeats" using primary key columns */
-  mqlHeartbeat?: Maybe<Mql_Heartbeats>;
-  /** fetch data from the table: "mql_heartbeats" */
-  mqlHeartbeats: Array<Mql_Heartbeats>;
-  /** fetch aggregated fields from the table: "mql_heartbeats" */
-  mqlHeartbeatsAggregate: Mql_Heartbeats_Aggregate;
-  /** execute function "my_most_viewed_metrics" which returns "org_metrics_current_view" */
-  my_most_viewed_metrics: Array<Org_Metrics_Current_View>;
-  /** execute function "my_most_viewed_metrics" and query aggregates on result of table type "org_metrics_current_view" */
-  my_most_viewed_metrics_aggregate: Org_Metrics_Current_View_Aggregate;
-  /** execute function "my_org" which returns "organizations" */
-  my_org: Array<Organizations>;
-  /** execute function "my_org" and query aggregates on result of table type "organizations" */
-  my_org_aggregate: Organizations_Aggregate;
-  /** fetch data from the table: "org_mql_servers" using primary key columns */
-  orgMqlServer?: Maybe<Org_Mql_Servers>;
-  /** fetch data from the table: "org_mql_servers" */
-  orgMqlServers: Array<Org_Mql_Servers>;
-  /** fetch aggregated fields from the table: "org_mql_servers" */
-  orgMqlServersAggregate: Org_Mql_Servers_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types: Array<Org_Mql_Server_Logs_Types>;
-  /** fetch aggregated fields from the table: "org_mql_server_logs_types" */
-  org_mql_server_logs_types_aggregate: Org_Mql_Server_Logs_Types_Aggregate;
-  /** fetch data from the table: "org_mql_server_logs_types" using primary key columns */
-  org_mql_server_logs_types_by_pk?: Maybe<Org_Mql_Server_Logs_Types>;
-  /** fetch data from the table: "organizations" using primary key columns */
-  organization?: Maybe<Organizations>;
-  /** fetch data from the table: "organization_features" using primary key columns */
-  organizationFeature?: Maybe<Organization_Features>;
-  /** fetch data from the table: "organization_features" */
-  organizationFeatures: Array<Organization_Features>;
-  /** fetch aggregated fields from the table: "organization_features" */
-  organizationFeaturesAggregate: Organization_Features_Aggregate;
-  /** fetch data from the table: "organizations" */
-  organizations: Array<Organizations>;
-  /** fetch aggregated fields from the table: "organizations" */
-  organizationsAggregate: Organizations_Aggregate;
-  /** fetch data from the table: "priorities" */
-  priorities: Array<Priorities>;
-  /** fetch aggregated fields from the table: "priorities" */
-  priorities_aggregate: Priorities_Aggregate;
-  /** fetch data from the table: "priorities" using primary key columns */
-  priorities_by_pk?: Maybe<Priorities>;
-  /** fetch data from the table: "questions" using primary key columns */
-  question?: Maybe<Questions>;
-  /** fetch data from the table: "question_directed_to" */
-  questionDirectedTo: Array<Question_Directed_To>;
-  /** fetch aggregated fields from the table: "question_directed_to" */
-  questionDirectedToAggregate: Question_Directed_To_Aggregate;
-  /** fetch data from the table: "question_directed_to" using primary key columns */
-  questionDirectedToByPK?: Maybe<Question_Directed_To>;
-  /** fetch data from the table: "question_likes" using primary key columns */
-  questionLike?: Maybe<Question_Likes>;
-  /** fetch data from the table: "question_likes" */
-  questionLikes: Array<Question_Likes>;
-  /** fetch aggregated fields from the table: "question_likes" */
-  questionLikesAggregate: Question_Likes_Aggregate;
-  /** fetch data from the table: "question_replies" */
-  questionReplies: Array<Question_Replies>;
-  /** fetch aggregated fields from the table: "question_replies" */
-  questionRepliesAggregate: Question_Replies_Aggregate;
-  /** fetch data from the table: "question_replies" using primary key columns */
-  questionReply?: Maybe<Question_Replies>;
-  /** fetch data from the table: "questions" */
-  questions: Array<Questions>;
-  /** fetch aggregated fields from the table: "questions" */
-  questionsAggregate: Questions_Aggregate;
-  /** fetch data from the table: "saved_queries" */
-  savedQueries: Array<Saved_Queries>;
-  /** fetch aggregated fields from the table: "saved_queries" */
-  savedQueriesAggregate: Saved_Queries_Aggregate;
-  /** fetch data from the table: "saved_queries" using primary key columns */
-  savedQuery?: Maybe<Saved_Queries>;
-  /** fetch data from the table: "saved_query_metrics" using primary key columns */
-  savedQueryMetric?: Maybe<Saved_Query_Metrics>;
-  /** fetch data from the table: "saved_query_metrics" */
-  savedQueryMetrics: Array<Saved_Query_Metrics>;
-  /** fetch aggregated fields from the table: "saved_query_metrics" */
-  savedQueryMetricsAggregate: Saved_Query_Metrics_Aggregate;
-  /** fetch data from the table: "teams" using primary key columns */
-  team?: Maybe<Teams>;
-  /** fetch data from the table: "team_dashboards" using primary key columns */
-  teamDashboard?: Maybe<Team_Dashboards>;
-  /** fetch data from the table: "team_dashboards" */
-  teamDashboards: Array<Team_Dashboards>;
-  /** fetch aggregated fields from the table: "team_dashboards" */
-  teamDashboardsAggregate: Team_Dashboards_Aggregate;
-  /** fetch data from the table: "team_members" using primary key columns */
-  teamMember?: Maybe<Team_Members>;
-  /** fetch data from the table: "team_members" */
-  teamMembers: Array<Team_Members>;
-  /** fetch aggregated fields from the table: "team_members" */
-  teamMembersAggregate: Team_Members_Aggregate;
-  /** fetch aggregated fields from the table: "team_views" */
-  teamViewsAggregate: Team_Views_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" */
-  team_page_theme_colors: Array<Team_Page_Theme_Colors>;
-  /** fetch aggregated fields from the table: "team_page_theme_colors" */
-  team_page_theme_colors_aggregate: Team_Page_Theme_Colors_Aggregate;
-  /** fetch data from the table: "team_page_theme_colors" using primary key columns */
-  team_page_theme_colors_by_pk?: Maybe<Team_Page_Theme_Colors>;
-  /** fetch data from the table: "team_views" */
-  team_views: Array<Team_Views>;
-  /** fetch data from the table: "team_views" using primary key columns */
-  team_views_by_pk?: Maybe<Team_Views>;
-  /** fetch data from the table: "teams" */
-  teams: Array<Teams>;
-  /** fetch aggregated fields from the table: "teams" */
-  teamsAggregate: Teams_Aggregate;
-  /** fetch data from the table: "unsubscribes" */
-  unsubscribes: Array<Unsubscribes>;
-  /** fetch aggregated fields from the table: "unsubscribes" */
-  unsubscribes_aggregate: Unsubscribes_Aggregate;
-  /** fetch data from the table: "unsubscribes" using primary key columns */
-  unsubscribes_by_pk?: Maybe<Unsubscribes>;
-  /** fetch data from the table: "users" using primary key columns */
-  user?: Maybe<Users>;
-  /** fetch data from the table: "user_dashboards" using primary key columns */
-  userDashboard?: Maybe<User_Dashboards>;
-  /** fetch data from the table: "user_dashboards" */
-  userDashboards: Array<User_Dashboards>;
-  /** fetch aggregated fields from the table: "user_dashboards" */
-  userDashboardsAggregate: User_Dashboards_Aggregate;
-  /** fetch data from the table: "user_features" using primary key columns */
-  userFeature?: Maybe<User_Features>;
-  /** fetch data from the table: "user_features" */
-  userFeatures: Array<User_Features>;
-  /** fetch aggregated fields from the table: "user_features" */
-  userFeaturesAggregate: User_Features_Aggregate;
-  /** fetch data from the table: "user_prefs" using primary key columns */
-  userPreference?: Maybe<User_Prefs>;
-  /** fetch data from the table: "user_prefs" */
-  userPreferences: Array<User_Prefs>;
-  /** fetch aggregated fields from the table: "user_prefs" */
-  userPreferencesAggregate: User_Prefs_Aggregate;
-  /** fetch data from the table: "user_roles" using primary key columns */
-  userRole?: Maybe<User_Roles>;
-  /** fetch data from the table: "user_roles" */
-  userRoles: Array<User_Roles>;
-  /** fetch aggregated fields from the table: "user_roles" */
-  userRolesAggregate: User_Roles_Aggregate;
-  /** fetch data from the table: "user_role_types" */
-  user_role_types: Array<User_Role_Types>;
-  /** fetch aggregated fields from the table: "user_role_types" */
-  user_role_types_aggregate: User_Role_Types_Aggregate;
-  /** fetch data from the table: "user_role_types" using primary key columns */
-  user_role_types_by_pk?: Maybe<User_Role_Types>;
-  /** fetch data from the table: "users" */
-  users: Array<Users>;
-  /** fetch aggregated fields from the table: "users" */
-  usersAggregate: Users_Aggregate;
-};
-
-
-/** subscription root */
-export type Subscription_RootAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Annotations_Order_By>>;
-  where?: Maybe<Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootApiKeyArgs = {
-  prefix: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootApiKeysArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootApiKeysAggregateArgs = {
-  distinct_on?: Maybe<Array<Api_Keys_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Api_Keys_Order_By>>;
-  where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootBranch_MetadatasArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootBranch_Metadatas_AggregateArgs = {
-  distinct_on?: Maybe<Array<Branch_Metadatas_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Branch_Metadatas_Order_By>>;
-  where?: Maybe<Branch_Metadatas_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootBranch_Metadatas_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardItemConfigArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardItemConfigsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardItemConfigsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Item_Configs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Item_Configs_Order_By>>;
-  where?: Maybe<Dashboard_Item_Configs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardLayoutArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardLayoutsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardRenderableTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardRenderableTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionTypeArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionTypesArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionsArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardSectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Sections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Sections_Order_By>>;
-  where?: Maybe<Dashboard_Sections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboard_Layouts_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Layouts_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Layouts_Order_By>>;
-  where?: Maybe<Dashboard_Layouts_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboard_Renderable_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Renderable_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Renderable_Types_Order_By>>;
-  where?: Maybe<Dashboard_Renderable_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboard_Section_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboard_Section_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboard_Section_Types_Order_By>>;
-  where?: Maybe<Dashboard_Section_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardsArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dashboards_Order_By>>;
-  where?: Maybe<Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceVersionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceVersionsArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourceVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Data_Source_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Data_Source_Versions_Order_By>>;
-  where?: Maybe<Data_Source_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Data_Sources_Order_By>>;
-  where?: Maybe<Org_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDw_EnginesArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDw_Engines_AggregateArgs = {
-  distinct_on?: Maybe<Array<Dw_Engines_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Dw_Engines_Order_By>>;
-  where?: Maybe<Dw_Engines_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootDw_Engines_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootFeatureArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootFeaturesArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Features_Order_By>>;
-  where?: Maybe<Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMeArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMe_AggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricAnnotationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricAnnotationsArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricAnnotationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Annotations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Annotations_Order_By>>;
-  where?: Maybe<Metric_Annotations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricApprovalArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricApprovalsArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricApprovalsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Approvals_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Approvals_Order_By>>;
-  where?: Maybe<Metric_Approvals_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricByIdTempArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionMetricsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_Metrics_Order_By>>;
-  where?: Maybe<Metric_Collection_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionViewArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionViewAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collection_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collection_View_Order_By>>;
-  where?: Maybe<Metric_Collection_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCollectionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Collections_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Collections_Order_By>>;
-  where?: Maybe<Metric_Collections_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricCurrentDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricDescriptionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricDescriptionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricDescriptionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Descriptions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Descriptions_Order_By>>;
-  where?: Maybe<Metric_Descriptions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricTeamOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricTeamOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricTeamOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Team_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Team_Owners_Order_By>>;
-  where?: Maybe<Metric_Team_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricUserOwnerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricUserOwnersArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricUserOwnersAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_User_Owners_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_User_Owners_Order_By>>;
-  where?: Maybe<Metric_User_Owners_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricVersionArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricVersionsArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricVersionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Versions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Versions_Order_By>>;
-  where?: Maybe<Metric_Versions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricViewsArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_View_Order_By>>;
-  where?: Maybe<Metric_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Current_Description_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Current_Description_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Current_Description_Order_By>>;
-  where?: Maybe<Metric_Current_Description_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Lineage_Data_SourcesArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Lineage_Data_Sources_AggregateArgs = {
-  distinct_on?: Maybe<Array<Metric_Lineage_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Metric_Lineage_Data_Sources_Order_By>>;
-  where?: Maybe<Metric_Lineage_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetric_Lineage_Data_Sources_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelArgs = {
-  id: Scalars['bigint'];
-};
-
-
-/** subscription root */
-export type Subscription_RootModelDataSourceArgs = {
-  dataSourceVersionId: Scalars['Int'];
-  modelId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootModelDataSourcesArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelDataSourcesAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Data_Sources_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Data_Sources_Order_By>>;
-  where?: Maybe<Model_Data_Sources_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelMetricArgs = {
-  metricId: Scalars['bigint'];
-  metricVersionId: Scalars['bigint'];
-  modelId: Scalars['bigint'];
-};
-
-
-/** subscription root */
-export type Subscription_RootModelMetricsArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Metrics_Order_By>>;
-  where?: Maybe<Model_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModel_CurrentArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModel_Current_AggregateArgs = {
-  distinct_on?: Maybe<Array<Model_Current_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Model_Current_Order_By>>;
-  where?: Maybe<Model_Current_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelsArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootModelsAggregateArgs = {
-  distinct_on?: Maybe<Array<Models_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Models_Order_By>>;
-  where?: Maybe<Models_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMqlHeartbeatArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootMqlHeartbeatsArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMqlHeartbeatsAggregateArgs = {
-  distinct_on?: Maybe<Array<Mql_Heartbeats_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Mql_Heartbeats_Order_By>>;
-  where?: Maybe<Mql_Heartbeats_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_Most_Viewed_MetricsArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_Most_Viewed_Metrics_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Metrics_Current_View_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Metrics_Current_View_Order_By>>;
-  where?: Maybe<Org_Metrics_Current_View_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_OrgArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootMy_Org_AggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrgMqlServerArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrgMqlServersArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrgMqlServersAggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Servers_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Servers_Order_By>>;
-  where?: Maybe<Org_Mql_Servers_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrg_Mql_Server_Logs_TypesArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrg_Mql_Server_Logs_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<Org_Mql_Server_Logs_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Org_Mql_Server_Logs_Types_Order_By>>;
-  where?: Maybe<Org_Mql_Server_Logs_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrg_Mql_Server_Logs_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationFeatureArgs = {
-  featureId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationFeaturesArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<Organization_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organization_Features_Order_By>>;
-  where?: Maybe<Organization_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationsArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootOrganizationsAggregateArgs = {
-  distinct_on?: Maybe<Array<Organizations_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Organizations_Order_By>>;
-  where?: Maybe<Organizations_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootPrioritiesArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootPriorities_AggregateArgs = {
-  distinct_on?: Maybe<Array<Priorities_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Priorities_Order_By>>;
-  where?: Maybe<Priorities_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootPriorities_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionDirectedToArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionDirectedToAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Directed_To_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Directed_To_Order_By>>;
-  where?: Maybe<Question_Directed_To_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionDirectedToByPkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionLikeArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionLikesArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionLikesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Likes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Likes_Order_By>>;
-  where?: Maybe<Question_Likes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionRepliesArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionRepliesAggregateArgs = {
-  distinct_on?: Maybe<Array<Question_Replies_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Question_Replies_Order_By>>;
-  where?: Maybe<Question_Replies_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionReplyArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionsArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootQuestionsAggregateArgs = {
-  distinct_on?: Maybe<Array<Questions_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Questions_Order_By>>;
-  where?: Maybe<Questions_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueriesArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueriesAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Queries_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Queries_Order_By>>;
-  where?: Maybe<Saved_Queries_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryMetricArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryMetricsArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootSavedQueryMetricsAggregateArgs = {
-  distinct_on?: Maybe<Array<Saved_Query_Metrics_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Saved_Query_Metrics_Order_By>>;
-  where?: Maybe<Saved_Query_Metrics_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  team_id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamDashboardsArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Dashboards_Order_By>>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamMemberArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamMembersArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamMembersAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Members_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Members_Order_By>>;
-  where?: Maybe<Team_Members_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamViewsAggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Page_Theme_ColorsArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Page_Theme_Colors_AggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Page_Theme_Colors_Order_By>>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Page_Theme_Colors_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_ViewsArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeam_Views_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamsArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootTeamsAggregateArgs = {
-  distinct_on?: Maybe<Array<Teams_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Teams_Order_By>>;
-  where?: Maybe<Teams_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUnsubscribesArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUnsubscribes_AggregateArgs = {
-  distinct_on?: Maybe<Array<Unsubscribes_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Unsubscribes_Order_By>>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUnsubscribes_By_PkArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserDashboardArgs = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserDashboardsArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserDashboardsAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserFeatureArgs = {
-  featureId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserFeaturesArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserFeaturesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Features_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Features_Order_By>>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserPreferenceArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserPreferencesArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserPreferencesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Prefs_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Prefs_Order_By>>;
-  where?: Maybe<User_Prefs_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserRoleArgs = {
-  id: Scalars['Int'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUserRolesArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUserRolesAggregateArgs = {
-  distinct_on?: Maybe<Array<User_Roles_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Roles_Order_By>>;
-  where?: Maybe<User_Roles_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUser_Role_TypesArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUser_Role_Types_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Role_Types_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Role_Types_Order_By>>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUser_Role_Types_By_PkArgs = {
-  value: Scalars['String'];
-};
-
-
-/** subscription root */
-export type Subscription_RootUsersArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
-};
-
-
-/** subscription root */
-export type Subscription_RootUsersAggregateArgs = {
-  distinct_on?: Maybe<Array<Users_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Users_Order_By>>;
-  where?: Maybe<Users_Bool_Exp>;
 };
 
 /** columns and relationships of "team_dashboards" */
 export type Team_Dashboards = {
   __typename?: 'team_dashboards';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-  team_id: Scalars['Int'];
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
@@ -24189,17 +15574,9 @@ export type Team_Dashboards_Aggregate = {
 /** aggregate fields of "team_dashboards" */
 export type Team_Dashboards_Aggregate_Fields = {
   __typename?: 'team_dashboards_aggregate_fields';
-  avg?: Maybe<Team_Dashboards_Avg_Fields>;
   count?: Maybe<Scalars['Int']>;
   max?: Maybe<Team_Dashboards_Max_Fields>;
   min?: Maybe<Team_Dashboards_Min_Fields>;
-  stddev?: Maybe<Team_Dashboards_Stddev_Fields>;
-  stddev_pop?: Maybe<Team_Dashboards_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Team_Dashboards_Stddev_Samp_Fields>;
-  sum?: Maybe<Team_Dashboards_Sum_Fields>;
-  var_pop?: Maybe<Team_Dashboards_Var_Pop_Fields>;
-  var_samp?: Maybe<Team_Dashboards_Var_Samp_Fields>;
-  variance?: Maybe<Team_Dashboards_Variance_Fields>;
 };
 
 
@@ -24211,38 +15588,14 @@ export type Team_Dashboards_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "team_dashboards" */
 export type Team_Dashboards_Aggregate_Order_By = {
-  avg?: Maybe<Team_Dashboards_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Team_Dashboards_Max_Order_By>;
   min?: Maybe<Team_Dashboards_Min_Order_By>;
-  stddev?: Maybe<Team_Dashboards_Stddev_Order_By>;
-  stddev_pop?: Maybe<Team_Dashboards_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Team_Dashboards_Stddev_Samp_Order_By>;
-  sum?: Maybe<Team_Dashboards_Sum_Order_By>;
-  var_pop?: Maybe<Team_Dashboards_Var_Pop_Order_By>;
-  var_samp?: Maybe<Team_Dashboards_Var_Samp_Order_By>;
-  variance?: Maybe<Team_Dashboards_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "team_dashboards" */
 export type Team_Dashboards_Arr_Rel_Insert_Input = {
   data: Array<Team_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Team_Dashboards_Avg_Fields = {
-  __typename?: 'team_dashboards_avg_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "team_dashboards" */
-export type Team_Dashboards_Avg_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "team_dashboards". All fields are combined with a logical 'AND'. */
@@ -24251,50 +15604,25 @@ export type Team_Dashboards_Bool_Exp = {
   _not?: Maybe<Team_Dashboards_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Team_Dashboards_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dashboardId?: Maybe<Int_Comparison_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-  team_id?: Maybe<Int_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "team_dashboards" */
-export enum Team_Dashboards_Constraint {
-  /** unique or primary key constraint */
-  TeamDashboardsPkey = 'team_dashboards_pkey'
-}
-
-/** input type for incrementing integer column in table "team_dashboards" */
-export type Team_Dashboards_Inc_Input = {
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "team_dashboards" */
 export type Team_Dashboards_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   team_id?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Team_Dashboards_Max_Fields = {
   __typename?: 'team_dashboards_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by max() on columns of table "team_dashboards" */
 export type Team_Dashboards_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -24302,18 +15630,12 @@ export type Team_Dashboards_Max_Order_By = {
 export type Team_Dashboards_Min_Fields = {
   __typename?: 'team_dashboards_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** order by min() on columns of table "team_dashboards" */
 export type Team_Dashboards_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -24329,22 +15651,11 @@ export type Team_Dashboards_Mutation_Response = {
 /** input type for inserting object relation for remote table "team_dashboards" */
 export type Team_Dashboards_Obj_Rel_Insert_Input = {
   data: Team_Dashboards_Insert_Input;
-  on_conflict?: Maybe<Team_Dashboards_On_Conflict>;
-};
-
-/** on conflict condition type for table "team_dashboards" */
-export type Team_Dashboards_On_Conflict = {
-  constraint: Team_Dashboards_Constraint;
-  update_columns: Array<Team_Dashboards_Update_Column>;
-  where?: Maybe<Team_Dashboards_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "team_dashboards" */
 export type Team_Dashboards_Order_By = {
   createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -24359,142 +15670,8 @@ export enum Team_Dashboards_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
   UpdatedAt = 'updatedAt'
 }
-
-/** input type for updating data in table "team_dashboards" */
-export type Team_Dashboards_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-};
-
-/** aggregate stddev on columns */
-export type Team_Dashboards_Stddev_Fields = {
-  __typename?: 'team_dashboards_stddev_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "team_dashboards" */
-export type Team_Dashboards_Stddev_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Team_Dashboards_Stddev_Pop_Fields = {
-  __typename?: 'team_dashboards_stddev_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "team_dashboards" */
-export type Team_Dashboards_Stddev_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Team_Dashboards_Stddev_Samp_Fields = {
-  __typename?: 'team_dashboards_stddev_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "team_dashboards" */
-export type Team_Dashboards_Stddev_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Team_Dashboards_Sum_Fields = {
-  __typename?: 'team_dashboards_sum_fields';
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "team_dashboards" */
-export type Team_Dashboards_Sum_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "team_dashboards" */
-export enum Team_Dashboards_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
-  UpdatedAt = 'updatedAt'
-}
-
-/** aggregate var_pop on columns */
-export type Team_Dashboards_Var_Pop_Fields = {
-  __typename?: 'team_dashboards_var_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "team_dashboards" */
-export type Team_Dashboards_Var_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Team_Dashboards_Var_Samp_Fields = {
-  __typename?: 'team_dashboards_var_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "team_dashboards" */
-export type Team_Dashboards_Var_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Team_Dashboards_Variance_Fields = {
-  __typename?: 'team_dashboards_variance_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "team_dashboards" */
-export type Team_Dashboards_Variance_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-};
 
 /**
  * Users belonging to a Team
@@ -24509,16 +15686,12 @@ export type Team_Members = {
   isTeamAdmin: Scalars['Boolean'];
   /** Indicates when the User was added to the Team */
   joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   team: Teams;
-  teamId: Scalars['Int'];
   /** An object relationship */
   user: Users;
-  user_id: Scalars['Int'];
 };
 
 /** aggregated selection of "team_members" */
@@ -24576,19 +15749,11 @@ export type Team_Members_Arr_Rel_Insert_Input = {
 export type Team_Members_Avg_Fields = {
   __typename?: 'team_members_avg_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "team_members" */
 export type Team_Members_Avg_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "team_members". All fields are combined with a logical 'AND'. */
@@ -24599,13 +15764,9 @@ export type Team_Members_Bool_Exp = {
   id?: Maybe<Int_Comparison_Exp>;
   isTeamAdmin?: Maybe<Boolean_Comparison_Exp>;
   joinedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  joined_ts?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   team?: Maybe<Teams_Bool_Exp>;
-  teamId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "team_members" */
@@ -24614,23 +15775,9 @@ export enum Team_Members_Constraint {
   TeamMembersPkey = 'team_members_pkey'
 }
 
-/** input type for incrementing integer column in table "team_members" */
-export type Team_Members_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "team_members" */
 export type Team_Members_Insert_Input = {
-  id?: Maybe<Scalars['Int']>;
   isTeamAdmin?: Maybe<Scalars['Boolean']>;
-  joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   team?: Maybe<Teams_Obj_Rel_Insert_Input>;
   teamId?: Maybe<Scalars['Int']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
@@ -24642,20 +15789,12 @@ export type Team_Members_Max_Fields = {
   __typename?: 'team_members_max_fields';
   id?: Maybe<Scalars['Int']>;
   joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "team_members" */
 export type Team_Members_Max_Order_By = {
   id?: Maybe<Order_By>;
   joinedAt?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -24663,20 +15802,12 @@ export type Team_Members_Min_Fields = {
   __typename?: 'team_members_min_fields';
   id?: Maybe<Scalars['Int']>;
   joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "team_members" */
 export type Team_Members_Min_Order_By = {
   id?: Maybe<Order_By>;
   joinedAt?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "team_members" */
@@ -24706,13 +15837,9 @@ export type Team_Members_Order_By = {
   id?: Maybe<Order_By>;
   isTeamAdmin?: Maybe<Order_By>;
   joinedAt?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   team?: Maybe<Teams_Order_By>;
-  teamId?: Maybe<Order_By>;
   user?: Maybe<Users_Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "team_members" */
@@ -24727,399 +15854,106 @@ export enum Team_Members_Select_Column {
   /** column name */
   IsTeamAdmin = 'isTeamAdmin',
   /** column name */
-  JoinedAt = 'joinedAt',
-  /** column name */
-  JoinedTs = 'joined_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'user_id'
+  JoinedAt = 'joinedAt'
 }
 
 /** input type for updating data in table "team_members" */
 export type Team_Members_Set_Input = {
-  id?: Maybe<Scalars['Int']>;
   isTeamAdmin?: Maybe<Scalars['Boolean']>;
-  joinedAt?: Maybe<Scalars['timestamptz']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type Team_Members_Stddev_Fields = {
   __typename?: 'team_members_stddev_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "team_members" */
 export type Team_Members_Stddev_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Team_Members_Stddev_Pop_Fields = {
   __typename?: 'team_members_stddev_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "team_members" */
 export type Team_Members_Stddev_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Team_Members_Stddev_Samp_Fields = {
   __typename?: 'team_members_stddev_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "team_members" */
 export type Team_Members_Stddev_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Team_Members_Sum_Fields = {
   __typename?: 'team_members_sum_fields';
   id?: Maybe<Scalars['Int']>;
-  joined_ts?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  teamId?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "team_members" */
 export type Team_Members_Sum_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** update columns of table "team_members" */
 export enum Team_Members_Update_Column {
   /** column name */
-  Id = 'id',
-  /** column name */
-  IsTeamAdmin = 'isTeamAdmin',
-  /** column name */
-  JoinedAt = 'joinedAt',
-  /** column name */
-  JoinedTs = 'joined_ts',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  TeamId = 'teamId',
-  /** column name */
-  UserId = 'user_id'
+  IsTeamAdmin = 'isTeamAdmin'
 }
 
 /** aggregate var_pop on columns */
 export type Team_Members_Var_Pop_Fields = {
   __typename?: 'team_members_var_pop_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "team_members" */
 export type Team_Members_Var_Pop_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Team_Members_Var_Samp_Fields = {
   __typename?: 'team_members_var_samp_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "team_members" */
 export type Team_Members_Var_Samp_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Team_Members_Variance_Fields = {
   __typename?: 'team_members_variance_fields';
   id?: Maybe<Scalars['Float']>;
-  joined_ts?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  teamId?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "team_members" */
 export type Team_Members_Variance_Order_By = {
   id?: Maybe<Order_By>;
-  joined_ts?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  teamId?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
-
-/** columns and relationships of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors = {
-  __typename?: 'team_page_theme_colors';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate = {
-  __typename?: 'team_page_theme_colors_aggregate';
-  aggregate?: Maybe<Team_Page_Theme_Colors_Aggregate_Fields>;
-  nodes: Array<Team_Page_Theme_Colors>;
-};
-
-/** aggregate fields of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate_Fields = {
-  __typename?: 'team_page_theme_colors_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Team_Page_Theme_Colors_Max_Fields>;
-  min?: Maybe<Team_Page_Theme_Colors_Min_Fields>;
-};
-
-
-/** aggregate fields of "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Team_Page_Theme_Colors_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<Team_Page_Theme_Colors_Max_Order_By>;
-  min?: Maybe<Team_Page_Theme_Colors_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Arr_Rel_Insert_Input = {
-  data: Array<Team_Page_Theme_Colors_Insert_Input>;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "team_page_theme_colors". All fields are combined with a logical 'AND'. */
-export type Team_Page_Theme_Colors_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Team_Page_Theme_Colors_Bool_Exp>>>;
-  _not?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Team_Page_Theme_Colors_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "team_page_theme_colors" */
-export enum Team_Page_Theme_Colors_Constraint {
-  /** unique or primary key constraint */
-  TeamPageThemeColorsPkey = 'team_page_theme_colors_pkey'
-}
-
-/** input type for inserting data into table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type Team_Page_Theme_Colors_Max_Fields = {
-  __typename?: 'team_page_theme_colors_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Team_Page_Theme_Colors_Min_Fields = {
-  __typename?: 'team_page_theme_colors_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Mutation_Response = {
-  __typename?: 'team_page_theme_colors_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Team_Page_Theme_Colors>;
-};
-
-/** input type for inserting object relation for remote table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Obj_Rel_Insert_Input = {
-  data: Team_Page_Theme_Colors_Insert_Input;
-  on_conflict?: Maybe<Team_Page_Theme_Colors_On_Conflict>;
-};
-
-/** on conflict condition type for table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_On_Conflict = {
-  constraint: Team_Page_Theme_Colors_Constraint;
-  update_columns: Array<Team_Page_Theme_Colors_Update_Column>;
-  where?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "team_page_theme_colors" */
-export enum Team_Page_Theme_Colors_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "team_page_theme_colors" */
-export type Team_Page_Theme_Colors_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "team_page_theme_colors" */
-export enum Team_Page_Theme_Colors_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
 
 /** columns and relationships of "team_views" */
 export type Team_Views = {
   __typename?: 'team_views';
   created_at: Scalars['timestamptz'];
-  id: Scalars['Int'];
-  organization_id: Scalars['Int'];
-  team_id: Scalars['Int'];
-  user_id: Scalars['Int'];
-};
-
-/** aggregated selection of "team_views" */
-export type Team_Views_Aggregate = {
-  __typename?: 'team_views_aggregate';
-  aggregate?: Maybe<Team_Views_Aggregate_Fields>;
-  nodes: Array<Team_Views>;
-};
-
-/** aggregate fields of "team_views" */
-export type Team_Views_Aggregate_Fields = {
-  __typename?: 'team_views_aggregate_fields';
-  avg?: Maybe<Team_Views_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Team_Views_Max_Fields>;
-  min?: Maybe<Team_Views_Min_Fields>;
-  stddev?: Maybe<Team_Views_Stddev_Fields>;
-  stddev_pop?: Maybe<Team_Views_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Team_Views_Stddev_Samp_Fields>;
-  sum?: Maybe<Team_Views_Sum_Fields>;
-  var_pop?: Maybe<Team_Views_Var_Pop_Fields>;
-  var_samp?: Maybe<Team_Views_Var_Samp_Fields>;
-  variance?: Maybe<Team_Views_Variance_Fields>;
-};
-
-
-/** aggregate fields of "team_views" */
-export type Team_Views_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Team_Views_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "team_views" */
-export type Team_Views_Aggregate_Order_By = {
-  avg?: Maybe<Team_Views_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Team_Views_Max_Order_By>;
-  min?: Maybe<Team_Views_Min_Order_By>;
-  stddev?: Maybe<Team_Views_Stddev_Order_By>;
-  stddev_pop?: Maybe<Team_Views_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Team_Views_Stddev_Samp_Order_By>;
-  sum?: Maybe<Team_Views_Sum_Order_By>;
-  var_pop?: Maybe<Team_Views_Var_Pop_Order_By>;
-  var_samp?: Maybe<Team_Views_Var_Samp_Order_By>;
-  variance?: Maybe<Team_Views_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "team_views" */
 export type Team_Views_Arr_Rel_Insert_Input = {
   data: Array<Team_Views_Insert_Input>;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Team_Views_Avg_Fields = {
-  __typename?: 'team_views_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "team_views" */
-export type Team_Views_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "team_views". All fields are combined with a logical 'AND'. */
@@ -25128,71 +15962,11 @@ export type Team_Views_Bool_Exp = {
   _not?: Maybe<Team_Views_Bool_Exp>;
   _or?: Maybe<Array<Maybe<Team_Views_Bool_Exp>>>;
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
-  organization_id?: Maybe<Int_Comparison_Exp>;
-  team_id?: Maybe<Int_Comparison_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "team_views" */
-export enum Team_Views_Constraint {
-  /** unique or primary key constraint */
-  TeamViewsPkey = 'team_views_pkey'
-}
-
-/** input type for incrementing integer column in table "team_views" */
-export type Team_Views_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "team_views" */
 export type Team_Views_Insert_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
   team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type Team_Views_Max_Fields = {
-  __typename?: 'team_views_max_fields';
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "team_views" */
-export type Team_Views_Max_Order_By = {
-  created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Team_Views_Min_Fields = {
-  __typename?: 'team_views_min_fields';
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "team_views" */
-export type Team_Views_Min_Order_By = {
-  created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "team_views" */
@@ -25207,23 +15981,11 @@ export type Team_Views_Mutation_Response = {
 /** input type for inserting object relation for remote table "team_views" */
 export type Team_Views_Obj_Rel_Insert_Input = {
   data: Team_Views_Insert_Input;
-  on_conflict?: Maybe<Team_Views_On_Conflict>;
-};
-
-/** on conflict condition type for table "team_views" */
-export type Team_Views_On_Conflict = {
-  constraint: Team_Views_Constraint;
-  update_columns: Array<Team_Views_Update_Column>;
-  where?: Maybe<Team_Views_Bool_Exp>;
 };
 
 /** ordering options when selecting data from "team_views" */
 export type Team_Views_Order_By = {
   created_at?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: "team_views" */
@@ -25234,158 +15996,8 @@ export type Team_Views_Pk_Columns_Input = {
 /** select columns of table "team_views" */
 export enum Team_Views_Select_Column {
   /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
-  UserId = 'user_id'
+  CreatedAt = 'created_at'
 }
-
-/** input type for updating data in table "team_views" */
-export type Team_Views_Set_Input = {
-  created_at?: Maybe<Scalars['timestamptz']>;
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Team_Views_Stddev_Fields = {
-  __typename?: 'team_views_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "team_views" */
-export type Team_Views_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Team_Views_Stddev_Pop_Fields = {
-  __typename?: 'team_views_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "team_views" */
-export type Team_Views_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Team_Views_Stddev_Samp_Fields = {
-  __typename?: 'team_views_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "team_views" */
-export type Team_Views_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Team_Views_Sum_Fields = {
-  __typename?: 'team_views_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  organization_id?: Maybe<Scalars['Int']>;
-  team_id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "team_views" */
-export type Team_Views_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "team_views" */
-export enum Team_Views_Update_Column {
-  /** column name */
-  CreatedAt = 'created_at',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organization_id',
-  /** column name */
-  TeamId = 'team_id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** aggregate var_pop on columns */
-export type Team_Views_Var_Pop_Fields = {
-  __typename?: 'team_views_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "team_views" */
-export type Team_Views_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Team_Views_Var_Samp_Fields = {
-  __typename?: 'team_views_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "team_views" */
-export type Team_Views_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Team_Views_Variance_Fields = {
-  __typename?: 'team_views_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  organization_id?: Maybe<Scalars['Float']>;
-  team_id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "team_views" */
-export type Team_Views_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  organization_id?: Maybe<Order_By>;
-  team_id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
 
 /**
  * Teams are groups of Users within an Organization
@@ -25399,18 +16011,12 @@ export type Teams = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   createdBy?: Maybe<Users>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   /** An array relationship */
   dashboards: Array<Team_Dashboards>;
   /** An aggregated array relationship */
   dashboards_aggregate: Team_Dashboards_Aggregate;
-  deactivated?: Maybe<Scalars['Int']>;
-  /** A soft delete mechanism for removing a Team */
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
   /** An object relationship */
   featuredMetricCollection?: Maybe<Metric_Collections>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   /** A unique identifier for a Team */
   id: Scalars['Int'];
   /** An array relationship */
@@ -25425,10 +16031,8 @@ export type Teams = {
   name: Scalars['String'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   primaryDashboard?: Maybe<Dashboards>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   /** An array relationship */
   questionsDirectedTo: Array<Question_Directed_To>;
   /** An aggregated array relationship */
@@ -25445,11 +16049,7 @@ export type Teams = {
   teamMembers_aggregate: Team_Members_Aggregate;
   /** An array relationship */
   teamViews: Array<Team_Views>;
-  /** An aggregated array relationship */
-  teamViews_aggregate: Team_Views_Aggregate;
   theme?: Maybe<Scalars['String']>;
-  /** An object relationship */
-  theme_color?: Maybe<Team_Page_Theme_Colors>;
   /** Timestamp indicating when the Team was last updated */
   updatedAt?: Maybe<Scalars['timestamptz']>;
   /** A computed field, executes function "user_is_team_admin" */
@@ -25651,21 +16251,6 @@ export type TeamsTeamViewsArgs = {
   where?: Maybe<Team_Views_Bool_Exp>;
 };
 
-
-/**
- * Teams are groups of Users within an Organization
- *
- *
- * columns and relationships of "teams"
- */
-export type TeamsTeamViews_AggregateArgs = {
-  distinct_on?: Maybe<Array<Team_Views_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<Team_Views_Order_By>>;
-  where?: Maybe<Team_Views_Bool_Exp>;
-};
-
 /** aggregated selection of "teams" */
 export type Teams_Aggregate = {
   __typename?: 'teams_aggregate';
@@ -25720,24 +16305,12 @@ export type Teams_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Teams_Avg_Fields = {
   __typename?: 'teams_avg_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "teams" */
 export type Teams_Avg_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "teams". All fields are combined with a logical 'AND'. */
@@ -25747,28 +16320,20 @@ export type Teams_Bool_Exp = {
   _or?: Maybe<Array<Maybe<Teams_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   createdBy?: Maybe<Users_Bool_Exp>;
-  created_by?: Maybe<Int_Comparison_Exp>;
-  created_ts?: Maybe<Int_Comparison_Exp>;
   dashboards?: Maybe<Team_Dashboards_Bool_Exp>;
-  deactivated?: Maybe<Int_Comparison_Exp>;
-  deactivatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   featuredMetricCollection?: Maybe<Metric_Collections_Bool_Exp>;
-  featuredMetricCollectionId?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   metricCollections?: Maybe<Metric_Collections_Bool_Exp>;
   metricTeamOwners?: Maybe<Metric_Team_Owners_Bool_Exp>;
   name?: Maybe<String_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   primaryDashboard?: Maybe<Dashboards_Bool_Exp>;
-  primaryDashboardId?: Maybe<Int_Comparison_Exp>;
   questionsDirectedTo?: Maybe<Question_Directed_To_Bool_Exp>;
   savedQueries?: Maybe<Saved_Queries_Bool_Exp>;
   slug?: Maybe<String_Comparison_Exp>;
   teamMembers?: Maybe<Team_Members_Bool_Exp>;
   teamViews?: Maybe<Team_Views_Bool_Exp>;
   theme?: Maybe<String_Comparison_Exp>;
-  theme_color?: Maybe<Team_Page_Theme_Colors_Bool_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
 };
 
@@ -25782,57 +16347,32 @@ export enum Teams_Constraint {
 
 /** input type for incrementing integer column in table "teams" */
 export type Teams_Inc_Input = {
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
   featuredMetricCollectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "teams" */
 export type Teams_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
   createdBy?: Maybe<Users_Obj_Rel_Insert_Input>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
   dashboards?: Maybe<Team_Dashboards_Arr_Rel_Insert_Input>;
-  deactivated?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
   featuredMetricCollection?: Maybe<Metric_Collections_Obj_Rel_Insert_Input>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   metricCollections?: Maybe<Metric_Collections_Arr_Rel_Insert_Input>;
   metricTeamOwners?: Maybe<Metric_Team_Owners_Arr_Rel_Insert_Input>;
   name?: Maybe<Scalars['String']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   primaryDashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   questionsDirectedTo?: Maybe<Question_Directed_To_Arr_Rel_Insert_Input>;
   savedQueries?: Maybe<Saved_Queries_Arr_Rel_Insert_Input>;
   slug?: Maybe<Scalars['String']>;
   teamMembers?: Maybe<Team_Members_Arr_Rel_Insert_Input>;
   teamViews?: Maybe<Team_Views_Arr_Rel_Insert_Input>;
   theme?: Maybe<Scalars['String']>;
-  theme_color?: Maybe<Team_Page_Theme_Colors_Obj_Rel_Insert_Input>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate max on columns */
 export type Teams_Max_Fields = {
   __typename?: 'teams_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   theme?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -25841,15 +16381,8 @@ export type Teams_Max_Fields = {
 /** order by max() on columns of table "teams" */
 export type Teams_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   slug?: Maybe<Order_By>;
   theme?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -25859,15 +16392,8 @@ export type Teams_Max_Order_By = {
 export type Teams_Min_Fields = {
   __typename?: 'teams_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   theme?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -25876,15 +16402,8 @@ export type Teams_Min_Fields = {
 /** order by min() on columns of table "teams" */
 export type Teams_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   name?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   slug?: Maybe<Order_By>;
   theme?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -25916,28 +16435,19 @@ export type Teams_On_Conflict = {
 export type Teams_Order_By = {
   createdAt?: Maybe<Order_By>;
   createdBy?: Maybe<Users_Order_By>;
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
   dashboards_aggregate?: Maybe<Team_Dashboards_Aggregate_Order_By>;
-  deactivated?: Maybe<Order_By>;
-  deactivatedAt?: Maybe<Order_By>;
   featuredMetricCollection?: Maybe<Metric_Collections_Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   metricCollections_aggregate?: Maybe<Metric_Collections_Aggregate_Order_By>;
   metricTeamOwners_aggregate?: Maybe<Metric_Team_Owners_Aggregate_Order_By>;
   name?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   primaryDashboard?: Maybe<Dashboards_Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   questionsDirectedTo_aggregate?: Maybe<Question_Directed_To_Aggregate_Order_By>;
   savedQueries_aggregate?: Maybe<Saved_Queries_Aggregate_Order_By>;
   slug?: Maybe<Order_By>;
   teamMembers_aggregate?: Maybe<Team_Members_Aggregate_Order_By>;
-  teamViews_aggregate?: Maybe<Team_Views_Aggregate_Order_By>;
   theme?: Maybe<Order_By>;
-  theme_color?: Maybe<Team_Page_Theme_Colors_Order_By>;
   updatedAt?: Maybe<Order_By>;
 };
 
@@ -25952,23 +16462,9 @@ export enum Teams_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  CreatedBy = 'created_by',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Deactivated = 'deactivated',
-  /** column name */
-  DeactivatedAt = 'deactivatedAt',
-  /** column name */
-  FeaturedMetricCollectionId = 'featuredMetricCollectionId',
-  /** column name */
   Id = 'id',
   /** column name */
   Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
   /** column name */
   Slug = 'slug',
   /** column name */
@@ -25979,210 +16475,102 @@ export enum Teams_Select_Column {
 
 /** input type for updating data in table "teams" */
 export type Teams_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   featuredMetricCollectionId?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   slug?: Maybe<Scalars['String']>;
   theme?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
 };
 
 /** aggregate stddev on columns */
 export type Teams_Stddev_Fields = {
   __typename?: 'teams_stddev_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "teams" */
 export type Teams_Stddev_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Teams_Stddev_Pop_Fields = {
   __typename?: 'teams_stddev_pop_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "teams" */
 export type Teams_Stddev_Pop_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Teams_Stddev_Samp_Fields = {
   __typename?: 'teams_stddev_samp_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "teams" */
 export type Teams_Stddev_Samp_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Teams_Sum_Fields = {
   __typename?: 'teams_sum_fields';
-  created_by?: Maybe<Scalars['Int']>;
-  created_ts?: Maybe<Scalars['Int']>;
-  deactivated?: Maybe<Scalars['Int']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "teams" */
 export type Teams_Sum_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** update columns of table "teams" */
 export enum Teams_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  CreatedBy = 'created_by',
-  /** column name */
-  CreatedTs = 'created_ts',
-  /** column name */
-  Deactivated = 'deactivated',
-  /** column name */
   DeactivatedAt = 'deactivatedAt',
   /** column name */
   FeaturedMetricCollectionId = 'featuredMetricCollectionId',
   /** column name */
-  Id = 'id',
-  /** column name */
   Name = 'name',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
   /** column name */
   Slug = 'slug',
   /** column name */
-  Theme = 'theme',
-  /** column name */
-  UpdatedAt = 'updatedAt'
+  Theme = 'theme'
 }
 
 /** aggregate var_pop on columns */
 export type Teams_Var_Pop_Fields = {
   __typename?: 'teams_var_pop_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "teams" */
 export type Teams_Var_Pop_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Teams_Var_Samp_Fields = {
   __typename?: 'teams_var_samp_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "teams" */
 export type Teams_Var_Samp_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Teams_Variance_Fields = {
   __typename?: 'teams_variance_fields';
-  created_by?: Maybe<Scalars['Float']>;
-  created_ts?: Maybe<Scalars['Float']>;
-  deactivated?: Maybe<Scalars['Float']>;
-  featuredMetricCollectionId?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "teams" */
 export type Teams_Variance_Order_By = {
-  created_by?: Maybe<Order_By>;
-  created_ts?: Maybe<Order_By>;
-  deactivated?: Maybe<Order_By>;
-  featuredMetricCollectionId?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 
@@ -26197,628 +16585,6 @@ export type Timestamptz_Comparison_Exp = {
   _lte?: Maybe<Scalars['timestamptz']>;
   _neq?: Maybe<Scalars['timestamptz']>;
   _nin?: Maybe<Array<Scalars['timestamptz']>>;
-};
-
-/**
- * Tracks which users have unsubscribed from which transactional emails.
- *
- *
- * columns and relationships of "unsubscribes"
- */
-export type Unsubscribes = {
-  __typename?: 'unsubscribes';
-  email_type: Scalars['String'];
-  id: Scalars['Int'];
-  /** An object relationship */
-  user: Users;
-  user_id: Scalars['Int'];
-};
-
-/** aggregated selection of "unsubscribes" */
-export type Unsubscribes_Aggregate = {
-  __typename?: 'unsubscribes_aggregate';
-  aggregate?: Maybe<Unsubscribes_Aggregate_Fields>;
-  nodes: Array<Unsubscribes>;
-};
-
-/** aggregate fields of "unsubscribes" */
-export type Unsubscribes_Aggregate_Fields = {
-  __typename?: 'unsubscribes_aggregate_fields';
-  avg?: Maybe<Unsubscribes_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<Unsubscribes_Max_Fields>;
-  min?: Maybe<Unsubscribes_Min_Fields>;
-  stddev?: Maybe<Unsubscribes_Stddev_Fields>;
-  stddev_pop?: Maybe<Unsubscribes_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<Unsubscribes_Stddev_Samp_Fields>;
-  sum?: Maybe<Unsubscribes_Sum_Fields>;
-  var_pop?: Maybe<Unsubscribes_Var_Pop_Fields>;
-  var_samp?: Maybe<Unsubscribes_Var_Samp_Fields>;
-  variance?: Maybe<Unsubscribes_Variance_Fields>;
-};
-
-
-/** aggregate fields of "unsubscribes" */
-export type Unsubscribes_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<Unsubscribes_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "unsubscribes" */
-export type Unsubscribes_Aggregate_Order_By = {
-  avg?: Maybe<Unsubscribes_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<Unsubscribes_Max_Order_By>;
-  min?: Maybe<Unsubscribes_Min_Order_By>;
-  stddev?: Maybe<Unsubscribes_Stddev_Order_By>;
-  stddev_pop?: Maybe<Unsubscribes_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<Unsubscribes_Stddev_Samp_Order_By>;
-  sum?: Maybe<Unsubscribes_Sum_Order_By>;
-  var_pop?: Maybe<Unsubscribes_Var_Pop_Order_By>;
-  var_samp?: Maybe<Unsubscribes_Var_Samp_Order_By>;
-  variance?: Maybe<Unsubscribes_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "unsubscribes" */
-export type Unsubscribes_Arr_Rel_Insert_Input = {
-  data: Array<Unsubscribes_Insert_Input>;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type Unsubscribes_Avg_Fields = {
-  __typename?: 'unsubscribes_avg_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "unsubscribes" */
-export type Unsubscribes_Avg_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "unsubscribes". All fields are combined with a logical 'AND'. */
-export type Unsubscribes_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<Unsubscribes_Bool_Exp>>>;
-  _not?: Maybe<Unsubscribes_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<Unsubscribes_Bool_Exp>>>;
-  email_type?: Maybe<String_Comparison_Exp>;
-  id?: Maybe<Int_Comparison_Exp>;
-  user?: Maybe<Users_Bool_Exp>;
-  user_id?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "unsubscribes" */
-export enum Unsubscribes_Constraint {
-  /** unique or primary key constraint */
-  UnsubscribesEmailTypeUserIdKey = 'unsubscribes_email_type_user_id_key',
-  /** unique or primary key constraint */
-  UnsubscribesPkey = 'unsubscribes_pkey'
-}
-
-/** input type for incrementing integer column in table "unsubscribes" */
-export type Unsubscribes_Inc_Input = {
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "unsubscribes" */
-export type Unsubscribes_Insert_Input = {
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type Unsubscribes_Max_Fields = {
-  __typename?: 'unsubscribes_max_fields';
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "unsubscribes" */
-export type Unsubscribes_Max_Order_By = {
-  email_type?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type Unsubscribes_Min_Fields = {
-  __typename?: 'unsubscribes_min_fields';
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "unsubscribes" */
-export type Unsubscribes_Min_Order_By = {
-  email_type?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "unsubscribes" */
-export type Unsubscribes_Mutation_Response = {
-  __typename?: 'unsubscribes_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<Unsubscribes>;
-};
-
-/** input type for inserting object relation for remote table "unsubscribes" */
-export type Unsubscribes_Obj_Rel_Insert_Input = {
-  data: Unsubscribes_Insert_Input;
-  on_conflict?: Maybe<Unsubscribes_On_Conflict>;
-};
-
-/** on conflict condition type for table "unsubscribes" */
-export type Unsubscribes_On_Conflict = {
-  constraint: Unsubscribes_Constraint;
-  update_columns: Array<Unsubscribes_Update_Column>;
-  where?: Maybe<Unsubscribes_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "unsubscribes" */
-export type Unsubscribes_Order_By = {
-  email_type?: Maybe<Order_By>;
-  id?: Maybe<Order_By>;
-  user?: Maybe<Users_Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "unsubscribes" */
-export type Unsubscribes_Pk_Columns_Input = {
-  id: Scalars['Int'];
-};
-
-/** select columns of table "unsubscribes" */
-export enum Unsubscribes_Select_Column {
-  /** column name */
-  EmailType = 'email_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** input type for updating data in table "unsubscribes" */
-export type Unsubscribes_Set_Input = {
-  email_type?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type Unsubscribes_Stddev_Fields = {
-  __typename?: 'unsubscribes_stddev_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "unsubscribes" */
-export type Unsubscribes_Stddev_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type Unsubscribes_Stddev_Pop_Fields = {
-  __typename?: 'unsubscribes_stddev_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "unsubscribes" */
-export type Unsubscribes_Stddev_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type Unsubscribes_Stddev_Samp_Fields = {
-  __typename?: 'unsubscribes_stddev_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "unsubscribes" */
-export type Unsubscribes_Stddev_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type Unsubscribes_Sum_Fields = {
-  __typename?: 'unsubscribes_sum_fields';
-  id?: Maybe<Scalars['Int']>;
-  user_id?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "unsubscribes" */
-export type Unsubscribes_Sum_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** update columns of table "unsubscribes" */
-export enum Unsubscribes_Update_Column {
-  /** column name */
-  EmailType = 'email_type',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  UserId = 'user_id'
-}
-
-/** aggregate var_pop on columns */
-export type Unsubscribes_Var_Pop_Fields = {
-  __typename?: 'unsubscribes_var_pop_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "unsubscribes" */
-export type Unsubscribes_Var_Pop_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type Unsubscribes_Var_Samp_Fields = {
-  __typename?: 'unsubscribes_var_samp_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "unsubscribes" */
-export type Unsubscribes_Var_Samp_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type Unsubscribes_Variance_Fields = {
-  __typename?: 'unsubscribes_variance_fields';
-  id?: Maybe<Scalars['Float']>;
-  user_id?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "unsubscribes" */
-export type Unsubscribes_Variance_Order_By = {
-  id?: Maybe<Order_By>;
-  user_id?: Maybe<Order_By>;
-};
-
-/** columns and relationships of "user_dashboards" */
-export type User_Dashboards = {
-  __typename?: 'user_dashboards';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId: Scalars['Int'];
-  organizationId: Scalars['Int'];
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId: Scalars['Int'];
-};
-
-/** aggregated selection of "user_dashboards" */
-export type User_Dashboards_Aggregate = {
-  __typename?: 'user_dashboards_aggregate';
-  aggregate?: Maybe<User_Dashboards_Aggregate_Fields>;
-  nodes: Array<User_Dashboards>;
-};
-
-/** aggregate fields of "user_dashboards" */
-export type User_Dashboards_Aggregate_Fields = {
-  __typename?: 'user_dashboards_aggregate_fields';
-  avg?: Maybe<User_Dashboards_Avg_Fields>;
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<User_Dashboards_Max_Fields>;
-  min?: Maybe<User_Dashboards_Min_Fields>;
-  stddev?: Maybe<User_Dashboards_Stddev_Fields>;
-  stddev_pop?: Maybe<User_Dashboards_Stddev_Pop_Fields>;
-  stddev_samp?: Maybe<User_Dashboards_Stddev_Samp_Fields>;
-  sum?: Maybe<User_Dashboards_Sum_Fields>;
-  var_pop?: Maybe<User_Dashboards_Var_Pop_Fields>;
-  var_samp?: Maybe<User_Dashboards_Var_Samp_Fields>;
-  variance?: Maybe<User_Dashboards_Variance_Fields>;
-};
-
-
-/** aggregate fields of "user_dashboards" */
-export type User_Dashboards_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<User_Dashboards_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "user_dashboards" */
-export type User_Dashboards_Aggregate_Order_By = {
-  avg?: Maybe<User_Dashboards_Avg_Order_By>;
-  count?: Maybe<Order_By>;
-  max?: Maybe<User_Dashboards_Max_Order_By>;
-  min?: Maybe<User_Dashboards_Min_Order_By>;
-  stddev?: Maybe<User_Dashboards_Stddev_Order_By>;
-  stddev_pop?: Maybe<User_Dashboards_Stddev_Pop_Order_By>;
-  stddev_samp?: Maybe<User_Dashboards_Stddev_Samp_Order_By>;
-  sum?: Maybe<User_Dashboards_Sum_Order_By>;
-  var_pop?: Maybe<User_Dashboards_Var_Pop_Order_By>;
-  var_samp?: Maybe<User_Dashboards_Var_Samp_Order_By>;
-  variance?: Maybe<User_Dashboards_Variance_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "user_dashboards" */
-export type User_Dashboards_Arr_Rel_Insert_Input = {
-  data: Array<User_Dashboards_Insert_Input>;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-/** aggregate avg on columns */
-export type User_Dashboards_Avg_Fields = {
-  __typename?: 'user_dashboards_avg_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by avg() on columns of table "user_dashboards" */
-export type User_Dashboards_Avg_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** Boolean expression to filter rows from the table "user_dashboards". All fields are combined with a logical 'AND'. */
-export type User_Dashboards_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<User_Dashboards_Bool_Exp>>>;
-  _not?: Maybe<User_Dashboards_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<User_Dashboards_Bool_Exp>>>;
-  createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dashboardId?: Maybe<Int_Comparison_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
-  updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "user_dashboards" */
-export enum User_Dashboards_Constraint {
-  /** unique or primary key constraint */
-  UserDashboardsPkey = 'user_dashboards_pkey'
-}
-
-/** input type for incrementing integer column in table "user_dashboards" */
-export type User_Dashboards_Inc_Input = {
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "user_dashboards" */
-export type User_Dashboards_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate max on columns */
-export type User_Dashboards_Max_Fields = {
-  __typename?: 'user_dashboards_max_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by max() on columns of table "user_dashboards" */
-export type User_Dashboards_Max_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type User_Dashboards_Min_Fields = {
-  __typename?: 'user_dashboards_min_fields';
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by min() on columns of table "user_dashboards" */
-export type User_Dashboards_Min_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "user_dashboards" */
-export type User_Dashboards_Mutation_Response = {
-  __typename?: 'user_dashboards_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<User_Dashboards>;
-};
-
-/** input type for inserting object relation for remote table "user_dashboards" */
-export type User_Dashboards_Obj_Rel_Insert_Input = {
-  data: User_Dashboards_Insert_Input;
-  on_conflict?: Maybe<User_Dashboards_On_Conflict>;
-};
-
-/** on conflict condition type for table "user_dashboards" */
-export type User_Dashboards_On_Conflict = {
-  constraint: User_Dashboards_Constraint;
-  update_columns: Array<User_Dashboards_Update_Column>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "user_dashboards" */
-export type User_Dashboards_Order_By = {
-  createdAt?: Maybe<Order_By>;
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  updatedAt?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "user_dashboards" */
-export type User_Dashboards_Pk_Columns_Input = {
-  dashboardId: Scalars['Int'];
-  userId: Scalars['Int'];
-};
-
-/** select columns of table "user_dashboards" */
-export enum User_Dashboards_Select_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
-}
-
-/** input type for updating data in table "user_dashboards" */
-export type User_Dashboards_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** aggregate stddev on columns */
-export type User_Dashboards_Stddev_Fields = {
-  __typename?: 'user_dashboards_stddev_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev() on columns of table "user_dashboards" */
-export type User_Dashboards_Stddev_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_pop on columns */
-export type User_Dashboards_Stddev_Pop_Fields = {
-  __typename?: 'user_dashboards_stddev_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_pop() on columns of table "user_dashboards" */
-export type User_Dashboards_Stddev_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate stddev_samp on columns */
-export type User_Dashboards_Stddev_Samp_Fields = {
-  __typename?: 'user_dashboards_stddev_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by stddev_samp() on columns of table "user_dashboards" */
-export type User_Dashboards_Stddev_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate sum on columns */
-export type User_Dashboards_Sum_Fields = {
-  __typename?: 'user_dashboards_sum_fields';
-  dashboardId?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** order by sum() on columns of table "user_dashboards" */
-export type User_Dashboards_Sum_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** update columns of table "user_dashboards" */
-export enum User_Dashboards_Update_Column {
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DashboardId = 'dashboardId',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
-}
-
-/** aggregate var_pop on columns */
-export type User_Dashboards_Var_Pop_Fields = {
-  __typename?: 'user_dashboards_var_pop_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_pop() on columns of table "user_dashboards" */
-export type User_Dashboards_Var_Pop_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate var_samp on columns */
-export type User_Dashboards_Var_Samp_Fields = {
-  __typename?: 'user_dashboards_var_samp_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by var_samp() on columns of table "user_dashboards" */
-export type User_Dashboards_Var_Samp_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
-};
-
-/** aggregate variance on columns */
-export type User_Dashboards_Variance_Fields = {
-  __typename?: 'user_dashboards_variance_fields';
-  dashboardId?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  userId?: Maybe<Scalars['Float']>;
-};
-
-/** order by variance() on columns of table "user_dashboards" */
-export type User_Dashboards_Variance_Order_By = {
-  dashboardId?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  userId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "user_features" */
@@ -26877,12 +16643,6 @@ export type User_Features_Aggregate_Order_By = {
   variance?: Maybe<User_Features_Variance_Order_By>;
 };
 
-/** input type for inserting array relation for remote table "user_features" */
-export type User_Features_Arr_Rel_Insert_Input = {
-  data: Array<User_Features_Insert_Input>;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
 /** aggregate avg on columns */
 export type User_Features_Avg_Fields = {
   __typename?: 'user_features_avg_fields';
@@ -26905,26 +16665,6 @@ export type User_Features_Bool_Exp = {
   featureId?: Maybe<Int_Comparison_Exp>;
   user?: Maybe<Users_Bool_Exp>;
   userId?: Maybe<Int_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "user_features" */
-export enum User_Features_Constraint {
-  /** unique or primary key constraint */
-  UserFeaturesPkey = 'user_features_pkey'
-}
-
-/** input type for incrementing integer column in table "user_features" */
-export type User_Features_Inc_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
-/** input type for inserting data into table "user_features" */
-export type User_Features_Insert_Input = {
-  feature?: Maybe<Features_Obj_Rel_Insert_Input>;
-  featureId?: Maybe<Scalars['Int']>;
-  user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -26953,28 +16693,6 @@ export type User_Features_Min_Order_By = {
   userId?: Maybe<Order_By>;
 };
 
-/** response of any mutation on the table "user_features" */
-export type User_Features_Mutation_Response = {
-  __typename?: 'user_features_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<User_Features>;
-};
-
-/** input type for inserting object relation for remote table "user_features" */
-export type User_Features_Obj_Rel_Insert_Input = {
-  data: User_Features_Insert_Input;
-  on_conflict?: Maybe<User_Features_On_Conflict>;
-};
-
-/** on conflict condition type for table "user_features" */
-export type User_Features_On_Conflict = {
-  constraint: User_Features_Constraint;
-  update_columns: Array<User_Features_Update_Column>;
-  where?: Maybe<User_Features_Bool_Exp>;
-};
-
 /** ordering options when selecting data from "user_features" */
 export type User_Features_Order_By = {
   feature?: Maybe<Features_Order_By>;
@@ -26996,12 +16714,6 @@ export enum User_Features_Select_Column {
   /** column name */
   UserId = 'userId'
 }
-
-/** input type for updating data in table "user_features" */
-export type User_Features_Set_Input = {
-  featureId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
 
 /** aggregate stddev on columns */
 export type User_Features_Stddev_Fields = {
@@ -27055,14 +16767,6 @@ export type User_Features_Sum_Order_By = {
   userId?: Maybe<Order_By>;
 };
 
-/** update columns of table "user_features" */
-export enum User_Features_Update_Column {
-  /** column name */
-  FeatureId = 'featureId',
-  /** column name */
-  UserId = 'userId'
-}
-
 /** aggregate var_pop on columns */
 export type User_Features_Var_Pop_Fields = {
   __typename?: 'user_features_var_pop_fields';
@@ -27112,7 +16816,6 @@ export type User_Prefs = {
   __typename?: 'user_prefs';
   /** Timestamp indicating when the User Preference was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
@@ -27182,7 +16885,6 @@ export type User_Prefs_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type User_Prefs_Avg_Fields = {
   __typename?: 'user_prefs_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27190,7 +16892,6 @@ export type User_Prefs_Avg_Fields = {
 
 /** order by avg() on columns of table "user_prefs" */
 export type User_Prefs_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27202,7 +16903,6 @@ export type User_Prefs_Bool_Exp = {
   _not?: Maybe<User_Prefs_Bool_Exp>;
   _or?: Maybe<Array<Maybe<User_Prefs_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
   organizationId?: Maybe<Int_Comparison_Exp>;
@@ -27221,33 +16921,17 @@ export enum User_Prefs_Constraint {
   UserPrefsUserIdPrefKeyKey = 'user_prefs_user_id_pref_key_key'
 }
 
-/** input type for incrementing integer column in table "user_prefs" */
-export type User_Prefs_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "user_prefs" */
 export type User_Prefs_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
   prefValue?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
 export type User_Prefs_Max_Fields = {
   __typename?: 'user_prefs_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
@@ -27259,7 +16943,6 @@ export type User_Prefs_Max_Fields = {
 /** order by max() on columns of table "user_prefs" */
 export type User_Prefs_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   prefKey?: Maybe<Order_By>;
@@ -27272,7 +16955,6 @@ export type User_Prefs_Max_Order_By = {
 export type User_Prefs_Min_Fields = {
   __typename?: 'user_prefs_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
@@ -27284,7 +16966,6 @@ export type User_Prefs_Min_Fields = {
 /** order by min() on columns of table "user_prefs" */
 export type User_Prefs_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   prefKey?: Maybe<Order_By>;
@@ -27318,7 +16999,6 @@ export type User_Prefs_On_Conflict = {
 /** ordering options when selecting data from "user_prefs" */
 export type User_Prefs_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
   organizationId?: Maybe<Order_By>;
@@ -27339,8 +17019,6 @@ export enum User_Prefs_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateCreate = 'date_create',
-  /** column name */
   Id = 'id',
   /** column name */
   OrganizationId = 'organizationId',
@@ -27356,20 +17034,13 @@ export enum User_Prefs_Select_Column {
 
 /** input type for updating data in table "user_prefs" */
 export type User_Prefs_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   prefKey?: Maybe<Scalars['String']>;
   prefValue?: Maybe<Scalars['String']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type User_Prefs_Stddev_Fields = {
   __typename?: 'user_prefs_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27377,7 +17048,6 @@ export type User_Prefs_Stddev_Fields = {
 
 /** order by stddev() on columns of table "user_prefs" */
 export type User_Prefs_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27386,7 +17056,6 @@ export type User_Prefs_Stddev_Order_By = {
 /** aggregate stddev_pop on columns */
 export type User_Prefs_Stddev_Pop_Fields = {
   __typename?: 'user_prefs_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27394,7 +17063,6 @@ export type User_Prefs_Stddev_Pop_Fields = {
 
 /** order by stddev_pop() on columns of table "user_prefs" */
 export type User_Prefs_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27403,7 +17071,6 @@ export type User_Prefs_Stddev_Pop_Order_By = {
 /** aggregate stddev_samp on columns */
 export type User_Prefs_Stddev_Samp_Fields = {
   __typename?: 'user_prefs_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27411,7 +17078,6 @@ export type User_Prefs_Stddev_Samp_Fields = {
 
 /** order by stddev_samp() on columns of table "user_prefs" */
 export type User_Prefs_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27420,7 +17086,6 @@ export type User_Prefs_Stddev_Samp_Order_By = {
 /** aggregate sum on columns */
 export type User_Prefs_Sum_Fields = {
   __typename?: 'user_prefs_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
   organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
@@ -27428,7 +17093,6 @@ export type User_Prefs_Sum_Fields = {
 
 /** order by sum() on columns of table "user_prefs" */
 export type User_Prefs_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27437,27 +17101,14 @@ export type User_Prefs_Sum_Order_By = {
 /** update columns of table "user_prefs" */
 export enum User_Prefs_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
   PrefKey = 'prefKey',
   /** column name */
-  PrefValue = 'prefValue',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  PrefValue = 'prefValue'
 }
 
 /** aggregate var_pop on columns */
 export type User_Prefs_Var_Pop_Fields = {
   __typename?: 'user_prefs_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27465,7 +17116,6 @@ export type User_Prefs_Var_Pop_Fields = {
 
 /** order by var_pop() on columns of table "user_prefs" */
 export type User_Prefs_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27474,7 +17124,6 @@ export type User_Prefs_Var_Pop_Order_By = {
 /** aggregate var_samp on columns */
 export type User_Prefs_Var_Samp_Fields = {
   __typename?: 'user_prefs_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27482,7 +17131,6 @@ export type User_Prefs_Var_Samp_Fields = {
 
 /** order by var_samp() on columns of table "user_prefs" */
 export type User_Prefs_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27491,7 +17139,6 @@ export type User_Prefs_Var_Samp_Order_By = {
 /** aggregate variance on columns */
 export type User_Prefs_Variance_Fields = {
   __typename?: 'user_prefs_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
   organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
@@ -27499,73 +17146,10 @@ export type User_Prefs_Variance_Fields = {
 
 /** order by variance() on columns of table "user_prefs" */
 export type User_Prefs_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
-
-/**
- * Enum for our User Roles
- *
- *
- * columns and relationships of "user_role_types"
- */
-export type User_Role_Types = {
-  __typename?: 'user_role_types';
-  comment: Scalars['String'];
-  value: Scalars['String'];
-};
-
-/** aggregated selection of "user_role_types" */
-export type User_Role_Types_Aggregate = {
-  __typename?: 'user_role_types_aggregate';
-  aggregate?: Maybe<User_Role_Types_Aggregate_Fields>;
-  nodes: Array<User_Role_Types>;
-};
-
-/** aggregate fields of "user_role_types" */
-export type User_Role_Types_Aggregate_Fields = {
-  __typename?: 'user_role_types_aggregate_fields';
-  count?: Maybe<Scalars['Int']>;
-  max?: Maybe<User_Role_Types_Max_Fields>;
-  min?: Maybe<User_Role_Types_Min_Fields>;
-};
-
-
-/** aggregate fields of "user_role_types" */
-export type User_Role_Types_Aggregate_FieldsCountArgs = {
-  columns?: Maybe<Array<User_Role_Types_Select_Column>>;
-  distinct?: Maybe<Scalars['Boolean']>;
-};
-
-/** order by aggregate values of table "user_role_types" */
-export type User_Role_Types_Aggregate_Order_By = {
-  count?: Maybe<Order_By>;
-  max?: Maybe<User_Role_Types_Max_Order_By>;
-  min?: Maybe<User_Role_Types_Min_Order_By>;
-};
-
-/** input type for inserting array relation for remote table "user_role_types" */
-export type User_Role_Types_Arr_Rel_Insert_Input = {
-  data: Array<User_Role_Types_Insert_Input>;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-/** Boolean expression to filter rows from the table "user_role_types". All fields are combined with a logical 'AND'. */
-export type User_Role_Types_Bool_Exp = {
-  _and?: Maybe<Array<Maybe<User_Role_Types_Bool_Exp>>>;
-  _not?: Maybe<User_Role_Types_Bool_Exp>;
-  _or?: Maybe<Array<Maybe<User_Role_Types_Bool_Exp>>>;
-  comment?: Maybe<String_Comparison_Exp>;
-  value?: Maybe<String_Comparison_Exp>;
-};
-
-/** unique or primary key constraints on table "user_role_types" */
-export enum User_Role_Types_Constraint {
-  /** unique or primary key constraint */
-  UserRoleTypesPkey = 'user_role_types_pkey'
-}
 
 export enum User_Role_Types_Enum {
   /** 	Full administrator access. */
@@ -27587,104 +17171,14 @@ export type User_Role_Types_Enum_Comparison_Exp = {
   _nin?: Maybe<Array<User_Role_Types_Enum>>;
 };
 
-/** input type for inserting data into table "user_role_types" */
-export type User_Role_Types_Insert_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** aggregate max on columns */
-export type User_Role_Types_Max_Fields = {
-  __typename?: 'user_role_types_max_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by max() on columns of table "user_role_types" */
-export type User_Role_Types_Max_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** aggregate min on columns */
-export type User_Role_Types_Min_Fields = {
-  __typename?: 'user_role_types_min_fields';
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** order by min() on columns of table "user_role_types" */
-export type User_Role_Types_Min_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** response of any mutation on the table "user_role_types" */
-export type User_Role_Types_Mutation_Response = {
-  __typename?: 'user_role_types_mutation_response';
-  /** number of affected rows by the mutation */
-  affected_rows: Scalars['Int'];
-  /** data of the affected rows by the mutation */
-  returning: Array<User_Role_Types>;
-};
-
-/** input type for inserting object relation for remote table "user_role_types" */
-export type User_Role_Types_Obj_Rel_Insert_Input = {
-  data: User_Role_Types_Insert_Input;
-  on_conflict?: Maybe<User_Role_Types_On_Conflict>;
-};
-
-/** on conflict condition type for table "user_role_types" */
-export type User_Role_Types_On_Conflict = {
-  constraint: User_Role_Types_Constraint;
-  update_columns: Array<User_Role_Types_Update_Column>;
-  where?: Maybe<User_Role_Types_Bool_Exp>;
-};
-
-/** ordering options when selecting data from "user_role_types" */
-export type User_Role_Types_Order_By = {
-  comment?: Maybe<Order_By>;
-  value?: Maybe<Order_By>;
-};
-
-/** primary key columns input for table: "user_role_types" */
-export type User_Role_Types_Pk_Columns_Input = {
-  value: Scalars['String'];
-};
-
-/** select columns of table "user_role_types" */
-export enum User_Role_Types_Select_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
-/** input type for updating data in table "user_role_types" */
-export type User_Role_Types_Set_Input = {
-  comment?: Maybe<Scalars['String']>;
-  value?: Maybe<Scalars['String']>;
-};
-
-/** update columns of table "user_role_types" */
-export enum User_Role_Types_Update_Column {
-  /** column name */
-  Comment = 'comment',
-  /** column name */
-  Value = 'value'
-}
-
 /** columns and relationships of "user_roles" */
 export type User_Roles = {
   __typename?: 'user_roles';
   /** Timestamp indicating when a user role was added */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** Soft delete mechanism for a User Role. Rows with non-null values are omitted from list results. */
   removedAt?: Maybe<Scalars['timestamptz']>;
   role: User_Role_Types_Enum;
@@ -27749,19 +17243,13 @@ export type User_Roles_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type User_Roles_Avg_Fields = {
   __typename?: 'user_roles_avg_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "user_roles" */
 export type User_Roles_Avg_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
@@ -27771,11 +17259,8 @@ export type User_Roles_Bool_Exp = {
   _not?: Maybe<User_Roles_Bool_Exp>;
   _or?: Maybe<Array<Maybe<User_Roles_Bool_Exp>>>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  date_added?: Maybe<Int_Comparison_Exp>;
-  date_removed?: Maybe<Int_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   removedAt?: Maybe<Timestamptz_Comparison_Exp>;
   role?: Maybe<User_Role_Types_Enum_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -27791,26 +17276,10 @@ export enum User_Roles_Constraint {
   UserRolesUserIdRoleKey = 'user_roles_user_id_role_key'
 }
 
-/** input type for incrementing integer column in table "user_roles" */
-export type User_Roles_Inc_Input = {
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  userId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "user_roles" */
 export type User_Roles_Insert_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
   role?: Maybe<User_Role_Types_Enum>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   user?: Maybe<Users_Obj_Rel_Insert_Input>;
   userId?: Maybe<Scalars['Int']>;
 };
@@ -27819,10 +17288,7 @@ export type User_Roles_Insert_Input = {
 export type User_Roles_Max_Fields = {
   __typename?: 'user_roles_max_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userId?: Maybe<Scalars['Int']>;
@@ -27831,10 +17297,7 @@ export type User_Roles_Max_Fields = {
 /** order by max() on columns of table "user_roles" */
 export type User_Roles_Max_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   removedAt?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27844,10 +17307,7 @@ export type User_Roles_Max_Order_By = {
 export type User_Roles_Min_Fields = {
   __typename?: 'user_roles_min_fields';
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userId?: Maybe<Scalars['Int']>;
@@ -27856,10 +17316,7 @@ export type User_Roles_Min_Fields = {
 /** order by min() on columns of table "user_roles" */
 export type User_Roles_Min_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   removedAt?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
@@ -27890,11 +17347,8 @@ export type User_Roles_On_Conflict = {
 /** ordering options when selecting data from "user_roles" */
 export type User_Roles_Order_By = {
   createdAt?: Maybe<Order_By>;
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   removedAt?: Maybe<Order_By>;
   role?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -27912,13 +17366,7 @@ export enum User_Roles_Select_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  DateAdded = 'date_added',
-  /** column name */
-  DateRemoved = 'date_removed',
-  /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
   /** column name */
   RemovedAt = 'removedAt',
   /** column name */
@@ -27931,169 +17379,103 @@ export enum User_Roles_Select_Column {
 
 /** input type for updating data in table "user_roles" */
 export type User_Roles_Set_Input = {
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   removedAt?: Maybe<Scalars['timestamptz']>;
-  role?: Maybe<User_Role_Types_Enum>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
-  userId?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate stddev on columns */
 export type User_Roles_Stddev_Fields = {
   __typename?: 'user_roles_stddev_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "user_roles" */
 export type User_Roles_Stddev_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type User_Roles_Stddev_Pop_Fields = {
   __typename?: 'user_roles_stddev_pop_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "user_roles" */
 export type User_Roles_Stddev_Pop_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type User_Roles_Stddev_Samp_Fields = {
   __typename?: 'user_roles_stddev_samp_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "user_roles" */
 export type User_Roles_Stddev_Samp_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type User_Roles_Sum_Fields = {
   __typename?: 'user_roles_sum_fields';
-  date_added?: Maybe<Scalars['Int']>;
-  date_removed?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "user_roles" */
 export type User_Roles_Sum_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** update columns of table "user_roles" */
 export enum User_Roles_Update_Column {
   /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateAdded = 'date_added',
-  /** column name */
-  DateRemoved = 'date_removed',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  RemovedAt = 'removedAt',
-  /** column name */
-  Role = 'role',
-  /** column name */
-  UpdatedAt = 'updatedAt',
-  /** column name */
-  UserId = 'userId'
+  RemovedAt = 'removedAt'
 }
 
 /** aggregate var_pop on columns */
 export type User_Roles_Var_Pop_Fields = {
   __typename?: 'user_roles_var_pop_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "user_roles" */
 export type User_Roles_Var_Pop_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type User_Roles_Var_Samp_Fields = {
   __typename?: 'user_roles_var_samp_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "user_roles" */
 export type User_Roles_Var_Samp_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type User_Roles_Variance_Fields = {
   __typename?: 'user_roles_variance_fields';
-  date_added?: Maybe<Scalars['Float']>;
-  date_removed?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "user_roles" */
 export type User_Roles_Variance_Order_By = {
-  date_added?: Maybe<Order_By>;
-  date_removed?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
 };
 
@@ -28117,18 +17499,11 @@ export type Users = {
   apiKeysByRevokerId_aggregate: Api_Keys_Aggregate;
   /** An aggregated array relationship */
   apiKeys_aggregate: Api_Keys_Aggregate;
-  auth0Id?: Maybe<Scalars['String']>;
   /** Remote relationship field */
   auth0Profile?: Maybe<Auth0Profile>;
   avatarUrl?: Maybe<Scalars['String']>;
   /** Timestamp indicating when the user was created */
   createdAt?: Maybe<Scalars['timestamptz']>;
-  /** An array relationship */
-  dashboards: Array<User_Dashboards>;
-  /** An aggregated array relationship */
-  dashboards_aggregate: User_Dashboards_Aggregate;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   /** Soft delete mechanism for a User. Rows with non-null values are omitted from list results. */
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   /** The `User`'s email address */
@@ -28158,10 +17533,8 @@ export type Users = {
   modelsUploaded_aggregate: Models_Aggregate;
   /** An object relationship */
   organization: Organizations;
-  organizationId: Scalars['Int'];
   /** An object relationship */
   primaryDashboard?: Maybe<Dashboards>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   /** An array relationship */
   question_likes: Array<Question_Likes>;
   /** An aggregated array relationship */
@@ -28296,36 +17669,6 @@ export type UsersApiKeys_AggregateArgs = {
   offset?: Maybe<Scalars['Int']>;
   order_by?: Maybe<Array<Api_Keys_Order_By>>;
   where?: Maybe<Api_Keys_Bool_Exp>;
-};
-
-
-/**
- * Users are Transform end users. They belong to Organizations and Teams within Organizations.
- *
- *
- * columns and relationships of "users"
- */
-export type UsersDashboardsArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
-};
-
-
-/**
- * Users are Transform end users. They belong to Organizations and Teams within Organizations.
- *
- *
- * columns and relationships of "users"
- */
-export type UsersDashboards_AggregateArgs = {
-  distinct_on?: Maybe<Array<User_Dashboards_Select_Column>>;
-  limit?: Maybe<Scalars['Int']>;
-  offset?: Maybe<Scalars['Int']>;
-  order_by?: Maybe<Array<User_Dashboards_Order_By>>;
-  where?: Maybe<User_Dashboards_Bool_Exp>;
 };
 
 
@@ -28832,20 +18175,12 @@ export type Users_Arr_Rel_Insert_Input = {
 /** aggregate avg on columns */
 export type Users_Avg_Fields = {
   __typename?: 'users_avg_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by avg() on columns of table "users" */
 export type Users_Avg_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "users". All fields are combined with a logical 'AND'. */
@@ -28856,12 +18191,8 @@ export type Users_Bool_Exp = {
   annotations?: Maybe<Annotations_Bool_Exp>;
   apiKeys?: Maybe<Api_Keys_Bool_Exp>;
   apiKeysByRevokerId?: Maybe<Api_Keys_Bool_Exp>;
-  auth0Id?: Maybe<String_Comparison_Exp>;
   avatarUrl?: Maybe<String_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  dashboards?: Maybe<User_Dashboards_Bool_Exp>;
-  date_create?: Maybe<Int_Comparison_Exp>;
-  date_deactivate?: Maybe<Int_Comparison_Exp>;
   deactivatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   email?: Maybe<String_Comparison_Exp>;
   features?: Maybe<User_Features_Bool_Exp>;
@@ -28871,9 +18202,7 @@ export type Users_Bool_Exp = {
   metric_views?: Maybe<Metric_View_Bool_Exp>;
   modelsUploaded?: Maybe<Models_Bool_Exp>;
   organization?: Maybe<Organizations_Bool_Exp>;
-  organizationId?: Maybe<Int_Comparison_Exp>;
   primaryDashboard?: Maybe<Dashboards_Bool_Exp>;
-  primaryDashboardId?: Maybe<Int_Comparison_Exp>;
   question_likes?: Maybe<Question_Likes_Bool_Exp>;
   question_replies?: Maybe<Question_Replies_Bool_Exp>;
   questions?: Maybe<Questions_Bool_Exp>;
@@ -28898,36 +18227,13 @@ export enum Users_Constraint {
   UsersPkey = 'users_pkey'
 }
 
-/** input type for incrementing integer column in table "users" */
-export type Users_Inc_Input = {
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
-};
-
 /** input type for inserting data into table "users" */
 export type Users_Insert_Input = {
   annotations?: Maybe<Annotations_Arr_Rel_Insert_Input>;
-  apiKeys?: Maybe<Api_Keys_Arr_Rel_Insert_Input>;
-  apiKeysByRevokerId?: Maybe<Api_Keys_Arr_Rel_Insert_Input>;
-  auth0Id?: Maybe<Scalars['String']>;
-  avatarUrl?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  dashboards?: Maybe<User_Dashboards_Arr_Rel_Insert_Input>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
-  deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
-  features?: Maybe<User_Features_Arr_Rel_Insert_Input>;
-  id?: Maybe<Scalars['Int']>;
   metricCollections?: Maybe<Metric_Collections_Arr_Rel_Insert_Input>;
   metric_approvals?: Maybe<Metric_Approvals_Arr_Rel_Insert_Input>;
   metric_views?: Maybe<Metric_View_Arr_Rel_Insert_Input>;
-  modelsUploaded?: Maybe<Models_Arr_Rel_Insert_Input>;
-  organization?: Maybe<Organizations_Obj_Rel_Insert_Input>;
-  organizationId?: Maybe<Scalars['Int']>;
   primaryDashboard?: Maybe<Dashboards_Obj_Rel_Insert_Input>;
   primaryDashboardId?: Maybe<Scalars['Int']>;
   question_likes?: Maybe<Question_Likes_Arr_Rel_Insert_Input>;
@@ -28938,7 +18244,6 @@ export type Users_Insert_Input = {
   savedQueries?: Maybe<Saved_Queries_Arr_Rel_Insert_Input>;
   team_members?: Maybe<Team_Members_Arr_Rel_Insert_Input>;
   teamsCreated?: Maybe<Teams_Arr_Rel_Insert_Input>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
   userRoles?: Maybe<User_Roles_Arr_Rel_Insert_Input>;
   user_prefs?: Maybe<User_Prefs_Arr_Rel_Insert_Input>;
@@ -28947,32 +18252,22 @@ export type Users_Insert_Input = {
 /** aggregate max on columns */
 export type Users_Max_Fields = {
   __typename?: 'users_max_fields';
-  auth0Id?: Maybe<Scalars['String']>;
   avatarUrl?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
 };
 
 /** order by max() on columns of table "users" */
 export type Users_Max_Order_By = {
-  auth0Id?: Maybe<Order_By>;
   avatarUrl?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userName?: Maybe<Order_By>;
 };
@@ -28980,32 +18275,22 @@ export type Users_Max_Order_By = {
 /** aggregate min on columns */
 export type Users_Min_Fields = {
   __typename?: 'users_min_fields';
-  auth0Id?: Maybe<Scalars['String']>;
   avatarUrl?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
 };
 
 /** order by min() on columns of table "users" */
 export type Users_Min_Order_By = {
-  auth0Id?: Maybe<Order_By>;
   avatarUrl?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   userName?: Maybe<Order_By>;
 };
@@ -29037,12 +18322,8 @@ export type Users_Order_By = {
   annotations_aggregate?: Maybe<Annotations_Aggregate_Order_By>;
   apiKeysByRevokerId_aggregate?: Maybe<Api_Keys_Aggregate_Order_By>;
   apiKeys_aggregate?: Maybe<Api_Keys_Aggregate_Order_By>;
-  auth0Id?: Maybe<Order_By>;
   avatarUrl?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  dashboards_aggregate?: Maybe<User_Dashboards_Aggregate_Order_By>;
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   deactivatedAt?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   features_aggregate?: Maybe<User_Features_Aggregate_Order_By>;
@@ -29052,9 +18333,7 @@ export type Users_Order_By = {
   metric_views_aggregate?: Maybe<Metric_View_Aggregate_Order_By>;
   modelsUploaded_aggregate?: Maybe<Models_Aggregate_Order_By>;
   organization?: Maybe<Organizations_Order_By>;
-  organizationId?: Maybe<Order_By>;
   primaryDashboard?: Maybe<Dashboards_Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
   question_likes_aggregate?: Maybe<Question_Likes_Aggregate_Order_By>;
   question_replies_aggregate?: Maybe<Question_Replies_Aggregate_Order_By>;
   questionsByResolvedBy_aggregate?: Maybe<Questions_Aggregate_Order_By>;
@@ -29077,25 +18356,15 @@ export type Users_Pk_Columns_Input = {
 /** select columns of table "users" */
 export enum Users_Select_Column {
   /** column name */
-  Auth0Id = 'auth0Id',
-  /** column name */
   AvatarUrl = 'avatarUrl',
   /** column name */
   CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDeactivate = 'date_deactivate',
   /** column name */
   DeactivatedAt = 'deactivatedAt',
   /** column name */
   Email = 'email',
   /** column name */
   Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
   /** column name */
   UpdatedAt = 'updatedAt',
   /** column name */
@@ -29104,120 +18373,61 @@ export enum Users_Select_Column {
 
 /** input type for updating data in table "users" */
 export type Users_Set_Input = {
-  auth0Id?: Maybe<Scalars['String']>;
-  avatarUrl?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['timestamptz']>;
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   deactivatedAt?: Maybe<Scalars['timestamptz']>;
   email?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
-  updatedAt?: Maybe<Scalars['timestamptz']>;
   userName?: Maybe<Scalars['String']>;
 };
 
 /** aggregate stddev on columns */
 export type Users_Stddev_Fields = {
   __typename?: 'users_stddev_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev() on columns of table "users" */
 export type Users_Stddev_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_pop on columns */
 export type Users_Stddev_Pop_Fields = {
   __typename?: 'users_stddev_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_pop() on columns of table "users" */
 export type Users_Stddev_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
 export type Users_Stddev_Samp_Fields = {
   __typename?: 'users_stddev_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by stddev_samp() on columns of table "users" */
 export type Users_Stddev_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate sum on columns */
 export type Users_Sum_Fields = {
   __typename?: 'users_sum_fields';
-  date_create?: Maybe<Scalars['Int']>;
-  date_deactivate?: Maybe<Scalars['Int']>;
   id?: Maybe<Scalars['Int']>;
-  organizationId?: Maybe<Scalars['Int']>;
-  primaryDashboardId?: Maybe<Scalars['Int']>;
 };
 
 /** order by sum() on columns of table "users" */
 export type Users_Sum_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** update columns of table "users" */
 export enum Users_Update_Column {
   /** column name */
-  Auth0Id = 'auth0Id',
-  /** column name */
-  AvatarUrl = 'avatarUrl',
-  /** column name */
-  CreatedAt = 'createdAt',
-  /** column name */
-  DateCreate = 'date_create',
-  /** column name */
-  DateDeactivate = 'date_deactivate',
-  /** column name */
   DeactivatedAt = 'deactivatedAt',
   /** column name */
   Email = 'email',
-  /** column name */
-  Id = 'id',
-  /** column name */
-  OrganizationId = 'organizationId',
-  /** column name */
-  PrimaryDashboardId = 'primaryDashboardId',
-  /** column name */
-  UpdatedAt = 'updatedAt',
   /** column name */
   UserName = 'userName'
 }
@@ -29225,58 +18435,34 @@ export enum Users_Update_Column {
 /** aggregate var_pop on columns */
 export type Users_Var_Pop_Fields = {
   __typename?: 'users_var_pop_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_pop() on columns of table "users" */
 export type Users_Var_Pop_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate var_samp on columns */
 export type Users_Var_Samp_Fields = {
   __typename?: 'users_var_samp_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by var_samp() on columns of table "users" */
 export type Users_Var_Samp_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 /** aggregate variance on columns */
 export type Users_Variance_Fields = {
   __typename?: 'users_variance_fields';
-  date_create?: Maybe<Scalars['Float']>;
-  date_deactivate?: Maybe<Scalars['Float']>;
   id?: Maybe<Scalars['Float']>;
-  organizationId?: Maybe<Scalars['Float']>;
-  primaryDashboardId?: Maybe<Scalars['Float']>;
 };
 
 /** order by variance() on columns of table "users" */
 export type Users_Variance_Order_By = {
-  date_create?: Maybe<Order_By>;
-  date_deactivate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
-  organizationId?: Maybe<Order_By>;
-  primaryDashboardId?: Maybe<Order_By>;
 };
 
 
@@ -29284,6 +18470,6 @@ export type MqlServerUrlQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type MqlServerUrlQuery = (
-  { __typename?: 'query_root' }
-  & Pick<Query_Root, 'mqlServerUrl'>
+  { __typename?: 'Query' }
+  & Pick<Query, 'mqlServerUrl'>
 );

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -9,11 +9,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /**
-   * The `DateTime` scalar type represents a DateTime
-   * value as specified by
-   * [iso8601](https://en.wikipedia.org/wiki/ISO_8601).
-   */
+  /** Wrapper around Graphene DateTime that is capable of handling string dates */
   DateTime: any;
 };
 
@@ -338,6 +334,8 @@ export type CreateMqlMaterializationInput = {
   metrics?: Maybe<Array<Scalars['String']>>;
   groupBy?: Maybe<Array<Scalars['String']>>;
   where?: Maybe<ConstraintInput>;
+  /** String-based constraint input field using SQL syntax */
+  constraint?: Maybe<Scalars['String']>;
   cacheMode?: Maybe<CacheMode>;
   clientMutationId?: Maybe<Scalars['String']>;
 };
@@ -395,7 +393,10 @@ export type CreateMqlQueryInput = {
   modelKey?: Maybe<ModelKeyInput>;
   metrics?: Maybe<Array<Scalars['String']>>;
   groupBy?: Maybe<Array<Scalars['String']>>;
+  /** Dict-based constraint input field */
   where?: Maybe<ConstraintInput>;
+  /** String-based constraint input field using SQL syntax */
+  constraint?: Maybe<Scalars['String']>;
   order?: Maybe<Array<Scalars['String']>>;
   limit?: Maybe<Scalars['Int']>;
   /** Set to True if you want to automatically add a default Time Series dimension to the query. This is useful for plotting the metric in time series without needing to know the time dimension up front. */


### PR DESCRIPTION
# Changes
Add ability to optionally pass `retries`.  Defaults to 0.  If retires is more than 0, FetchMQLTimeSeriesQuery will retry `retries` times if the initial query fails or errors.

Add custom error message when the query fails but does not error.

# Security Implications
None.
