### PR TITLE
remove granularity param, always use timeGranularity

### DIFF
--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -300,7 +300,6 @@ export default function useMqlQuery({
         where: clearEmptyConstraints(formState.where),
         pctChange: formState.pctChange,
         timeGranularity: formState.timeGranularity,
-        granularity: formState.granularity,
         addTimeSeries: true,
         startTime: formState.startTime,
         endTime: formState.endTime,

--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -9,7 +9,6 @@ const mutation = gql`
     $addTimeSeries: Boolean
     $pctChange: PercentChange
     $timeGranularity: TimeGranularity
-    $granularity: Granularity # todo: remove granularity once Opendoor MQL server is updated beyond 642d0663e3a243dcabcd4dfe738a3d29a9b98394
     $startTime: String
     $endTime: String
     $limit: LimitInput
@@ -25,7 +24,6 @@ const mutation = gql`
         addTimeSeries: $addTimeSeries
         pctChange: $pctChange
         timeGranularity: $timeGranularity
-        granularity: $granularity
         startTime: $startTime
         endTime: $endTime
         resultFormat: TFD

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -718,7 +718,6 @@ export type CreateMqlQueryMutationVariables = Exact<{
   addTimeSeries?: Maybe<Scalars['Boolean']>;
   pctChange?: Maybe<PercentChange>;
   timeGranularity?: Maybe<TimeGranularity>;
-  granularity?: Maybe<Granularity>;
   startTime?: Maybe<Scalars['String']>;
   endTime?: Maybe<Scalars['String']>;
   limit?: Maybe<Scalars['LimitInput']>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
* Remove granularity param from createMqlQuery, always use timeGranularity.

# Security Implications
* None
