### PR TITLE
use new mql query with timeGranularity

### DIFF
--- a/hooks/useNewMqlQuery.ts
+++ b/hooks/useNewMqlQuery.ts
@@ -271,7 +271,6 @@ export default function useNewMqlQuery({
   skip,
   retries = 0,
 }: UseMqlQueryParams) {
-  console.log('new')
   const {
     useQuery,
     useMutation,

--- a/hooks/useNewMqlQuery.ts
+++ b/hooks/useNewMqlQuery.ts
@@ -297,17 +297,6 @@ export default function useNewMqlQuery({
       formState = queryInput;
     }
 
-    console.log('mutation vars', {
-      metrics: [metricName],
-      groupBy: formState.groupBy || [],
-      where: clearEmptyConstraints(formState.where),
-      pctChange: formState.pctChange,
-      timeGranularity: formState?.granularity ? granularityToTimeGranularityMap[formState?.granularity] : TimeGranularity.Day,
-      addTimeSeries: true,
-      startTime: formState.startTime,
-      endTime: formState.endTime,
-    })
-
     dispatch({ type: "postQueryStart" });
     createMqlQuery({
       metrics: [metricName],

--- a/hooks/useNewMqlQuery.ts
+++ b/hooks/useNewMqlQuery.ts
@@ -21,7 +21,7 @@ const granularityToTimeGranularityMap = {
   [Granularity.Daily]: TimeGranularity.Day,
   [Granularity.Weekly]: TimeGranularity.Week,
   [Granularity.Monthly]: TimeGranularity.Month,
-  // [Granularity.Daily]: TimeGranularity.Quarter,
+  // [Granularity.Quaterly]: TimeGranularity.Quarter,
   [Granularity.Yearly]: TimeGranularity.Year,
 }
 

--- a/hooks/useNewMqlQuery.ts
+++ b/hooks/useNewMqlQuery.ts
@@ -2,11 +2,13 @@ import { useEffect, useReducer, useContext } from "react";
 import { CombinedError } from "urql";
 
 import MqlContext from "../context/MqlContext/MqlContext";
-import CreateMqlQuery from "../mutations/mql/CreateMqlQuery";
+import CreateMqlQueryWithTimeGranularity from "../mutations/mql/CreateMqlQueryWithTimeGranularity";
 import {
-  CreateMqlQueryMutation,
-  CreateMqlQueryMutationVariables,
+  CreateMqlQueryWithTimeGranularityMutation,
+  CreateMqlQueryWithTimeGranularityMutationVariables,
   ConstraintInput,
+  TimeGranularity,
+  Granularity
 } from "../mutations/mql/MqlMutationTypes";
 import FetchMqlQueryTimeSeries from "../queries/mql/FetchMqlQueryTimeSeries";
 import {
@@ -14,6 +16,14 @@ import {
   FetchMqlTimeSeriesQueryVariables,
   MqlQueryStatus,
 } from "../queries/mql/MqlQueryTypes";
+
+const granularityToTimeGranularityMap = {
+  [Granularity.Daily]: TimeGranularity.Day,
+  [Granularity.Weekly]: TimeGranularity.Week,
+  [Granularity.Monthly]: TimeGranularity.Month,
+  // [Granularity.Daily]: TimeGranularity.Quarter,
+  [Granularity.Yearly]: TimeGranularity.Year,
+}
 
 // This is the delay between the _response_ from the last query and the _start_ of the new query
 const QUERY_POLLING_MS = 200;
@@ -92,7 +102,7 @@ type Action =
   | { type: "postQueryFail"; errorMessage: string }
   | { type: "postQuerySuccess"; queryId: string }
   | { type: "postQueryCachedResultsSuccess";
-      data: CreateMqlQueryMutation;
+      data: CreateMqlQueryWithTimeGranularityMutation;
       limit?: number;
       handleCombinedError: (e: CombinedError) => void;
     }
@@ -246,7 +256,7 @@ function mqlQueryReducer(
 type UseMqlQueryParams = {
   metricName: string;
   limit?: number;
-  queryInput?: CreateMqlQueryMutationVariables;
+  queryInput?: CreateMqlQueryWithTimeGranularityMutationVariables;
   skip?: boolean;
   retries?: number;
 };
@@ -254,13 +264,14 @@ type UseMqlQueryParams = {
 // This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
 // data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
 // user updates their request while a query is in flight
-export default function useMqlQuery({
+export default function useNewMqlQuery({
   queryInput,
   metricName,
   limit,
   skip,
   retries = 0,
 }: UseMqlQueryParams) {
+  console.log('new')
   const {
     useQuery,
     useMutation,
@@ -273,18 +284,29 @@ export default function useMqlQuery({
   //   state.queryStatus === MqlQueryStatus.Pending;
 
   const [{}, createMqlQuery] = useMutation<
-    CreateMqlQueryMutation,
-    CreateMqlQueryMutationVariables
-  >(CreateMqlQuery);
+    CreateMqlQueryWithTimeGranularityMutation,
+    CreateMqlQueryWithTimeGranularityMutationVariables
+  >(CreateMqlQueryWithTimeGranularity);
 
   useEffect(() => {
     if (!metricName || !mqlServerUrl || skip) {
       return;
     }
-    let formState: CreateMqlQueryMutationVariables = {};
+    let formState: CreateMqlQueryWithTimeGranularityMutationVariables & {granularity?: Granularity} = {};
     if (queryInput) {
       formState = queryInput;
     }
+
+    console.log('mutation vars', {
+      metrics: [metricName],
+      groupBy: formState.groupBy || [],
+      where: clearEmptyConstraints(formState.where),
+      pctChange: formState.pctChange,
+      timeGranularity: formState?.granularity ? granularityToTimeGranularityMap[formState?.granularity] : TimeGranularity.Day,
+      addTimeSeries: true,
+      startTime: formState.startTime,
+      endTime: formState.endTime,
+    })
 
     dispatch({ type: "postQueryStart" });
     createMqlQuery({
@@ -292,7 +314,7 @@ export default function useMqlQuery({
       groupBy: formState.groupBy || [],
       where: clearEmptyConstraints(formState.where),
       pctChange: formState.pctChange,
-      granularity: formState.granularity,
+      timeGranularity: formState?.granularity ? granularityToTimeGranularityMap[formState?.granularity] : TimeGranularity.Day,
       addTimeSeries: true,
       startTime: formState.startTime,
       endTime: formState.endTime,

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -45,7 +45,8 @@ export type Query = {
   __typename?: 'Query';
   auth0Profile?: Maybe<Auth0Profile>;
   mqlServerUrl?: Maybe<Scalars['String']>;
-  latestMqlServer?: Maybe<MqlServerVersion>;
+  latestMqlServer?: Maybe<ServiceRelease>;
+  latestAvaticaServer?: Maybe<ServiceRelease>;
   myOrganization?: Maybe<Organization>;
   myUser?: Maybe<User>;
   allFeatures?: Maybe<Array<Maybe<Feature>>>;
@@ -133,8 +134,9 @@ export type Auth0Profile = {
  *
  * TODO: There's likely a simple way to merge these two objects together
  */
-export type MqlServerVersion = {
-  __typename?: 'MQLServerVersion';
+export type ServiceRelease = {
+  __typename?: 'ServiceRelease';
+  serviceName?: Maybe<Scalars['String']>;
   version?: Maybe<Scalars['String']>;
   downloadUrl?: Maybe<Scalars['String']>;
   versionHash?: Maybe<Scalars['String']>;
@@ -164,13 +166,12 @@ export type Organization = {
   mqlHeartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   currentModel?: Maybe<Array<Maybe<Model>>>;
   teams?: Maybe<Array<Maybe<Team>>>;
+  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   metricViews?: Maybe<Array<Maybe<MetricView>>>;
   savedQueries?: Maybe<Array<Maybe<SavedQuery>>>;
   teamViews?: Maybe<Array<Maybe<TeamView>>>;
-  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
   dashboards?: Maybe<Array<Maybe<Dashboard>>>;
   metricCollections?: Maybe<Array<Maybe<MetricCollection>>>;
-  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   questions?: Maybe<Array<Maybe<Question>>>;
   question?: Maybe<Question>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
@@ -183,6 +184,7 @@ export type Organization = {
   latestMqlHeartbeat?: Maybe<MqlHeartbeat>;
   totalUsers?: Maybe<Scalars['Int']>;
   totalTeams?: Maybe<Scalars['Int']>;
+  mqlServer?: Maybe<OrgMqlServer>;
   totalMqlServers?: Maybe<Scalars['Int']>;
   metric?: Maybe<Metric>;
   team?: Maybe<Team>;
@@ -191,6 +193,8 @@ export type Organization = {
   metricCollection?: Maybe<MetricCollection>;
   totalMetricCollections?: Maybe<Scalars['Int']>;
   totalSavedQueries?: Maybe<Scalars['Int']>;
+  totalActiveFeatures?: Maybe<Scalars['Int']>;
+  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
 
@@ -308,6 +312,11 @@ export type OrganizationMetricsArgs = {
 };
 
 
+export type OrganizationMqlServerArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type OrganizationMetricArgs = {
   name: Scalars['String'];
 };
@@ -353,12 +362,11 @@ export type User = {
   teamMemberships?: Maybe<Array<Maybe<TeamMember>>>;
   dashboards?: Maybe<Array<Maybe<Dashboard>>>;
   primaryDashboard?: Maybe<Dashboard>;
+  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   savedQueries?: Maybe<Array<Maybe<SavedQuery>>>;
   organization?: Maybe<Organization>;
   teamViews?: Maybe<Array<Maybe<TeamView>>>;
-  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
   metricCollections?: Maybe<Array<Maybe<MetricCollection>>>;
-  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   mqlServerUrl?: Maybe<Scalars['String']>;
   activeRoles?: Maybe<Array<Maybe<Scalars['String']>>>;
   isAdmin?: Maybe<Scalars['Boolean']>;
@@ -373,7 +381,9 @@ export type User = {
   totalViewedTeams?: Maybe<Scalars['Int']>;
   viewedMetricCollections?: Maybe<Array<Maybe<MetricCollection>>>;
   totalViewedMetricCollections?: Maybe<Scalars['Int']>;
+  totalActiveFeatures?: Maybe<Scalars['Int']>;
   viewedMetrics?: Maybe<Array<Maybe<Metric>>>;
+  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
 
@@ -384,6 +394,17 @@ export type UserTeamsArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type UserApiKeysArgs = {
+  activeOnly?: Maybe<Scalars['Boolean']>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<ApiKeyStrColumn>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<ApiKeyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
 };
 
@@ -404,17 +425,6 @@ export type UserMetricCollectionsArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
-  desc?: Maybe<Scalars['Boolean']>;
-};
-
-
-export type UserApiKeysArgs = {
-  activeOnly?: Maybe<Scalars['Boolean']>;
-  searchStr?: Maybe<Scalars['String']>;
-  searchColumns?: Maybe<Array<Maybe<ApiKeyStrColumn>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<ApiKeyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
 };
 
@@ -1328,17 +1338,6 @@ export enum MetricCollectionOrderBy {
   Views = 'VIEWS'
 }
 
-export type Feature = {
-  __typename?: 'Feature';
-  id: Scalars['ID'];
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  name: Scalars['String'];
-  retiredAt?: Maybe<Scalars['DateTime']>;
-  users?: Maybe<Array<Maybe<User>>>;
-  organizations?: Maybe<Array<Maybe<Organization>>>;
-};
-
 export type ApiKey = {
   __typename?: 'ApiKey';
   prefix: Scalars['String'];
@@ -1378,6 +1377,71 @@ export enum ApiKeyOrderBy {
   RevokerId = 'REVOKER_ID',
   LastUsedAt = 'LAST_USED_AT',
   Scope = 'SCOPE'
+}
+
+export type Feature = {
+  __typename?: 'Feature';
+  id: Scalars['ID'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  name: Scalars['String'];
+  retiredAt?: Maybe<Scalars['DateTime']>;
+  organizations?: Maybe<Array<Maybe<Organization>>>;
+  users?: Maybe<Array<Maybe<User>>>;
+  totalOrganizations?: Maybe<Scalars['Int']>;
+  totalUsers?: Maybe<Scalars['Int']>;
+};
+
+
+export type FeatureOrganizationsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<OrganizationStrColumn>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<OrganizationOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type FeatureUsersArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<UserStrColumn>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<UserOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+/** An enumeration. */
+export enum OrganizationStrColumn {
+  Name = 'NAME',
+  Domain = 'DOMAIN',
+  LogoUrl = 'LOGO_URL',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  MqlServerUrl = 'MQL_SERVER_URL',
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
+  Slug = 'SLUG'
+}
+
+/** An enumeration. */
+export enum OrganizationOrderBy {
+  Id = 'ID',
+  Name = 'NAME',
+  Domain = 'DOMAIN',
+  CreatedAt = 'CREATED_AT',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  ShardId = 'SHARD_ID',
+  LogoUrl = 'LOGO_URL',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  MqlServerUrl = 'MQL_SERVER_URL',
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
+  UpdatedAt = 'UPDATED_AT',
+  Slug = 'SLUG',
+  IsHosted = 'IS_HOSTED'
 }
 
 export type OrgMqlServer = {
@@ -1461,38 +1525,6 @@ export enum FeatureOrderBy {
   RetiredAt = 'RETIRED_AT'
 }
 
-/** An enumeration. */
-export enum OrganizationStrColumn {
-  Name = 'NAME',
-  Domain = 'DOMAIN',
-  LogoUrl = 'LOGO_URL',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  Slug = 'SLUG'
-}
-
-/** An enumeration. */
-export enum OrganizationOrderBy {
-  Id = 'ID',
-  Name = 'NAME',
-  Domain = 'DOMAIN',
-  CreatedAt = 'CREATED_AT',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  ShardId = 'SHARD_ID',
-  LogoUrl = 'LOGO_URL',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  UpdatedAt = 'UPDATED_AT',
-  Slug = 'SLUG',
-  IsHosted = 'IS_HOSTED'
-}
-
 /**
  * Base mutation object exposed by GraphQL.
  *
@@ -1528,8 +1560,8 @@ export type Mutation = {
   setUserPreference?: Maybe<SetUserPreference>;
   featuresCreate?: Maybe<Feature>;
   featuresUpdate?: Maybe<Feature>;
-  featuresAddOrg?: Maybe<Feature>;
-  featuresAddUser?: Maybe<Feature>;
+  featuresAddOrgs?: Maybe<Feature>;
+  featuresAddUsers?: Maybe<Feature>;
   featuresRemoveAccess?: Maybe<Feature>;
   questionsCreateReply?: Maybe<Question>;
   questionRepliesLike?: Maybe<QuestionReply>;
@@ -1822,9 +1854,9 @@ export type MutationFeaturesUpdateArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
-export type MutationFeaturesAddOrgArgs = {
+export type MutationFeaturesAddOrgsArgs = {
   featureId: Scalars['ID'];
-  organizationId: Scalars['ID'];
+  organizationIds: Array<Maybe<Scalars['ID']>>;
 };
 
 
@@ -1834,9 +1866,9 @@ export type MutationFeaturesAddOrgArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
-export type MutationFeaturesAddUserArgs = {
+export type MutationFeaturesAddUsersArgs = {
   featureId: Scalars['ID'];
-  userId: Scalars['ID'];
+  userIds: Array<Maybe<Scalars['ID']>>;
 };
 
 

--- a/mutations/mql/CreateMqlQueryWithTimeGranularity.ts
+++ b/mutations/mql/CreateMqlQueryWithTimeGranularity.ts
@@ -1,0 +1,49 @@
+import { gql } from "urql";
+
+const mutation = gql`
+  mutation CreateMqlQueryWithTimeGranularity(
+    $modelKey: ModelKeyInput
+    $metrics: [String!]
+    $groupBy: [String!]
+    $where: ConstraintInput
+    $addTimeSeries: Boolean
+    $pctChange: PercentChange
+    $timeGranularity: TimeGranularity = DAY
+    $startTime: String
+    $endTime: String
+  ) {
+    createMqlQuery(
+      input: {
+        modelKey: $modelKey
+        metrics: $metrics
+        groupBy: $groupBy
+        where: $where
+        addTimeSeries: $addTimeSeries
+        pctChange: $pctChange
+        timeGranularity: $timeGranularity
+        startTime: $startTime
+        endTime: $endTime
+        resultFormat: TFD
+      }
+    ) {
+      id
+      query {
+        id
+        status
+        metrics
+        dimensions
+        result {
+          seriesValue
+          data {
+            y
+            ... on TimeSeriesDatum {
+              xDate
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default mutation;

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -67,7 +67,7 @@ export type QueryMqlQueryArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMaterializationsArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
 };
 
 
@@ -77,7 +77,7 @@ export type QueryMaterializationsArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMetricsArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
 };
 
 
@@ -87,7 +87,7 @@ export type QueryMetricsArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMetricByNameArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   name: Scalars['String'];
 };
 
@@ -98,7 +98,7 @@ export type QueryMetricByNameArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMeasuresArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
 };
 
 
@@ -108,7 +108,7 @@ export type QueryMeasuresArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMeasureByNameArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   name: Scalars['String'];
 };
 
@@ -119,7 +119,7 @@ export type QueryMeasureByNameArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryDimensionNamesForMetricsArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -177,6 +177,8 @@ export type MqlQuery = {
   errorTraceback?: Maybe<Scalars['String']>;
   logs?: Maybe<Scalars['String']>;
   logsByLine?: Maybe<Scalars['String']>;
+  chartValueMin?: Maybe<Scalars['Float']>;
+  chartValueMax?: Maybe<Scalars['Float']>;
 };
 
 
@@ -205,7 +207,7 @@ export type MqlQueryLogsByLineArgs = {
   maxLines?: Maybe<Scalars['Int']>;
 };
 
-/** A Model Key is unsed to uniquely identify a model at a specific commit */
+/** API Output definition for a Model Key */
 export type ModelKey = {
   __typename?: 'ModelKey';
   organization: Scalars['String'];
@@ -274,12 +276,12 @@ export type Materialization = {
   destinationTable?: Maybe<Scalars['String']>;
 };
 
-/** Directly mirrors ModelKey in models as an input argument */
-export type ModelKeyArgument = {
-  organization?: Maybe<Scalars['String']>;
-  repo?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
-  commit?: Maybe<Scalars['String']>;
+/** API Input definition for a Model Key */
+export type ModelKeyInput = {
+  organization: Scalars['String'];
+  repo: Scalars['String'];
+  branch: Scalars['String'];
+  commit: Scalars['String'];
 };
 
 export type Metric = {
@@ -292,8 +294,10 @@ export type Metric = {
 
 
 export type MetricDimensionValuesArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   dimensionName?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
 };
 
 export type Measure = {
@@ -404,14 +408,6 @@ export type CreateMqlMaterializationNewInput = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
-/** Directly mirrors ModelKey in models */
-export type ModelKeyInput = {
-  organization?: Maybe<Scalars['String']>;
-  repo?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
-  commit?: Maybe<Scalars['String']>;
-};
-
 export type CreateMqlDropMaterializationPayload = {
   __typename?: 'CreateMqlDropMaterializationPayload';
   id?: Maybe<Scalars['ID']>;
@@ -443,11 +439,11 @@ export type CreateMqlQueryInput = {
   modelKey?: Maybe<ModelKeyInput>;
   metrics?: Maybe<Array<Scalars['String']>>;
   groupBy?: Maybe<Array<Scalars['String']>>;
-  /** String-based constraint input field using SQL syntax */
-  constraint?: Maybe<Scalars['String']>;
   where?: Maybe<ConstraintInput>;
   whereConstraint?: Maybe<Scalars['String']>;
   timeConstraint?: Maybe<Scalars['String']>;
+  /** Optionally, provide a granularity for the primary time dimension in the returned results. */
+  timeGranularity?: Maybe<TimeGranularity>;
   order?: Maybe<Array<Scalars['String']>>;
   /** Integer, '-1', or 'inf' to represent the number of rows of a query to return input field */
   limit?: Maybe<Scalars['LimitInput']>;
@@ -470,7 +466,6 @@ export type CreateMqlQueryInput = {
 /** Container class for inputs to allow for and/or wrappers on the `where` clause */
 export type ConstraintInput = {
   And?: Maybe<Array<SingleConstraintInput>>;
-  Or?: Maybe<Array<SingleConstraintInput>>;
   constraint?: Maybe<SingleConstraintInput>;
 };
 
@@ -487,6 +482,15 @@ export type SingleConstraintInput = {
 export enum AtomicConstraintType {
   Set = 'SET',
   Range = 'RANGE'
+}
+
+/** An enumeration. */
+export enum TimeGranularity {
+  Day = 'DAY',
+  Week = 'WEEK',
+  Month = 'MONTH',
+  Quarter = 'QUARTER',
+  Year = 'YEAR'
 }
 
 
@@ -581,6 +585,39 @@ export type CreateMqlQueryMutationVariables = Exact<{
 
 
 export type CreateMqlQueryMutation = (
+  { __typename?: 'Mutation' }
+  & { createMqlQuery?: Maybe<(
+    { __typename?: 'CreateMqlQueryPayload' }
+    & Pick<CreateMqlQueryPayload, 'id'>
+    & { query?: Maybe<(
+      { __typename?: 'MqlQuery' }
+      & Pick<MqlQuery, 'id' | 'status' | 'metrics' | 'dimensions'>
+      & { result?: Maybe<Array<(
+        { __typename?: 'MqlQueryResultSeries' }
+        & Pick<MqlQueryResultSeries, 'seriesValue'>
+        & { data?: Maybe<Array<(
+          { __typename?: 'TimeSeriesDatum' }
+          & Pick<TimeSeriesDatum, 'xDate' | 'y'>
+        )>> }
+      )>> }
+    )> }
+  )> }
+);
+
+export type CreateMqlQueryWithTimeGranularityMutationVariables = Exact<{
+  modelKey?: Maybe<ModelKeyInput>;
+  metrics?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  groupBy?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  where?: Maybe<ConstraintInput>;
+  addTimeSeries?: Maybe<Scalars['Boolean']>;
+  pctChange?: Maybe<PercentChange>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+}>;
+
+
+export type CreateMqlQueryWithTimeGranularityMutation = (
   { __typename?: 'Mutation' }
   & { createMqlQuery?: Maybe<(
     { __typename?: 'CreateMqlQueryPayload' }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -45,7 +45,8 @@ export type Query = {
   __typename?: 'Query';
   auth0Profile?: Maybe<Auth0Profile>;
   mqlServerUrl?: Maybe<Scalars['String']>;
-  latestMqlServer?: Maybe<MqlServerVersion>;
+  latestMqlServer?: Maybe<ServiceRelease>;
+  latestAvaticaServer?: Maybe<ServiceRelease>;
   myOrganization?: Maybe<Organization>;
   myUser?: Maybe<User>;
   allFeatures?: Maybe<Array<Maybe<Feature>>>;
@@ -133,8 +134,9 @@ export type Auth0Profile = {
  *
  * TODO: There's likely a simple way to merge these two objects together
  */
-export type MqlServerVersion = {
-  __typename?: 'MQLServerVersion';
+export type ServiceRelease = {
+  __typename?: 'ServiceRelease';
+  serviceName?: Maybe<Scalars['String']>;
   version?: Maybe<Scalars['String']>;
   downloadUrl?: Maybe<Scalars['String']>;
   versionHash?: Maybe<Scalars['String']>;
@@ -164,13 +166,12 @@ export type Organization = {
   mqlHeartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   currentModel?: Maybe<Array<Maybe<Model>>>;
   teams?: Maybe<Array<Maybe<Team>>>;
+  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   metricViews?: Maybe<Array<Maybe<MetricView>>>;
   savedQueries?: Maybe<Array<Maybe<SavedQuery>>>;
   teamViews?: Maybe<Array<Maybe<TeamView>>>;
-  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
   dashboards?: Maybe<Array<Maybe<Dashboard>>>;
   metricCollections?: Maybe<Array<Maybe<MetricCollection>>>;
-  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   questions?: Maybe<Array<Maybe<Question>>>;
   question?: Maybe<Question>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
@@ -183,6 +184,7 @@ export type Organization = {
   latestMqlHeartbeat?: Maybe<MqlHeartbeat>;
   totalUsers?: Maybe<Scalars['Int']>;
   totalTeams?: Maybe<Scalars['Int']>;
+  mqlServer?: Maybe<OrgMqlServer>;
   totalMqlServers?: Maybe<Scalars['Int']>;
   metric?: Maybe<Metric>;
   team?: Maybe<Team>;
@@ -191,6 +193,8 @@ export type Organization = {
   metricCollection?: Maybe<MetricCollection>;
   totalMetricCollections?: Maybe<Scalars['Int']>;
   totalSavedQueries?: Maybe<Scalars['Int']>;
+  totalActiveFeatures?: Maybe<Scalars['Int']>;
+  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
 
@@ -308,6 +312,11 @@ export type OrganizationMetricsArgs = {
 };
 
 
+export type OrganizationMqlServerArgs = {
+  id: Scalars['ID'];
+};
+
+
 export type OrganizationMetricArgs = {
   name: Scalars['String'];
 };
@@ -353,12 +362,11 @@ export type User = {
   teamMemberships?: Maybe<Array<Maybe<TeamMember>>>;
   dashboards?: Maybe<Array<Maybe<Dashboard>>>;
   primaryDashboard?: Maybe<Dashboard>;
+  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   savedQueries?: Maybe<Array<Maybe<SavedQuery>>>;
   organization?: Maybe<Organization>;
   teamViews?: Maybe<Array<Maybe<TeamView>>>;
-  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
   metricCollections?: Maybe<Array<Maybe<MetricCollection>>>;
-  apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   mqlServerUrl?: Maybe<Scalars['String']>;
   activeRoles?: Maybe<Array<Maybe<Scalars['String']>>>;
   isAdmin?: Maybe<Scalars['Boolean']>;
@@ -373,7 +381,9 @@ export type User = {
   totalViewedTeams?: Maybe<Scalars['Int']>;
   viewedMetricCollections?: Maybe<Array<Maybe<MetricCollection>>>;
   totalViewedMetricCollections?: Maybe<Scalars['Int']>;
+  totalActiveFeatures?: Maybe<Scalars['Int']>;
   viewedMetrics?: Maybe<Array<Maybe<Metric>>>;
+  activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
 
@@ -384,6 +394,17 @@ export type UserTeamsArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type UserApiKeysArgs = {
+  activeOnly?: Maybe<Scalars['Boolean']>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<ApiKeyStrColumn>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<ApiKeyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
 };
 
@@ -404,17 +425,6 @@ export type UserMetricCollectionsArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
-  desc?: Maybe<Scalars['Boolean']>;
-};
-
-
-export type UserApiKeysArgs = {
-  activeOnly?: Maybe<Scalars['Boolean']>;
-  searchStr?: Maybe<Scalars['String']>;
-  searchColumns?: Maybe<Array<Maybe<ApiKeyStrColumn>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<ApiKeyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
 };
 
@@ -1328,17 +1338,6 @@ export enum MetricCollectionOrderBy {
   Views = 'VIEWS'
 }
 
-export type Feature = {
-  __typename?: 'Feature';
-  id: Scalars['ID'];
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  name: Scalars['String'];
-  retiredAt?: Maybe<Scalars['DateTime']>;
-  users?: Maybe<Array<Maybe<User>>>;
-  organizations?: Maybe<Array<Maybe<Organization>>>;
-};
-
 export type ApiKey = {
   __typename?: 'ApiKey';
   prefix: Scalars['String'];
@@ -1378,6 +1377,71 @@ export enum ApiKeyOrderBy {
   RevokerId = 'REVOKER_ID',
   LastUsedAt = 'LAST_USED_AT',
   Scope = 'SCOPE'
+}
+
+export type Feature = {
+  __typename?: 'Feature';
+  id: Scalars['ID'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  name: Scalars['String'];
+  retiredAt?: Maybe<Scalars['DateTime']>;
+  organizations?: Maybe<Array<Maybe<Organization>>>;
+  users?: Maybe<Array<Maybe<User>>>;
+  totalOrganizations?: Maybe<Scalars['Int']>;
+  totalUsers?: Maybe<Scalars['Int']>;
+};
+
+
+export type FeatureOrganizationsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<OrganizationStrColumn>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<OrganizationOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type FeatureUsersArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<UserStrColumn>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+  orderBy?: Maybe<UserOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+/** An enumeration. */
+export enum OrganizationStrColumn {
+  Name = 'NAME',
+  Domain = 'DOMAIN',
+  LogoUrl = 'LOGO_URL',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  MqlServerUrl = 'MQL_SERVER_URL',
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
+  Slug = 'SLUG'
+}
+
+/** An enumeration. */
+export enum OrganizationOrderBy {
+  Id = 'ID',
+  Name = 'NAME',
+  Domain = 'DOMAIN',
+  CreatedAt = 'CREATED_AT',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  ShardId = 'SHARD_ID',
+  LogoUrl = 'LOGO_URL',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  MqlServerUrl = 'MQL_SERVER_URL',
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
+  UpdatedAt = 'UPDATED_AT',
+  Slug = 'SLUG',
+  IsHosted = 'IS_HOSTED'
 }
 
 export type OrgMqlServer = {
@@ -1461,38 +1525,6 @@ export enum FeatureOrderBy {
   RetiredAt = 'RETIRED_AT'
 }
 
-/** An enumeration. */
-export enum OrganizationStrColumn {
-  Name = 'NAME',
-  Domain = 'DOMAIN',
-  LogoUrl = 'LOGO_URL',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  Slug = 'SLUG'
-}
-
-/** An enumeration. */
-export enum OrganizationOrderBy {
-  Id = 'ID',
-  Name = 'NAME',
-  Domain = 'DOMAIN',
-  CreatedAt = 'CREATED_AT',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  ShardId = 'SHARD_ID',
-  LogoUrl = 'LOGO_URL',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  UpdatedAt = 'UPDATED_AT',
-  Slug = 'SLUG',
-  IsHosted = 'IS_HOSTED'
-}
-
 /**
  * Base mutation object exposed by GraphQL.
  *
@@ -1528,8 +1560,8 @@ export type Mutation = {
   setUserPreference?: Maybe<SetUserPreference>;
   featuresCreate?: Maybe<Feature>;
   featuresUpdate?: Maybe<Feature>;
-  featuresAddOrg?: Maybe<Feature>;
-  featuresAddUser?: Maybe<Feature>;
+  featuresAddOrgs?: Maybe<Feature>;
+  featuresAddUsers?: Maybe<Feature>;
   featuresRemoveAccess?: Maybe<Feature>;
   questionsCreateReply?: Maybe<Question>;
   questionRepliesLike?: Maybe<QuestionReply>;
@@ -1822,9 +1854,9 @@ export type MutationFeaturesUpdateArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
-export type MutationFeaturesAddOrgArgs = {
+export type MutationFeaturesAddOrgsArgs = {
   featureId: Scalars['ID'];
-  organizationId: Scalars['ID'];
+  organizationIds: Array<Maybe<Scalars['ID']>>;
 };
 
 
@@ -1834,9 +1866,9 @@ export type MutationFeaturesAddOrgArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
-export type MutationFeaturesAddUserArgs = {
+export type MutationFeaturesAddUsersArgs = {
   featureId: Scalars['ID'];
-  userId: Scalars['ID'];
+  userIds: Array<Maybe<Scalars['ID']>>;
 };
 
 

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -67,7 +67,7 @@ export type QueryMqlQueryArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMaterializationsArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
 };
 
 
@@ -77,7 +77,7 @@ export type QueryMaterializationsArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMetricsArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
 };
 
 
@@ -87,7 +87,7 @@ export type QueryMetricsArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMetricByNameArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   name: Scalars['String'];
 };
 
@@ -98,7 +98,7 @@ export type QueryMetricByNameArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMeasuresArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
 };
 
 
@@ -108,7 +108,7 @@ export type QueryMeasuresArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryMeasureByNameArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   name: Scalars['String'];
 };
 
@@ -119,7 +119,7 @@ export type QueryMeasureByNameArgs = {
  * Each field defined below is accessible by the API, by calling the equivalent resolver.
  */
 export type QueryDimensionNamesForMetricsArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -177,6 +177,8 @@ export type MqlQuery = {
   errorTraceback?: Maybe<Scalars['String']>;
   logs?: Maybe<Scalars['String']>;
   logsByLine?: Maybe<Scalars['String']>;
+  chartValueMin?: Maybe<Scalars['Float']>;
+  chartValueMax?: Maybe<Scalars['Float']>;
 };
 
 
@@ -205,7 +207,7 @@ export type MqlQueryLogsByLineArgs = {
   maxLines?: Maybe<Scalars['Int']>;
 };
 
-/** A Model Key is unsed to uniquely identify a model at a specific commit */
+/** API Output definition for a Model Key */
 export type ModelKey = {
   __typename?: 'ModelKey';
   organization: Scalars['String'];
@@ -274,12 +276,12 @@ export type Materialization = {
   destinationTable?: Maybe<Scalars['String']>;
 };
 
-/** Directly mirrors ModelKey in models as an input argument */
-export type ModelKeyArgument = {
-  organization?: Maybe<Scalars['String']>;
-  repo?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
-  commit?: Maybe<Scalars['String']>;
+/** API Input definition for a Model Key */
+export type ModelKeyInput = {
+  organization: Scalars['String'];
+  repo: Scalars['String'];
+  branch: Scalars['String'];
+  commit: Scalars['String'];
 };
 
 export type Metric = {
@@ -292,8 +294,10 @@ export type Metric = {
 
 
 export type MetricDimensionValuesArgs = {
-  modelKey?: Maybe<ModelKeyArgument>;
+  modelKey?: Maybe<ModelKeyInput>;
   dimensionName?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
 };
 
 export type Measure = {
@@ -404,14 +408,6 @@ export type CreateMqlMaterializationNewInput = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
-/** Directly mirrors ModelKey in models */
-export type ModelKeyInput = {
-  organization?: Maybe<Scalars['String']>;
-  repo?: Maybe<Scalars['String']>;
-  branch?: Maybe<Scalars['String']>;
-  commit?: Maybe<Scalars['String']>;
-};
-
 export type CreateMqlDropMaterializationPayload = {
   __typename?: 'CreateMqlDropMaterializationPayload';
   id?: Maybe<Scalars['ID']>;
@@ -443,11 +439,11 @@ export type CreateMqlQueryInput = {
   modelKey?: Maybe<ModelKeyInput>;
   metrics?: Maybe<Array<Scalars['String']>>;
   groupBy?: Maybe<Array<Scalars['String']>>;
-  /** String-based constraint input field using SQL syntax */
-  constraint?: Maybe<Scalars['String']>;
   where?: Maybe<ConstraintInput>;
   whereConstraint?: Maybe<Scalars['String']>;
   timeConstraint?: Maybe<Scalars['String']>;
+  /** Optionally, provide a granularity for the primary time dimension in the returned results. */
+  timeGranularity?: Maybe<TimeGranularity>;
   order?: Maybe<Array<Scalars['String']>>;
   /** Integer, '-1', or 'inf' to represent the number of rows of a query to return input field */
   limit?: Maybe<Scalars['LimitInput']>;
@@ -470,7 +466,6 @@ export type CreateMqlQueryInput = {
 /** Container class for inputs to allow for and/or wrappers on the `where` clause */
 export type ConstraintInput = {
   And?: Maybe<Array<SingleConstraintInput>>;
-  Or?: Maybe<Array<SingleConstraintInput>>;
   constraint?: Maybe<SingleConstraintInput>;
 };
 
@@ -487,6 +482,15 @@ export type SingleConstraintInput = {
 export enum AtomicConstraintType {
   Set = 'SET',
   Range = 'RANGE'
+}
+
+/** An enumeration. */
+export enum TimeGranularity {
+  Day = 'DAY',
+  Week = 'WEEK',
+  Month = 'MONTH',
+  Quarter = 'QUARTER',
+  Year = 'YEAR'
 }
 
 

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -6,7 +6,8 @@ Each field defined below is accessible by the API, by calling the equivalent res
 type Query {
   auth0Profile(auth0Id: String!): Auth0Profile
   mqlServerUrl: String
-  latestMqlServer: MQLServerVersion
+  latestMqlServer: ServiceRelease
+  latestAvaticaServer: ServiceRelease
   myOrganization: Organization
   myUser: User
   allFeatures(searchStr: String, searchColumns: [FeatureStrColumn], pageNumber: Int, pageSize: Int, orderBy: FeatureOrderBy, desc: Boolean): [Feature]
@@ -39,7 +40,8 @@ This is the externally-facing Graphene object representing the available MQL ser
 
 TODO: There's likely a simple way to merge these two objects together
 """
-type MQLServerVersion {
+type ServiceRelease {
+  serviceName: String
   version: String
   downloadUrl: String
   versionHash: String
@@ -68,13 +70,12 @@ type Organization {
   mqlHeartbeats: [MqlHeartbeat]
   currentModel: [Model]
   teams(searchStr: String, searchColumns: [TeamStrColumn], pageNumber: Int, pageSize: Int, orderBy: TeamOrderBy, desc: Boolean): [Team]
+  apiKeys: [ApiKey]
   metricViews: [MetricView]
   savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumn], pageNumber: Int, pageSize: Int, orderBy: SavedQueryOrderBy, desc: Boolean): [SavedQuery]
   teamViews: [TeamView]
-  activeFeatures: [Feature]
   dashboards: [Dashboard]
   metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumn], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
-  apiKeys: [ApiKey]
   questions(searchStr: String, searchColumns: [QuestionStrColumn], pageNumber: Int, pageSize: Int, orderBy: QuestionOrderBy, desc: Boolean): [Question]
   question(id: ID!): Question
   annotations(searchStr: String, searchColumns: [AnnotationStrColumn], pageNumber: Int, pageSize: Int, orderBy: AnnotationOrderBy, desc: Boolean): [Annotation]
@@ -87,6 +88,7 @@ type Organization {
   latestMqlHeartbeat: MqlHeartbeat
   totalUsers: Int
   totalTeams: Int
+  mqlServer(id: ID!): OrgMqlServer
   totalMqlServers: Int
   metric(name: String!): Metric
   team(slug: String!): Team
@@ -95,6 +97,8 @@ type Organization {
   metricCollection(slug: String!): MetricCollection
   totalMetricCollections: Int
   totalSavedQueries: Int
+  totalActiveFeatures: Int
+  activeFeatures: [Feature]
 }
 
 type User {
@@ -117,12 +121,11 @@ type User {
   teamMemberships: [TeamMember]
   dashboards: [Dashboard]
   primaryDashboard: Dashboard
+  apiKeys(activeOnly: Boolean, searchStr: String, searchColumns: [ApiKeyStrColumn], pageNumber: Int, pageSize: Int, orderBy: ApiKeyOrderBy, desc: Boolean): [ApiKey]
   savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumn], pageNumber: Int, pageSize: Int, orderBy: SavedQueryOrderBy, desc: Boolean): [SavedQuery]
   organization: Organization
   teamViews: [TeamView]
-  activeFeatures: [Feature]
   metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumn], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
-  apiKeys(activeOnly: Boolean, searchStr: String, searchColumns: [ApiKeyStrColumn], pageNumber: Int, pageSize: Int, orderBy: ApiKeyOrderBy, desc: Boolean): [ApiKey]
   mqlServerUrl: String
   activeRoles: [String]
   isAdmin: Boolean
@@ -137,7 +140,9 @@ type User {
   totalViewedTeams: Int
   viewedMetricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumn], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
   totalViewedMetricCollections: Int
+  totalActiveFeatures: Int
   viewedMetrics(searchStr: String, searchColumns: [MetricVersionStrColumn], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
+  activeFeatures: [Feature]
 }
 
 type UserRole {
@@ -860,16 +865,6 @@ enum MetricCollectionOrderBy {
   VIEWS
 }
 
-type Feature {
-  id: ID!
-  createdAt: DateTime
-  updatedAt: DateTime
-  name: String!
-  retiredAt: DateTime
-  users: [User]
-  organizations: [Organization]
-}
-
 type ApiKey {
   prefix: String!
   organizationId: Int!
@@ -908,6 +903,50 @@ enum ApiKeyOrderBy {
   REVOKER_ID
   LAST_USED_AT
   SCOPE
+}
+
+type Feature {
+  id: ID!
+  createdAt: DateTime
+  updatedAt: DateTime
+  name: String!
+  retiredAt: DateTime
+  organizations(searchStr: String, searchColumns: [OrganizationStrColumn], pageNumber: Int, pageSize: Int, orderBy: OrganizationOrderBy, desc: Boolean): [Organization]
+  users(searchStr: String, searchColumns: [UserStrColumn], pageNumber: Int, pageSize: Int, orderBy: UserOrderBy, desc: Boolean): [User]
+  totalOrganizations: Int
+  totalUsers: Int
+}
+
+"""An enumeration."""
+enum OrganizationStrColumn {
+  NAME
+  DOMAIN
+  LOGO_URL
+  PRIMARY_CONFIG_REPO
+  PRIMARY_CONFIG_BRANCH
+  MQL_SERVER_URL
+  SOURCE_CONTROL_URL
+  MQL_SERVER_LOGS
+  SLUG
+}
+
+"""An enumeration."""
+enum OrganizationOrderBy {
+  ID
+  NAME
+  DOMAIN
+  CREATED_AT
+  DEACTIVATED_AT
+  SHARD_ID
+  LOGO_URL
+  PRIMARY_CONFIG_REPO
+  PRIMARY_CONFIG_BRANCH
+  MQL_SERVER_URL
+  SOURCE_CONTROL_URL
+  MQL_SERVER_LOGS
+  UPDATED_AT
+  SLUG
+  IS_HOSTED
 }
 
 type OrgMqlServer {
@@ -989,38 +1028,6 @@ enum FeatureOrderBy {
   RETIRED_AT
 }
 
-"""An enumeration."""
-enum OrganizationStrColumn {
-  NAME
-  DOMAIN
-  LOGO_URL
-  PRIMARY_CONFIG_REPO
-  PRIMARY_CONFIG_BRANCH
-  MQL_SERVER_URL
-  SOURCE_CONTROL_URL
-  MQL_SERVER_LOGS
-  SLUG
-}
-
-"""An enumeration."""
-enum OrganizationOrderBy {
-  ID
-  NAME
-  DOMAIN
-  CREATED_AT
-  DEACTIVATED_AT
-  SHARD_ID
-  LOGO_URL
-  PRIMARY_CONFIG_REPO
-  PRIMARY_CONFIG_BRANCH
-  MQL_SERVER_URL
-  SOURCE_CONTROL_URL
-  MQL_SERVER_LOGS
-  UPDATED_AT
-  SLUG
-  IS_HOSTED
-}
-
 """
 Base mutation object exposed by GraphQL.
 
@@ -1069,8 +1076,8 @@ type Mutation {
   setUserPreference(prefKey: String!, prefValue: String!, userId: ID): SetUserPreference
   featuresCreate(name: String!): Feature
   featuresUpdate(id: ID!, name: String, retireFeature: Boolean): Feature
-  featuresAddOrg(featureId: ID!, organizationId: ID!): Feature
-  featuresAddUser(featureId: ID!, userId: ID!): Feature
+  featuresAddOrgs(featureId: ID!, organizationIds: [ID]!): Feature
+  featuresAddUsers(featureId: ID!, userIds: [ID]!): Feature
   featuresRemoveAccess(featureId: ID!, userIds: [ID], organizationIds: [ID]): Feature
   questionsCreateReply(questionId: ID!, text: String!): Question
   questionRepliesLike(id: ID!): QuestionReply

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -6,12 +6,12 @@ Each field defined below is accessible by the API, by calling the equivalent res
 type Query {
   version: String
   mqlQuery(id: ID!): MqlQuery
-  materializations(modelKey: ModelKeyArgument): [Materialization!]
-  metrics(modelKey: ModelKeyArgument): [Metric!]
-  metricByName(modelKey: ModelKeyArgument, name: String!): Metric
-  measures(modelKey: ModelKeyArgument): [Measure!]
-  measureByName(modelKey: ModelKeyArgument, name: String!): Measure
-  dimensionNamesForMetrics(modelKey: ModelKeyArgument, metricNames: [String]): [String]
+  materializations(modelKey: ModelKeyInput): [Materialization!]
+  metrics(modelKey: ModelKeyInput): [Metric!]
+  metricByName(modelKey: ModelKeyInput, name: String!): Metric
+  measures(modelKey: ModelKeyInput): [Measure!]
+  measureByName(modelKey: ModelKeyInput, name: String!): Measure
+  dimensionNamesForMetrics(modelKey: ModelKeyInput, metricNames: [String]): [String]
   queries(activeOnly: Boolean, status: MqlQueryStatus, metricNames: [String], dateRangeStart: Date, dateRangeEnd: Date, minExecutionSeconds: Float, maxExecutionSeconds: Float, userIds: [Int], limit: Int, offset: Int): [MqlQuery]
   healthReport: [MqlServerHealthItem]
 }
@@ -63,9 +63,11 @@ type MqlQuery {
   errorTraceback: String
   logs: String
   logsByLine(fromLine: Int, maxLines: Int): String
+  chartValueMin: Float
+  chartValueMax: Float
 }
 
-"""A Model Key is unsed to uniquely identify a model at a specific commit"""
+"""API Output definition for a Model Key"""
 type ModelKey {
   organization: String!
   repo: String!
@@ -147,19 +149,19 @@ type Materialization {
   destinationTable: String
 }
 
-"""Directly mirrors ModelKey in models as an input argument"""
-input ModelKeyArgument {
-  organization: String
-  repo: String
-  branch: String
-  commit: String
+"""API Input definition for a Model Key"""
+input ModelKeyInput {
+  organization: String!
+  repo: String!
+  branch: String!
+  commit: String!
 }
 
 type Metric {
   name: String!
   measures: [String!]
   dimensions: [String!]
-  dimensionValues(modelKey: ModelKeyArgument, dimensionName: String): [String!]
+  dimensionValues(modelKey: ModelKeyInput, dimensionName: String, startTime: String, endTime: String): [String!]
 }
 
 type Measure {
@@ -225,14 +227,6 @@ input CreateMqlMaterializationNewInput {
   clientMutationId: String
 }
 
-"""Directly mirrors ModelKey in models"""
-input ModelKeyInput {
-  organization: String
-  repo: String
-  branch: String
-  commit: String
-}
-
 type CreateMqlDropMaterializationPayload {
   id: ID
   clientMutationId: String
@@ -262,12 +256,14 @@ input CreateMqlQueryInput {
   modelKey: ModelKeyInput
   metrics: [String!]
   groupBy: [String!]
-
-  """String-based constraint input field using SQL syntax"""
-  constraint: String
   where: ConstraintInput
   whereConstraint: String
   timeConstraint: String
+
+  """
+  Optionally, provide a granularity for the primary time dimension in the returned results.
+  """
+  timeGranularity: TimeGranularity
   order: [String!]
 
   """
@@ -305,7 +301,6 @@ Container class for inputs to allow for and/or wrappers on the `where` clause
 """
 input ConstraintInput {
   And: [SingleConstraintInput!]
-  Or: [SingleConstraintInput!]
   constraint: SingleConstraintInput
 }
 
@@ -322,6 +317,15 @@ input SingleConstraintInput {
 enum AtomicConstraintType {
   SET
   RANGE
+}
+
+"""An enumeration."""
+enum TimeGranularity {
+  DAY
+  WEEK
+  MONTH
+  QUARTER
+  YEAR
 }
 
 """


### PR DESCRIPTION
# Changes
Adds new and temporary useNewMqlQuery hook.  Allows us to pass timeGranularity instead of granularity.

# Security Implications
None