### PR TITLE
Jenna default daily granularity

### DIFF
--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -1,4 +1,5 @@
 import { gql } from "urql";
+import { Granularity } from "./MqlMutationTypes";
 
 const mutation = gql`
   mutation CreateMqlQuery(
@@ -8,7 +9,7 @@ const mutation = gql`
     $where: ConstraintInput
     $addTimeSeries: Boolean
     $pctChange: PercentChange
-    $granularity: Granularity
+    $granularity: Granularity = ${Granularity.Daily}
     $startTime: String
     $endTime: String
   ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
Default granularity to daily.

Will prevent chart queries from failing when the user doesn't select a granularity.

# Security Implications
None
