### PR TITLE
[mql mutation]update mql sever graphql schema for `updateMqlServerConfig`

### DIFF
--- a/context/MqlContext/MqlContext.ts
+++ b/context/MqlContext/MqlContext.ts
@@ -1,10 +1,7 @@
 import { Client, useQuery, useMutation, CombinedError } from "urql";
 import { createContext } from "react";
 import buildMqlUrqlClient from "../../utils/builMqlUrqlClient";
-import {
-  SetMqlServerMutation,
-  SetMqlServerMutationVariables,
-} from "../../mutations/core/CoreApiMutationTypes";
+
 // TODO: Make this configurable when needed
 export const CORE_API_URL = "https://api.transformdata.io/graphql";
 

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -96,7 +96,6 @@ type Action =
   | { type: "postQuerySuccess"; queryId: string }
   | { type: "postQueryCachedResultsSuccess";
       data: CreateMqlQueryMutation;
-      limit?: number;
       handleCombinedError: (e: CombinedError) => void;
     }
   | { type: "fetchResultsFail"; errorMessage: string }
@@ -105,7 +104,6 @@ type Action =
   | {
       type: "fetchResultsSuccess";
       data: FetchMqlTimeSeriesQuery;
-      limit?: number;
       handleCombinedError: (e: CombinedError) => void;
     };
 
@@ -254,7 +252,6 @@ function mqlQueryReducer(
 */
 type UseMqlQueryParams = {
   metricName: string;
-  limit?: number;
   queryInput?: CreateMqlQueryMutationVariables;
   skip?: boolean;
   retries?: number;
@@ -266,7 +263,6 @@ type UseMqlQueryParams = {
 export default function useMqlQuery({
   queryInput,
   metricName,
-  limit,
   skip,
   retries = 5,
 }: UseMqlQueryParams) {
@@ -309,13 +305,13 @@ export default function useMqlQuery({
         startTime: formState.startTime,
         endTime: formState.endTime,
         order: formState.order,
-        limit: formState.limit
+        limit: formState.limit,
+        daysLimit: formState.daysLimit
       }).then(({ data, error }) => {
         if (data?.createMqlQuery?.query?.status === MqlQueryStatus.Successful) {
           dispatch({
             type: "postQueryCachedResultsSuccess",
             data,
-            limit,
             handleCombinedError,
           });
         } else {
@@ -399,7 +395,6 @@ export default function useMqlQuery({
       dispatch({
         type: "fetchResultsSuccess",
         data,
-        limit,
         handleCombinedError,
       });
     }
@@ -464,7 +459,7 @@ export default function useMqlQuery({
 
       }
     }
-  }, [data, error, state.cancelledQueries, limit, handleCombinedError]);
+  }, [data, error, state.cancelledQueries, handleCombinedError]);
 
   return state;
 }

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -164,7 +164,6 @@ export type Organization = {
   logoUrl?: Maybe<Scalars['String']>;
   primaryConfigRepo: Scalars['String'];
   primaryConfigBranch: Scalars['String'];
-  mqlServerUrl?: Maybe<Scalars['String']>;
   sourceControlUrl?: Maybe<Scalars['String']>;
   mqlServerLogs?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
@@ -207,6 +206,7 @@ export type Organization = {
   totalActiveFeatures?: Maybe<Scalars['Int']>;
   requireMfa?: Maybe<Scalars['Boolean']>;
   allowMfaRememberBrowser?: Maybe<Scalars['Boolean']>;
+  mqlServerUrl?: Maybe<Scalars['String']>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -322,6 +322,15 @@ export type OrganizationMetricsArgs = {
   pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type OrganizationTotalMetricsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumn>>>;
+  names?: Maybe<Array<Maybe<Scalars['String']>>>;
+  tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  types?: Maybe<Array<Maybe<MetricType>>>;
 };
 
 
@@ -480,8 +489,6 @@ export type UserRole = {
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
   removedAt?: Maybe<Scalars['DateTime']>;
-  dateAdded?: Maybe<Scalars['Int']>;
-  dateRemoved?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   user?: Maybe<User>;
 };
@@ -495,7 +502,6 @@ export type UserPref = {
   prefValue: Scalars['String'];
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  dateCreate?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   user?: Maybe<User>;
 };
@@ -514,8 +520,6 @@ export type Team = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   deactivatedAt?: Maybe<Scalars['DateTime']>;
   description?: Maybe<Scalars['String']>;
-  createdTs?: Maybe<Scalars['Int']>;
-  deactivatedTs?: Maybe<Scalars['Int']>;
   createdByUser?: Maybe<User>;
   organization?: Maybe<Organization>;
   members?: Maybe<Array<Maybe<TeamMember>>>;
@@ -542,7 +546,7 @@ export type Team = {
 export type TeamMembersArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<TeamMemberUserOrderBy>;
+  orderBy?: Maybe<UserUserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
 };
 
@@ -584,21 +588,19 @@ export type TeamMember = {
   userId: Scalars['Int'];
   isTeamAdmin: Scalars['Boolean'];
   joinedAt?: Maybe<Scalars['DateTime']>;
-  joinedTs?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   team?: Maybe<Team>;
   user?: Maybe<User>;
 };
 
 /** An enumeration. */
-export enum TeamMemberUserOrderBy {
+export enum UserUserOrderBy {
   TeamMemberId = 'TeamMember_ID',
   TeamMemberTeamId = 'TeamMember_TEAM_ID',
   TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
   TeamMemberUserId = 'TeamMember_USER_ID',
   TeamMemberIsTeamAdmin = 'TeamMember_IS_TEAM_ADMIN',
   TeamMemberJoinedAt = 'TeamMember_JOINED_AT',
-  TeamMemberJoinedTs = 'TeamMember_JOINED_TS',
   UserId = 'User_ID',
   UserOrganizationId = 'User_ORGANIZATION_ID',
   UserAuth0Id = 'User_AUTH0_ID',
@@ -732,7 +734,7 @@ export type MetricUserOwner = {
   __typename?: 'MetricUserOwner';
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
-  orgMetricId?: Maybe<Scalars['Int']>;
+  orgMetricId: Scalars['Int'];
   userId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   user?: Maybe<User>;
@@ -743,10 +745,9 @@ export type MetricTeamOwner = {
   __typename?: 'MetricTeamOwner';
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
-  metricName?: Maybe<Scalars['String']>;
   teamId: Scalars['Int'];
   createdTs?: Maybe<Scalars['Int']>;
-  orgMetricId?: Maybe<Scalars['Int']>;
+  orgMetricId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   team?: Maybe<Team>;
   organization?: Maybe<Organization>;
@@ -760,7 +761,7 @@ export type Metric = {
   description: Scalars['String'];
   tier: Scalars['Int'];
   metricType: Scalars['Int'];
-  metricId?: Maybe<Scalars['Int']>;
+  metricId: Scalars['Int'];
   params?: Maybe<Scalars['GenericScalar']>;
   createdAt: Scalars['DateTime'];
   hash: Scalars['String'];
@@ -934,8 +935,6 @@ export type MetricView = {
   userId: Scalars['ID'];
   metricId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
-  metricName?: Maybe<Scalars['String']>;
-  viewedTs?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
 };
 
@@ -952,10 +951,7 @@ export type Question = {
   notifiedAt?: Maybe<Scalars['DateTime']>;
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  metricId?: Maybe<Scalars['Int']>;
-  resolvedTs?: Maybe<Scalars['Int']>;
-  createdTs?: Maybe<Scalars['Int']>;
-  metricName: Scalars['String'];
+  metricId: Scalars['Int'];
   organization?: Maybe<Organization>;
   replies?: Maybe<Array<Maybe<QuestionReply>>>;
   orgMetric?: Maybe<OrgMetric>;
@@ -967,6 +963,7 @@ export type Question = {
   likedByCurrentUser?: Maybe<Scalars['Boolean']>;
   totalReplies?: Maybe<Scalars['Int']>;
   currentUserIsAuthor?: Maybe<Scalars['Boolean']>;
+  metricName?: Maybe<Scalars['String']>;
   metric?: Maybe<Metric>;
 };
 
@@ -989,7 +986,6 @@ export type QuestionReply = {
   text: Scalars['String'];
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  createdTs?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   author?: Maybe<User>;
   question?: Maybe<Question>;
@@ -1010,15 +1006,13 @@ export enum QuestionReplyOrderBy {
   AuthorId = 'AUTHOR_ID',
   Text = 'TEXT',
   CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT',
-  CreatedTs = 'CREATED_TS'
+  UpdatedAt = 'UPDATED_AT'
 }
 
 /** An enumeration. */
 export enum QuestionStrColumn {
   Text = 'TEXT',
-  Priority = 'PRIORITY',
-  MetricName = 'METRIC_NAME'
+  Priority = 'PRIORITY'
 }
 
 /** An enumeration. */
@@ -1034,10 +1028,7 @@ export enum QuestionOrderBy {
   NotifiedAt = 'NOTIFIED_AT',
   CreatedAt = 'CREATED_AT',
   UpdatedAt = 'UPDATED_AT',
-  MetricId = 'METRIC_ID',
-  ResolvedTs = 'RESOLVED_TS',
-  CreatedTs = 'CREATED_TS',
-  MetricName = 'METRIC_NAME'
+  MetricId = 'METRIC_ID'
 }
 
 export type MetricApproval = {
@@ -1046,9 +1037,7 @@ export type MetricApproval = {
   organizationId: Scalars['Int'];
   approverId: Scalars['Int'];
   approvedAt?: Maybe<Scalars['DateTime']>;
-  metricId?: Maybe<Scalars['Int']>;
-  approvalTs?: Maybe<Scalars['Int']>;
-  metricName?: Maybe<Scalars['String']>;
+  metricId: Scalars['Int'];
   approver?: Maybe<User>;
   organization?: Maybe<Organization>;
 };
@@ -1068,9 +1057,6 @@ export type Annotation = {
   deletedAt?: Maybe<Scalars['DateTime']>;
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  dateStart?: Maybe<Scalars['String']>;
-  dateEnd?: Maybe<Scalars['String']>;
-  timestampCreated?: Maybe<Scalars['Int']>;
   orgMetrics?: Maybe<Array<Maybe<OrgMetric>>>;
   author?: Maybe<User>;
   organization?: Maybe<Organization>;
@@ -1084,12 +1070,9 @@ export type MetricAnnotation = {
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
   annotationId: Scalars['Int'];
-  metricId?: Maybe<Scalars['Int']>;
+  metricId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  metricName?: Maybe<Scalars['String']>;
-  dimensionName?: Maybe<Scalars['String']>;
-  dimensionValue?: Maybe<Scalars['String']>;
   organization?: Maybe<Organization>;
   annotation?: Maybe<Annotation>;
   orgMetric?: Maybe<OrgMetric>;
@@ -1125,9 +1108,7 @@ export enum AnnotationStrColumn {
   Title = 'TITLE',
   Text = 'TEXT',
   ExpectedImpact = 'EXPECTED_IMPACT',
-  Priority = 'PRIORITY',
-  DateStart = 'DATE_START',
-  DateEnd = 'DATE_END'
+  Priority = 'PRIORITY'
 }
 
 /** An enumeration. */
@@ -1144,10 +1125,7 @@ export enum AnnotationOrderBy {
   NotifiedAt = 'NOTIFIED_AT',
   DeletedAt = 'DELETED_AT',
   CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT',
-  DateStart = 'DATE_START',
-  DateEnd = 'DATE_END',
-  TimestampCreated = 'TIMESTAMP_CREATED'
+  UpdatedAt = 'UPDATED_AT'
 }
 
 /** An enumeration. */
@@ -1274,8 +1252,6 @@ export enum TeamOrderBy {
   UpdatedAt = 'UPDATED_AT',
   DeactivatedAt = 'DEACTIVATED_AT',
   Description = 'DESCRIPTION',
-  CreatedTs = 'CREATED_TS',
-  DeactivatedTs = 'DEACTIVATED_TS',
   Views = 'VIEWS'
 }
 
@@ -1357,7 +1333,6 @@ export type ApiKey = {
   userId: Scalars['Int'];
   type: Scalars['String'];
   secretHash: Scalars['String'];
-  dateRevoked?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['DateTime']>;
   revokedAt?: Maybe<Scalars['DateTime']>;
   revokerId?: Maybe<Scalars['Int']>;
@@ -1383,7 +1358,6 @@ export enum ApiKeyOrderBy {
   UserId = 'USER_ID',
   Type = 'TYPE',
   SecretHash = 'SECRET_HASH',
-  DateRevoked = 'DATE_REVOKED',
   CreatedAt = 'CREATED_AT',
   RevokedAt = 'REVOKED_AT',
   RevokerId = 'REVOKER_ID',
@@ -1431,7 +1405,6 @@ export enum OrganizationStrColumn {
   LogoUrl = 'LOGO_URL',
   PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
   PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
   MqlServerLogs = 'MQL_SERVER_LOGS',
   Slug = 'SLUG'
@@ -1448,7 +1421,6 @@ export enum OrganizationOrderBy {
   LogoUrl = 'LOGO_URL',
   PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
   PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
   MqlServerLogs = 'MQL_SERVER_LOGS',
   UpdatedAt = 'UPDATED_AT',

--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -14,6 +14,7 @@ const mutation = gql`
     $endTime: String
     $limit: LimitInput
     $order: [String!]
+    $daysLimit: Int
   ) {
     createMqlQuery(
       input: {
@@ -30,6 +31,7 @@ const mutation = gql`
         resultFormat: TFD
         limit: $limit
         order: $order
+        daysLimit: $daysLimit
       }
     ) {
       id

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -500,6 +500,7 @@ export type MutationDropCacheArgs = {
 /** Base mutation object exposed by GraphQL. */
 export type MutationUpdateMqlServerConfigArgs = {
   dwPassword?: Maybe<Scalars['String']>;
+  modeCreds?: Maybe<Scalars['String']>;
   mqlServerId?: Maybe<Scalars['Int']>;
   tfdApiKey?: Maybe<Scalars['String']>;
 };
@@ -671,6 +672,8 @@ export type MqlServerConfig = {
   tfdApiKey?: Maybe<Scalars['String']>;
   /** Password used to access the Data Warehouse. _Note:_ Stored securely using AWS Secrets Manager. */
   dwPassword?: Maybe<Scalars['String']>;
+  /** Mode bridge connection config. _Note:_ Stored securely using AWS Secrets Manager. */
+  modeCreds?: Maybe<Scalars['String']>;
 };
 
 /** Removes hosted MQL Server config using AWS Secrets Manager. */

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -586,6 +586,8 @@ export type CreateMqlQueryInput = {
   endTime?: Maybe<Scalars['String']>;
   /** If granularity is applied, trim start/end periods with incomplete date ranges or data. */
   trimIncompletePeriods?: Maybe<Scalars['Boolean']>;
+  /** Limit time dimension to a specific number of days, whether or not those days have data. */
+  daysLimit?: Maybe<Scalars['Int']>;
   clientMutationId?: Maybe<Scalars['String']>;
 };
 

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -710,6 +710,7 @@ export type CreateMqlQueryMutationVariables = Exact<{
   endTime?: Maybe<Scalars['String']>;
   limit?: Maybe<Scalars['LimitInput']>;
   order?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  daysLimit?: Maybe<Scalars['Int']>;
 }>;
 
 

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -735,7 +735,8 @@ export type CreateMqlQueryMutation = (
 
 export type UpdateMqlServerConfigMutationVariables = Exact<{
   mqlServerId: Scalars['Int'];
-  dwPassword: Scalars['String'];
+  dwPassword?: Maybe<Scalars['String']>;
+  modeCreds?: Maybe<Scalars['String']>;
   tfdApiKey: Scalars['String'];
 }>;
 

--- a/mutations/mql/UpdateMqlServerConfig.ts
+++ b/mutations/mql/UpdateMqlServerConfig.ts
@@ -3,13 +3,15 @@ import { gql } from "urql";
 const mutation = gql`
   mutation UpdateMqlServerConfig(
     $mqlServerId: Int!
-    $dwPassword: String!
+    $dwPassword: String
+    $modeCreds: String
     $tfdApiKey: String!
   ) {
     updateMqlServerConfig(
       mqlServerId: $mqlServerId
       dwPassword: $dwPassword
       tfdApiKey: $tfdApiKey
+      modeCreds: $modeCreds
     ) {
       config {
         mqlServerId

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.7.1",
+  "version": "1.8.1",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -164,7 +164,6 @@ export type Organization = {
   logoUrl?: Maybe<Scalars['String']>;
   primaryConfigRepo: Scalars['String'];
   primaryConfigBranch: Scalars['String'];
-  mqlServerUrl?: Maybe<Scalars['String']>;
   sourceControlUrl?: Maybe<Scalars['String']>;
   mqlServerLogs?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
@@ -207,6 +206,7 @@ export type Organization = {
   totalActiveFeatures?: Maybe<Scalars['Int']>;
   requireMfa?: Maybe<Scalars['Boolean']>;
   allowMfaRememberBrowser?: Maybe<Scalars['Boolean']>;
+  mqlServerUrl?: Maybe<Scalars['String']>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -322,6 +322,15 @@ export type OrganizationMetricsArgs = {
   pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type OrganizationTotalMetricsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumn>>>;
+  names?: Maybe<Array<Maybe<Scalars['String']>>>;
+  tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  types?: Maybe<Array<Maybe<MetricType>>>;
 };
 
 
@@ -480,8 +489,6 @@ export type UserRole = {
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
   removedAt?: Maybe<Scalars['DateTime']>;
-  dateAdded?: Maybe<Scalars['Int']>;
-  dateRemoved?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   user?: Maybe<User>;
 };
@@ -495,7 +502,6 @@ export type UserPref = {
   prefValue: Scalars['String'];
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  dateCreate?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   user?: Maybe<User>;
 };
@@ -514,8 +520,6 @@ export type Team = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   deactivatedAt?: Maybe<Scalars['DateTime']>;
   description?: Maybe<Scalars['String']>;
-  createdTs?: Maybe<Scalars['Int']>;
-  deactivatedTs?: Maybe<Scalars['Int']>;
   createdByUser?: Maybe<User>;
   organization?: Maybe<Organization>;
   members?: Maybe<Array<Maybe<TeamMember>>>;
@@ -542,7 +546,7 @@ export type Team = {
 export type TeamMembersArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<TeamMemberUserOrderBy>;
+  orderBy?: Maybe<UserUserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
 };
 
@@ -584,21 +588,19 @@ export type TeamMember = {
   userId: Scalars['Int'];
   isTeamAdmin: Scalars['Boolean'];
   joinedAt?: Maybe<Scalars['DateTime']>;
-  joinedTs?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   team?: Maybe<Team>;
   user?: Maybe<User>;
 };
 
 /** An enumeration. */
-export enum TeamMemberUserOrderBy {
+export enum UserUserOrderBy {
   TeamMemberId = 'TeamMember_ID',
   TeamMemberTeamId = 'TeamMember_TEAM_ID',
   TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
   TeamMemberUserId = 'TeamMember_USER_ID',
   TeamMemberIsTeamAdmin = 'TeamMember_IS_TEAM_ADMIN',
   TeamMemberJoinedAt = 'TeamMember_JOINED_AT',
-  TeamMemberJoinedTs = 'TeamMember_JOINED_TS',
   UserId = 'User_ID',
   UserOrganizationId = 'User_ORGANIZATION_ID',
   UserAuth0Id = 'User_AUTH0_ID',
@@ -732,7 +734,7 @@ export type MetricUserOwner = {
   __typename?: 'MetricUserOwner';
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
-  orgMetricId?: Maybe<Scalars['Int']>;
+  orgMetricId: Scalars['Int'];
   userId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   user?: Maybe<User>;
@@ -743,10 +745,9 @@ export type MetricTeamOwner = {
   __typename?: 'MetricTeamOwner';
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
-  metricName?: Maybe<Scalars['String']>;
   teamId: Scalars['Int'];
   createdTs?: Maybe<Scalars['Int']>;
-  orgMetricId?: Maybe<Scalars['Int']>;
+  orgMetricId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   team?: Maybe<Team>;
   organization?: Maybe<Organization>;
@@ -760,7 +761,7 @@ export type Metric = {
   description: Scalars['String'];
   tier: Scalars['Int'];
   metricType: Scalars['Int'];
-  metricId?: Maybe<Scalars['Int']>;
+  metricId: Scalars['Int'];
   params?: Maybe<Scalars['GenericScalar']>;
   createdAt: Scalars['DateTime'];
   hash: Scalars['String'];
@@ -934,8 +935,6 @@ export type MetricView = {
   userId: Scalars['ID'];
   metricId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
-  metricName?: Maybe<Scalars['String']>;
-  viewedTs?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
 };
 
@@ -952,10 +951,7 @@ export type Question = {
   notifiedAt?: Maybe<Scalars['DateTime']>;
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  metricId?: Maybe<Scalars['Int']>;
-  resolvedTs?: Maybe<Scalars['Int']>;
-  createdTs?: Maybe<Scalars['Int']>;
-  metricName: Scalars['String'];
+  metricId: Scalars['Int'];
   organization?: Maybe<Organization>;
   replies?: Maybe<Array<Maybe<QuestionReply>>>;
   orgMetric?: Maybe<OrgMetric>;
@@ -967,6 +963,7 @@ export type Question = {
   likedByCurrentUser?: Maybe<Scalars['Boolean']>;
   totalReplies?: Maybe<Scalars['Int']>;
   currentUserIsAuthor?: Maybe<Scalars['Boolean']>;
+  metricName?: Maybe<Scalars['String']>;
   metric?: Maybe<Metric>;
 };
 
@@ -989,7 +986,6 @@ export type QuestionReply = {
   text: Scalars['String'];
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  createdTs?: Maybe<Scalars['Int']>;
   organization?: Maybe<Organization>;
   author?: Maybe<User>;
   question?: Maybe<Question>;
@@ -1010,15 +1006,13 @@ export enum QuestionReplyOrderBy {
   AuthorId = 'AUTHOR_ID',
   Text = 'TEXT',
   CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT',
-  CreatedTs = 'CREATED_TS'
+  UpdatedAt = 'UPDATED_AT'
 }
 
 /** An enumeration. */
 export enum QuestionStrColumn {
   Text = 'TEXT',
-  Priority = 'PRIORITY',
-  MetricName = 'METRIC_NAME'
+  Priority = 'PRIORITY'
 }
 
 /** An enumeration. */
@@ -1034,10 +1028,7 @@ export enum QuestionOrderBy {
   NotifiedAt = 'NOTIFIED_AT',
   CreatedAt = 'CREATED_AT',
   UpdatedAt = 'UPDATED_AT',
-  MetricId = 'METRIC_ID',
-  ResolvedTs = 'RESOLVED_TS',
-  CreatedTs = 'CREATED_TS',
-  MetricName = 'METRIC_NAME'
+  MetricId = 'METRIC_ID'
 }
 
 export type MetricApproval = {
@@ -1046,9 +1037,7 @@ export type MetricApproval = {
   organizationId: Scalars['Int'];
   approverId: Scalars['Int'];
   approvedAt?: Maybe<Scalars['DateTime']>;
-  metricId?: Maybe<Scalars['Int']>;
-  approvalTs?: Maybe<Scalars['Int']>;
-  metricName?: Maybe<Scalars['String']>;
+  metricId: Scalars['Int'];
   approver?: Maybe<User>;
   organization?: Maybe<Organization>;
 };
@@ -1068,9 +1057,6 @@ export type Annotation = {
   deletedAt?: Maybe<Scalars['DateTime']>;
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  dateStart?: Maybe<Scalars['String']>;
-  dateEnd?: Maybe<Scalars['String']>;
-  timestampCreated?: Maybe<Scalars['Int']>;
   orgMetrics?: Maybe<Array<Maybe<OrgMetric>>>;
   author?: Maybe<User>;
   organization?: Maybe<Organization>;
@@ -1084,12 +1070,9 @@ export type MetricAnnotation = {
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
   annotationId: Scalars['Int'];
-  metricId?: Maybe<Scalars['Int']>;
+  metricId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   updatedAt?: Maybe<Scalars['DateTime']>;
-  metricName?: Maybe<Scalars['String']>;
-  dimensionName?: Maybe<Scalars['String']>;
-  dimensionValue?: Maybe<Scalars['String']>;
   organization?: Maybe<Organization>;
   annotation?: Maybe<Annotation>;
   orgMetric?: Maybe<OrgMetric>;
@@ -1125,9 +1108,7 @@ export enum AnnotationStrColumn {
   Title = 'TITLE',
   Text = 'TEXT',
   ExpectedImpact = 'EXPECTED_IMPACT',
-  Priority = 'PRIORITY',
-  DateStart = 'DATE_START',
-  DateEnd = 'DATE_END'
+  Priority = 'PRIORITY'
 }
 
 /** An enumeration. */
@@ -1144,10 +1125,7 @@ export enum AnnotationOrderBy {
   NotifiedAt = 'NOTIFIED_AT',
   DeletedAt = 'DELETED_AT',
   CreatedAt = 'CREATED_AT',
-  UpdatedAt = 'UPDATED_AT',
-  DateStart = 'DATE_START',
-  DateEnd = 'DATE_END',
-  TimestampCreated = 'TIMESTAMP_CREATED'
+  UpdatedAt = 'UPDATED_AT'
 }
 
 /** An enumeration. */
@@ -1274,8 +1252,6 @@ export enum TeamOrderBy {
   UpdatedAt = 'UPDATED_AT',
   DeactivatedAt = 'DEACTIVATED_AT',
   Description = 'DESCRIPTION',
-  CreatedTs = 'CREATED_TS',
-  DeactivatedTs = 'DEACTIVATED_TS',
   Views = 'VIEWS'
 }
 
@@ -1357,7 +1333,6 @@ export type ApiKey = {
   userId: Scalars['Int'];
   type: Scalars['String'];
   secretHash: Scalars['String'];
-  dateRevoked?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['DateTime']>;
   revokedAt?: Maybe<Scalars['DateTime']>;
   revokerId?: Maybe<Scalars['Int']>;
@@ -1383,7 +1358,6 @@ export enum ApiKeyOrderBy {
   UserId = 'USER_ID',
   Type = 'TYPE',
   SecretHash = 'SECRET_HASH',
-  DateRevoked = 'DATE_REVOKED',
   CreatedAt = 'CREATED_AT',
   RevokedAt = 'REVOKED_AT',
   RevokerId = 'REVOKER_ID',
@@ -1431,7 +1405,6 @@ export enum OrganizationStrColumn {
   LogoUrl = 'LOGO_URL',
   PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
   PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
   MqlServerLogs = 'MQL_SERVER_LOGS',
   Slug = 'SLUG'
@@ -1448,7 +1421,6 @@ export enum OrganizationOrderBy {
   LogoUrl = 'LOGO_URL',
   PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
   PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  MqlServerUrl = 'MQL_SERVER_URL',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
   MqlServerLogs = 'MQL_SERVER_LOGS',
   UpdatedAt = 'UPDATED_AT',

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -500,6 +500,7 @@ export type MutationDropCacheArgs = {
 /** Base mutation object exposed by GraphQL. */
 export type MutationUpdateMqlServerConfigArgs = {
   dwPassword?: Maybe<Scalars['String']>;
+  modeCreds?: Maybe<Scalars['String']>;
   mqlServerId?: Maybe<Scalars['Int']>;
   tfdApiKey?: Maybe<Scalars['String']>;
 };
@@ -671,6 +672,8 @@ export type MqlServerConfig = {
   tfdApiKey?: Maybe<Scalars['String']>;
   /** Password used to access the Data Warehouse. _Note:_ Stored securely using AWS Secrets Manager. */
   dwPassword?: Maybe<Scalars['String']>;
+  /** Mode bridge connection config. _Note:_ Stored securely using AWS Secrets Manager. */
+  modeCreds?: Maybe<Scalars['String']>;
 };
 
 /** Removes hosted MQL Server config using AWS Secrets Manager. */

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -586,6 +586,8 @@ export type CreateMqlQueryInput = {
   endTime?: Maybe<Scalars['String']>;
   /** If granularity is applied, trim start/end periods with incomplete date ranges or data. */
   trimIncompletePeriods?: Maybe<Scalars['Boolean']>;
+  /** Limit time dimension to a specific number of days, whether or not those days have data. */
+  daysLimit?: Maybe<Scalars['Int']>;
   clientMutationId?: Maybe<Scalars['String']>;
 };
 

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -58,7 +58,6 @@ type Organization {
   logoUrl: String
   primaryConfigRepo: String!
   primaryConfigBranch: String!
-  mqlServerUrl: String
   sourceControlUrl: String
   mqlServerLogs: String
   updatedAt: DateTime
@@ -85,7 +84,7 @@ type Organization {
   totalQuestions: Int
   totalAnnotations: Int
   metrics(names: [String], tiers: [MetricTier], types: [MetricType], searchStr: String, searchColumns: [MetricVersionStrColumn], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
-  totalMetrics: Int
+  totalMetrics(searchStr: String, searchColumns: [MetricVersionStrColumn], names: [String], tiers: [MetricTier], types: [MetricType]): Int
   latestMqlHeartbeat: MqlHeartbeat
   totalUsers: Int
   totalTeams: Int
@@ -101,6 +100,7 @@ type Organization {
   totalActiveFeatures: Int
   requireMfa: Boolean
   allowMfaRememberBrowser: Boolean
+  mqlServerUrl: String
   activeFeatures: [Feature]
 }
 
@@ -156,8 +156,6 @@ type UserRole {
   createdAt: DateTime
   updatedAt: DateTime
   removedAt: DateTime
-  dateAdded: Int
-  dateRemoved: Int
   organization: Organization
   user: User
 }
@@ -170,7 +168,6 @@ type UserPref {
   prefValue: String!
   createdAt: DateTime
   updatedAt: DateTime
-  dateCreate: Int
   organization: Organization
   user: User
 }
@@ -188,11 +185,9 @@ type Team {
   updatedAt: DateTime
   deactivatedAt: DateTime
   description: String
-  createdTs: Int
-  deactivatedTs: Int
   createdByUser: User
   organization: Organization
-  members(pageNumber: Int, pageSize: Int, orderBy: TeamMemberUserOrderBy, desc: Boolean): [TeamMember]
+  members(pageNumber: Int, pageSize: Int, orderBy: UserUserOrderBy, desc: Boolean): [TeamMember]
   adminMembers: [TeamMember]
   memberUsers: [User]
   dashboards: [Dashboard]
@@ -219,21 +214,19 @@ type TeamMember {
   userId: Int!
   isTeamAdmin: Boolean!
   joinedAt: DateTime
-  joinedTs: Int
   organization: Organization
   team: Team
   user: User
 }
 
 """An enumeration."""
-enum TeamMemberUserOrderBy {
+enum UserUserOrderBy {
   TeamMember_ID
   TeamMember_TEAM_ID
   TeamMember_ORGANIZATION_ID
   TeamMember_USER_ID
   TeamMember_IS_TEAM_ADMIN
   TeamMember_JOINED_AT
-  TeamMember_JOINED_TS
   User_ID
   User_ORGANIZATION_ID
   User_AUTH0_ID
@@ -351,7 +344,7 @@ type OrgMetric {
 type MetricUserOwner {
   id: ID!
   organizationId: Int!
-  orgMetricId: Int
+  orgMetricId: Int!
   userId: Int!
   createdAt: DateTime
   user: User
@@ -361,10 +354,9 @@ type MetricUserOwner {
 type MetricTeamOwner {
   id: ID!
   organizationId: Int!
-  metricName: String
   teamId: Int!
   createdTs: Int
-  orgMetricId: Int
+  orgMetricId: Int!
   createdAt: DateTime
   team: Team
   organization: Organization
@@ -377,7 +369,7 @@ type Metric {
   description: String!
   tier: Int!
   metricType: Int!
-  metricId: Int
+  metricId: Int!
   params: GenericScalar
   createdAt: DateTime!
   hash: String!
@@ -495,8 +487,6 @@ type MetricView {
   userId: ID!
   metricId: ID!
   createdAt: DateTime!
-  metricName: String
-  viewedTs: Int
   organization: Organization
 }
 
@@ -512,10 +502,7 @@ type Question {
   notifiedAt: DateTime
   createdAt: DateTime
   updatedAt: DateTime
-  metricId: Int
-  resolvedTs: Int
-  createdTs: Int
-  metricName: String!
+  metricId: Int!
   organization: Organization
   replies(searchStr: String, searchColumns: [QuestionReplyStrColumn], pageNumber: Int, pageSize: Int, orderBy: QuestionReplyOrderBy, desc: Boolean): [QuestionReply]
   orgMetric: OrgMetric
@@ -527,6 +514,7 @@ type Question {
   likedByCurrentUser: Boolean
   totalReplies: Int
   currentUserIsAuthor: Boolean
+  metricName: String
   metric: Metric
 }
 
@@ -538,7 +526,6 @@ type QuestionReply {
   text: String!
   createdAt: DateTime
   updatedAt: DateTime
-  createdTs: Int
   organization: Organization
   author: User
   question: Question
@@ -560,14 +547,12 @@ enum QuestionReplyOrderBy {
   TEXT
   CREATED_AT
   UPDATED_AT
-  CREATED_TS
 }
 
 """An enumeration."""
 enum QuestionStrColumn {
   TEXT
   PRIORITY
-  METRIC_NAME
 }
 
 """An enumeration."""
@@ -584,9 +569,6 @@ enum QuestionOrderBy {
   CREATED_AT
   UPDATED_AT
   METRIC_ID
-  RESOLVED_TS
-  CREATED_TS
-  METRIC_NAME
 }
 
 type MetricApproval {
@@ -594,9 +576,7 @@ type MetricApproval {
   organizationId: Int!
   approverId: Int!
   approvedAt: DateTime
-  metricId: Int
-  approvalTs: Int
-  metricName: String
+  metricId: Int!
   approver: User
   organization: Organization
 }
@@ -615,9 +595,6 @@ type Annotation {
   deletedAt: DateTime
   createdAt: DateTime
   updatedAt: DateTime
-  dateStart: String
-  dateEnd: String
-  timestampCreated: Int
   orgMetrics: [OrgMetric]
   author: User
   organization: Organization
@@ -630,12 +607,9 @@ type MetricAnnotation {
   id: ID!
   organizationId: Int!
   annotationId: Int!
-  metricId: Int
+  metricId: Int!
   createdAt: DateTime
   updatedAt: DateTime
-  metricName: String
-  dimensionName: String
-  dimensionValue: String
   organization: Organization
   annotation: Annotation
   orgMetric: OrgMetric
@@ -677,8 +651,6 @@ enum AnnotationStrColumn {
   TEXT
   EXPECTED_IMPACT
   PRIORITY
-  DATE_START
-  DATE_END
 }
 
 """An enumeration."""
@@ -696,9 +668,6 @@ enum AnnotationOrderBy {
   DELETED_AT
   CREATED_AT
   UPDATED_AT
-  DATE_START
-  DATE_END
-  TIMESTAMP_CREATED
 }
 
 """An enumeration."""
@@ -814,8 +783,6 @@ enum TeamOrderBy {
   UPDATED_AT
   DEACTIVATED_AT
   DESCRIPTION
-  CREATED_TS
-  DEACTIVATED_TS
   VIEWS
 }
 
@@ -895,7 +862,6 @@ type ApiKey {
   userId: Int!
   type: String!
   secretHash: String!
-  dateRevoked: Int
   createdAt: DateTime
   revokedAt: DateTime
   revokerId: Int
@@ -921,7 +887,6 @@ enum ApiKeyOrderBy {
   USER_ID
   TYPE
   SECRET_HASH
-  DATE_REVOKED
   CREATED_AT
   REVOKED_AT
   REVOKER_ID
@@ -948,7 +913,6 @@ enum OrganizationStrColumn {
   LOGO_URL
   PRIMARY_CONFIG_REPO
   PRIMARY_CONFIG_BRANCH
-  MQL_SERVER_URL
   SOURCE_CONTROL_URL
   MQL_SERVER_LOGS
   SLUG
@@ -965,7 +929,6 @@ enum OrganizationOrderBy {
   LOGO_URL
   PRIMARY_CONFIG_REPO
   PRIMARY_CONFIG_BRANCH
-  MQL_SERVER_URL
   SOURCE_CONTROL_URL
   MQL_SERVER_LOGS
   UPDATED_AT

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -262,7 +262,7 @@ type Mutation {
   dropCache(confirm: String): DropCache
 
   """Stores hosted MQL Server config using AWS Secrets Manager."""
-  updateMqlServerConfig(dwPassword: String, mqlServerId: Int, tfdApiKey: String): UpdateMqlServerConfig
+  updateMqlServerConfig(dwPassword: String, modeCreds: String, mqlServerId: Int, tfdApiKey: String): UpdateMqlServerConfig
 
   """Removes hosted MQL Server config using AWS Secrets Manager."""
   revokeMqlServerConfig(mqlServerId: Int): RevokeMqlServerConfig
@@ -457,6 +457,11 @@ type MqlServerConfig {
   Password used to access the Data Warehouse. _Note:_ Stored securely using AWS Secrets Manager.
   """
   dwPassword: String
+
+  """
+  Mode bridge connection config. _Note:_ Stored securely using AWS Secrets Manager.
+  """
+  modeCreds: String
 }
 
 """Removes hosted MQL Server config using AWS Secrets Manager."""

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -358,6 +358,11 @@ input CreateMqlQueryInput {
   If granularity is applied, trim start/end periods with incomplete date ranges or data.
   """
   trimIncompletePeriods: Boolean
+
+  """
+  Limit time dimension to a specific number of days, whether or not those days have data.
+  """
+  daysLimit: Int
   clientMutationId: String
 }
 


### PR DESCRIPTION
# Changes
This is to update the mql schema per change in the PR https://github.com/transform-data/hedgehog/pull/1298 and it also bump update the core backend schema to the lasted version.

# Security Implications
No

<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
