### PR TITLE
pass query context in error rather than add it to error message

### DIFF
--- a/context/MqlContext/MqlContext.ts
+++ b/context/MqlContext/MqlContext.ts
@@ -8,6 +8,12 @@ import {
 // TODO: Make this configurable when needed
 export const CORE_API_URL = "https://api.transformdata.io/graphql";
 
+export type HandleCombinedErrorContext = {
+  queryId?: string,
+  queryStatus?: string,
+  json?: string
+}
+
 export type MqlContextType = {
   /*
     The Core API URL is used to query Transform's universal backend system, as opposed
@@ -62,7 +68,7 @@ export type MqlContextType = {
   getToken: () => Promise<string>;
   useQuery: typeof useQuery;
   useMutation: typeof useMutation;
-  handleCombinedError: (e: CombinedError) => void;
+  handleCombinedError: (e: CombinedError, context?: HandleCombinedErrorContext) => void;
 };
 
 export const MqlContextInitialState = {
@@ -77,8 +83,8 @@ export const MqlContextInitialState = {
   getToken: () => Promise.resolve(""),
   useQuery,
   useMutation,
-  handleCombinedError: (e: CombinedError) => {
-    throw new Error(e.message);
+  handleCombinedError: (e: CombinedError, context?: HandleCombinedErrorContext) => {
+    throw new Error(context ? `Query Id: ${context.queryId} - Query Status: ${context.queryStatus} - Result: ${context.json} - ${e.message}` : e.message);
   },
 };
 

--- a/context/MqlContext/MqlContextProvider.tsx
+++ b/context/MqlContext/MqlContextProvider.tsx
@@ -9,7 +9,7 @@ import {
   SetMqlServerMutation as SetMqlServerMutationType,
   SetMqlServerMutationVariables,
 } from "../../mutations/core/CoreApiMutationTypes";
-import MqlContext, { MqlContextType, CORE_API_URL } from "./MqlContext";
+import MqlContext, { HandleCombinedErrorContext, MqlContextType, CORE_API_URL } from "./MqlContext";
 import getUserIdFromAuthToken from "./utils/getUserIdFromAuthToken";
 
 type Props = {
@@ -51,13 +51,13 @@ function MqlContextProviderInternal({
 }: Props) {
   // We do this because we want to allow the parent to provide a bespoke error handling function.
   const handleCombinedError = useCallback(
-    (e: CombinedError) => {
+    (e: CombinedError, context?: HandleCombinedErrorContext) => {
       const errFunction = captureException || console.error;
       if (e.message) {
-        errFunction(e.message);
+        errFunction(e.message, context);
       }
       if (e.networkError) {
-        errFunction(e.networkError);
+        errFunction(e.networkError, context);
       }
     },
     [captureException]

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -305,16 +305,6 @@ export default function useMqlQuery({
           limit,
           handleCombinedError,
         });
-        console.log('asdfasdfsadf', data)
-        handleCombinedError({
-          name: "Unknown Error",
-          message: "Test error",
-          graphQLErrors: [],
-        }, {
-          queryId: data?.createMqlQuery?.query?.id as string,
-          queryStatus: data?.createMqlQuery?.query?.status as string,
-          json: "Test json string"
-        });
       } else {
         if (data?.createMqlQuery?.id) {
           dispatch({

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -297,12 +297,23 @@ export default function useMqlQuery({
       startTime: formState.startTime,
       endTime: formState.endTime,
     }).then(({ data, error }) => {
+      console.log('asdfasdfsadf')
       if (data?.createMqlQuery?.query?.status === MqlQueryStatus.Successful) {
         dispatch({
           type: "postQueryCachedResultsSuccess",
           data,
           limit,
           handleCombinedError,
+        });
+        console.log('asdfasdfsadf', data)
+        handleCombinedError({
+          name: "Unknown Error",
+          message: "Test error",
+          graphQLErrors: [],
+        }, {
+          queryId: data?.createMqlQuery?.query?.id as string,
+          queryStatus: data?.createMqlQuery?.query?.status as string,
+          json: "Test json string"
         });
       } else {
         if (data?.createMqlQuery?.id) {
@@ -394,7 +405,7 @@ export default function useMqlQuery({
           jsonString = "Invalid data.mqlQuery.result";
         }
 
-        const errorMessage = `This query failed for an unknown reason.\n\nQueryId: ${data?.mqlQuery?.id}\nStatus: ${data?.mqlQuery?.status}\nResult: ${jsonString}`;
+        const errorMessage = `This query failed for an unknown reason.`;
 
         dispatch({
           type: "fetchResultsFail",
@@ -405,6 +416,10 @@ export default function useMqlQuery({
           name: "Unknown Error",
           message: errorMessage,
           graphQLErrors: [],
+        }, {
+          queryId: data?.mqlQuery?.id as string,
+          queryStatus: data?.mqlQuery?.status as string,
+          json: jsonString
         });
       }
     }

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -297,7 +297,6 @@ export default function useMqlQuery({
       startTime: formState.startTime,
       endTime: formState.endTime,
     }).then(({ data, error }) => {
-      console.log('asdfasdfsadf')
       if (data?.createMqlQuery?.query?.status === MqlQueryStatus.Successful) {
         dispatch({
           type: "postQueryCachedResultsSuccess",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
Pass query details in error context rather than in error message.

# Security Implications
None