### PR TITLE
Jenna retry when expired query

### DIFF
--- a/hooks/actions/doRetryAfterExpiredQuery.ts
+++ b/hooks/actions/doRetryAfterExpiredQuery.ts
@@ -1,0 +1,17 @@
+interface ShouldRetryAfterExpiredQueryArgs {
+  errorMessage: string;
+  doRetryAfterExpiredQuery: boolean;
+}
+
+export const shouldRetryAfterExpiredQuery = ({errorMessage, doRetryAfterExpiredQuery}: ShouldRetryAfterExpiredQueryArgs) => {
+  return (
+    errorMessage?.toLowerCase()?.indexOf('unknown query id') > -1
+        && errorMessage?.toLowerCase()?.indexOf('it may have expired') > -1
+        && !doRetryAfterExpiredQuery
+  )
+};
+
+export const doRetryAfterExpiredQueryAction = (retries: number) => ({
+  type: 'fetchResultsExpiredQuery' as 'fetchResultsExpiredQuery',
+  payload: {retries}
+})

--- a/hooks/actions/index.ts
+++ b/hooks/actions/index.ts
@@ -1,0 +1,1 @@
+export {shouldRetryAfterExpiredQuery, doRetryAfterExpiredQueryAction} from './doRetryAfterExpiredQuery'

--- a/hooks/useMqlQuery.ts
+++ b/hooks/useMqlQuery.ts
@@ -227,7 +227,6 @@ function mqlQueryReducer(
         queryId: null,
         queryStatus: initialState.queryStatus,
         data: null,
-        // retries: action.payload.retries,
         errorMessage: undefined,
         doRetryAfterExpiredQuery: true,
       }

--- a/hooks/utils/clearEmptyConstraints.ts
+++ b/hooks/utils/clearEmptyConstraints.ts
@@ -1,0 +1,22 @@
+import {
+  ConstraintInput,
+} from "../../mutations/mql/MqlMutationTypes";
+
+const EMPTY_CONSTRAINT: ConstraintInput = { constraint: null };
+
+// This filters out invalid WHERE clauses the consequence of janky form state;
+const clearEmptyConstraints = (where?: ConstraintInput | null | undefined) => {
+  if (!where) return EMPTY_CONSTRAINT;
+  if (where.And) {
+    const newAnd = where.And.filter((val) => (val.values || []).length > 0);
+    return newAnd.length > 0 ? { ...where, And: newAnd } : EMPTY_CONSTRAINT;
+  }
+  // if (where.Or) {
+  //   const newOr = where.Or.filter((val) => (val.values || []).length > 0);
+  //   return newOr.length > 0 ? { ...where, Or: newOr } : EMPTY_CONSTRAINT;
+  // }
+
+  return where;
+}
+
+export default clearEmptyConstraints;

--- a/hooks/utils/getErrorMessage.ts
+++ b/hooks/utils/getErrorMessage.ts
@@ -1,0 +1,10 @@
+import { CombinedError } from "urql";
+
+const getErrorMessage = (e: CombinedError) => {
+  if (e.message) return e.message;
+  if (e.networkError) return e.networkError.message;
+  if (e.graphQLErrors) return e.graphQLErrors[0].message;
+  return "Invalid MQL Query error message";
+}
+
+export default getErrorMessage;

--- a/hooks/utils/useCreateMqlQuery.ts
+++ b/hooks/utils/useCreateMqlQuery.ts
@@ -1,0 +1,95 @@
+import { useContext, Dispatch } from 'react';
+import MqlContext from "../../context/MqlContext/MqlContext";
+import CreateMqlQuery from "../../mutations/mql/CreateMqlQuery";
+import {
+  CreateMqlQueryMutation,
+  CreateMqlQueryMutationVariables,
+} from "../../mutations/mql/MqlMutationTypes";
+import clearEmptyConstraints from './clearEmptyConstraints';
+import { Action as UseMqlQueryAction, UseMqlQueryState, RETRY_POLLING_MS } from '../useMqlQuery'
+import getErrorMessage from './getErrorMessage';
+import {
+  MqlQueryStatus,
+} from "../../queries/mql/MqlQueryTypes";
+
+interface DoCreateMqlQueryArgs {
+  stateRetries: number
+}
+
+interface UseCreateMqlQueryArgs {
+  state: UseMqlQueryState;
+  retries: number; // the number of retries passed as an arg from the client.
+  metricName: string;
+  formState?: CreateMqlQueryMutationVariables;
+  dispatch: Dispatch<UseMqlQueryAction>;
+}
+
+interface UseCreateMqlQuery {
+  createMqlQuery: (args: DoCreateMqlQueryArgs) => void;
+}
+
+const useCreateMqlQuery = ({metricName, formState = {}, dispatch, state, retries}: UseCreateMqlQueryArgs): UseCreateMqlQuery => {
+  const {
+    useMutation,
+    handleCombinedError,
+  } = useContext(MqlContext);
+
+  const [{}, createMqlQueryMutation] = useMutation<
+    CreateMqlQueryMutation,
+    CreateMqlQueryMutationVariables
+  >(CreateMqlQuery);
+
+  const createMqlQuery = ({stateRetries}:DoCreateMqlQueryArgs) => {
+    createMqlQueryMutation({
+      metrics: [metricName],
+      groupBy: formState.groupBy || [],
+      where: clearEmptyConstraints(formState.where),
+      pctChange: formState.pctChange,
+      timeGranularity: formState.timeGranularity,
+      granularity: formState.granularity,
+      addTimeSeries: true,
+      startTime: formState.startTime,
+      endTime: formState.endTime,
+      order: formState.order,
+      limit: formState.limit,
+      daysLimit: formState.daysLimit
+    }).then(({ data, error }) => {
+      if (data?.createMqlQuery?.query?.status === MqlQueryStatus.Successful) {
+        dispatch({
+          type: "postQueryCachedResultsSuccess",
+          data,
+          handleCombinedError,
+        });
+      } else {
+        if (data?.createMqlQuery?.id) {
+          dispatch({
+            type: "postQuerySuccess",
+            queryId: data?.createMqlQuery?.id,
+          });
+        } else if (error) {
+          if (retries > 0 && stateRetries !== retries && stateRetries < retries) {
+            setTimeout(() => {
+              dispatch({ type: "retryFetchResults" });
+              createMqlQuery({stateRetries: state.retries + 1});
+            }, RETRY_POLLING_MS)
+          } else {
+            dispatch({
+              type: "postQueryFail",
+              errorMessage: getErrorMessage(error),
+            });
+          }
+          handleCombinedError(error);
+        }
+      }
+
+    });
+  };
+
+  return {
+    createMqlQuery
+  }
+}
+
+
+
+export default useCreateMqlQuery;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
* Restart the entire query when FetchMqlTimeSeries fails due to an expired queryId.

This PR aims to fix the expired query id error we encounter when the mql server restarts mid query.

I am clearing the entire query state, and restarting it resulting in a fresh retry state.  If the original query had retried 4 times, then fails with expired query id, the entire flow will restart with 0 retries, so will try the new query 5 times before finally erroring if there is a real error.

# Security Implications
* None