### PR TITLE
Jenna only update state if change

### DIFF
--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -182,12 +182,17 @@ function mqlQueryReducer(
       const now = Date.now();
       const diff = now - (state.fetchStartTime || 0);
 
-      return {
-        ...state,
-        queryStatus: MqlQueryStatus.Running,
-        isTakingForever: diff >= LONG_FETCH_QUERY_ATTEMPT_MAX,
-        errorMessage: undefined,
-      };
+      if (state.queryStatus !== MqlQueryStatus.Running && state.isTakingForever !== diff >= LONG_FETCH_QUERY_ATTEMPT_MAX && state.errorMessage !== undefined) {
+        return {
+          ...state,
+          queryStatus: MqlQueryStatus.Running,
+          isTakingForever: diff >= LONG_FETCH_QUERY_ATTEMPT_MAX,
+          errorMessage: undefined,
+        }
+      }
+      else {
+        return state;
+      }
     }
 
     case "retryFetchResults": {

--- a/hooks/useNewMqlQuery.ts
+++ b/hooks/useNewMqlQuery.ts
@@ -192,12 +192,17 @@ function mqlQueryReducer(
       const now = Date.now();
       const diff = now - (state.fetchStartTime || 0);
 
-      return {
-        ...state,
-        queryStatus: MqlQueryStatus.Running,
-        isTakingForever: diff >= LONG_FETCH_QUERY_ATTEMPT_MAX,
-        errorMessage: undefined,
-      };
+      if (state.queryStatus !== MqlQueryStatus.Running && state.isTakingForever !== diff >= LONG_FETCH_QUERY_ATTEMPT_MAX && state.errorMessage !== undefined) {
+        return {
+          ...state,
+          queryStatus: MqlQueryStatus.Running,
+          isTakingForever: diff >= LONG_FETCH_QUERY_ATTEMPT_MAX,
+          errorMessage: undefined,
+        }
+      }
+      else {
+        return state;
+      }
     }
 
     case "retryFetchResults": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
* Check for changes during `retryFetchResults` before setting state, to prevent the UI from running a render cycle.

# Security Implications
* None.