### PR TITLE
Jenna only cancel if not running

### DIFF
--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -228,7 +228,7 @@ type UseMqlQueryParams = {
   retries?: number;
 };
 
-// This custom hook consists of one useCallback and two useHooks that should asynchronously handle all scenarios for this chained
+// This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
 // data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
 // user updates their request while a query is in flight
 export default function useMqlQuery({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
Only cancel query if query isn't running.  Fixes the savedQuery not loading on add/update bug.

# Security Implications
None.
