### PR TITLE
Pct Change and Latest Change

### DIFF
--- a/hooks/reducers/mqlQueryReducer.ts
+++ b/hooks/reducers/mqlQueryReducer.ts
@@ -1,22 +1,11 @@
-import { useEffect, useReducer, useContext } from "react";
 import { CombinedError } from "urql";
-import MqlContext from "../context/MqlContext/MqlContext";
-import {
-  CreateMqlQueryMutation,
-  CreateMqlQueryMutationVariables,
-} from "../mutations/mql/MqlMutationTypes";
-import FetchMqlQueryTimeSeries from "../queries/mql/FetchMqlQueryTimeSeries";
 import {
   FetchMqlTimeSeriesQuery,
-  FetchMqlTimeSeriesQueryVariables,
   MqlQueryStatus,
-} from "../queries/mql/MqlQueryTypes";
-import {shouldRetryAfterExpiredQuery, doRetryAfterExpiredQueryAction} from './actions';
-import useCreateMqlQuery from './utils/useCreateMqlQuery';
-import getErrorMessage from './utils/getErrorMessage';
+} from "../../queries/mql/MqlQueryTypes";
 
 // This is the delay between the _response_ from the last query and the _start_ of the new query
-const QUERY_POLLING_MS = 400;
+export const QUERY_POLLING_MS = 400;
 
 // Length of time to wait before retrying when query fails
 export const RETRY_POLLING_MS = 200;
@@ -56,7 +45,7 @@ export type UseMqlQueryState = {
   doRetryAfterExpiredQuery: boolean;
 };
 
-const initialState: UseMqlQueryState = {
+export const initialState: UseMqlQueryState = {
   retries: 0,
   queryId: null,
   queryStatus: MqlQueryStatus.Pending,
@@ -67,7 +56,7 @@ const initialState: UseMqlQueryState = {
   doRetryAfterExpiredQuery: false,
 };
 
-export type Action =
+export type Action<CreateQueryDataType> =
   | { type: "postQueryStart" }
   | { type: "postQueryFail";
       errorMessage: string
@@ -76,7 +65,7 @@ export type Action =
       queryId: string
     }
   | { type: "postQueryCachedResultsSuccess";
-      data: CreateMqlQueryMutation;
+      data: CreateQueryDataType;
       handleCombinedError: (e: CombinedError) => void;
     }
   | { type: "fetchResultsFail";
@@ -96,7 +85,7 @@ export type Action =
     }
   };
 
-/*
+  /*
     At first glance, it is counter-intuitive that we should have a mix of the Reducer pattern
     and the Hook pattern. The explanation for this complexity is that we have several fetches
     that require coordination.
@@ -105,10 +94,10 @@ export type Action =
       3. None of this can take place until an MQL Server URL is supplied
     This reducer abstracts all this complexity.
 */
-function mqlQueryReducer(
+const mqlQueryReducer = <CreateQueryDataType extends unknown>(dataAccr: (data: CreateQueryDataType) => any) => (
   state: UseMqlQueryState,
-  action: Action
-): UseMqlQueryState {
+  action: Action<CreateQueryDataType>,
+): UseMqlQueryState => {
   switch (action.type) {
     case "postQueryStart": {
       // This condition is triggered when there is already a queryId being fetched.
@@ -161,7 +150,7 @@ function mqlQueryReducer(
         ...state,
         queryId: null,
         queryStatus: MqlQueryStatus.Successful,
-        data: action.data?.createMqlQuery?.query,
+        data: dataAccr(action.data),
         fetchStartTime: null,
         isTakingForever: false,
         errorMessage: undefined,
@@ -238,176 +227,4 @@ function mqlQueryReducer(
   }
 }
 
-/*
-  Please Beware!
-  Here Be Dragons!
-
-  If `queryInput` is provided, it *must* be stable for this to work.
-  That means if the value is calculated and generating a fresh object every render,
-  this will result in an infinite loop!
-
-  So we are doing something that seems like it could be improved, which is that if the form is based on the URL,
-  we pass in locationSearch, which is stable, and calculate the form state inside an effect. I know. Gross, right?
-  Is there a better approach?
-*/
-type UseMqlQueryParams = {
-  metricName: string;
-  queryInput?: CreateMqlQueryMutationVariables;
-  skip?: boolean;
-  retries?: number;
-};
-
-// This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
-// data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
-// user updates their request while a query is in flight
-export default function useMqlQuery({
-  queryInput,
-  metricName,
-  skip,
-  retries = 5,
-}: UseMqlQueryParams) {
-  const {
-    useQuery,
-    handleCombinedError,
-    mqlServerUrl,
-  } = useContext(MqlContext);
-
-  const [state, dispatch] = useReducer(mqlQueryReducer, initialState);
-  const {createMqlQuery} = useCreateMqlQuery({metricName, formState: queryInput, dispatch, retries})
-
-  useEffect(() => {
-    if (!metricName || !mqlServerUrl || skip) {
-      return;
-    }
-    dispatch({ type: "postQueryStart" });
-    createMqlQuery({stateRetries: state.retries})
-
-  }, [queryInput, metricName, mqlServerUrl, skip]);
-
-  const _skip =
-    skip ||
-    !state.queryId ||
-    state.cancelledQueries.includes(state.queryId); /* && !isRunning*/
-
-  const [{ data, error }, refetchMqlQuery] = useQuery<
-    FetchMqlTimeSeriesQuery,
-    FetchMqlTimeSeriesQueryVariables
-  >({
-    query: FetchMqlQueryTimeSeries,
-    variables: {
-      queryId: state.queryId || ""
-    },
-    pause: _skip,
-  });
-
-
-  const retry = () => {
-    setTimeout(() => {
-      dispatch({ type: "retryFetchResults" });
-      refetchMqlQuery();
-    }, RETRY_POLLING_MS);
-  }
-
-  useEffect(() => {
-    if (error) {
-      // if error is an expired query id, the mql server may have been restarted, restart the entire query.
-      if (shouldRetryAfterExpiredQuery({
-            errorMessage: error?.message,
-            doRetryAfterExpiredQuery: state.doRetryAfterExpiredQuery
-          })
-        ) {
-          dispatch(doRetryAfterExpiredQueryAction(retries));
-          createMqlQuery({stateRetries: state.retries});
-      } else if (retries > 0 && state.retries !== retries) {
-        retry()
-
-      } else {
-        dispatch({
-          type: "fetchResultsFail",
-          errorMessage: getErrorMessage(error),
-        });
-        handleCombinedError(error);
-      }
-
-      return;
-    }
-
-    if (!data?.mqlQuery) {
-      return;
-    }
-
-    const { status, id } = data.mqlQuery;
-    if (id && state.cancelledQueries.includes(id) /*&& !isRunning*/) {
-      return;
-    }
-    if (status === MqlQueryStatus.Successful) {
-      dispatch({
-        type: "fetchResultsSuccess",
-        data,
-        handleCombinedError,
-      });
-    }
-
-    if (
-      // isRunning ||
-      status === MqlQueryStatus.Running ||
-      status === MqlQueryStatus.Pending
-    ) {
-      window.setTimeout(() => {
-        dispatch({ type: "fetchResultsRunning" });
-        refetchMqlQuery();
-      }, QUERY_POLLING_MS);
-    }
-
-    if (status === MqlQueryStatus.Failed) {
-      if (retries > 0 && state.retries !== retries) {
-        retry()
-      } else {
-        if (data?.mqlQuery?.error) {
-          const {error} = data.mqlQuery;
-          dispatch({
-            type: "fetchResultsFail",
-            errorMessage: error,
-          });
-
-          handleCombinedError({
-            name: "Unknown Error",
-            message: error,
-            graphQLErrors: [],
-          }, {
-            queryId: data?.mqlQuery?.id as string,
-            queryStatus: data?.mqlQuery?.status as string,
-            json: error
-          });
-        } else {
-          let jsonString: string;
-          try {
-            jsonString = JSON.stringify(data?.mqlQuery?.result);
-          } catch (e) {
-            jsonString = "Invalid data.mqlQuery.result";
-          }
-
-          const errorMessage = `This query failed for an unknown reason.`;
-
-          dispatch({
-            type: "fetchResultsFail",
-            errorMessage,
-          });
-
-          handleCombinedError({
-            name: "Unknown Error",
-            message: errorMessage,
-            graphQLErrors: [],
-          }, {
-            queryId: data?.mqlQuery?.id as string,
-            queryStatus: data?.mqlQuery?.status as string,
-            json: jsonString
-          });
-        }
-
-      }
-    }
-  }, [data, error, state.cancelledQueries, handleCombinedError]);
-
-  return state;
-}
+export default mqlQueryReducer;

--- a/hooks/useLatestChangeMqlQuery/index.ts
+++ b/hooks/useLatestChangeMqlQuery/index.ts
@@ -1,0 +1,3 @@
+import useLatestChangeMqlQuery from './useLatestChangeMqlQuery';
+
+export default useLatestChangeMqlQuery;

--- a/hooks/useLatestChangeMqlQuery/useLatestChangeMqlQuery.ts
+++ b/hooks/useLatestChangeMqlQuery/useLatestChangeMqlQuery.ts
@@ -1,0 +1,69 @@
+import { useEffect, useReducer, useContext } from "react";
+import MqlContext from "../../context/MqlContext/MqlContext";
+import {
+  CreateLatestMetricChangeMutation,
+  CreateLatestMetricChangeMutationVariables,
+} from "../../mutations/mql/MqlMutationTypes";
+import useCreateLatestChangeMqlQuery from './utils/useCreateLatestChangeMqlQuery';
+import mqlQueryReducer, { initialState } from '../reducers/mqlQueryReducer';
+import useFetchMqlTimeSeries from '../utils/useFetchMqlTimeSeries';
+
+/*
+  Please Beware!
+  Here Be Dragons!
+
+  If `queryInput` is provided, it *must* be stable for this to work.
+  That means if the value is calculated and generating a fresh object every render,
+  this will result in an infinite loop!
+
+  So we are doing something that seems like it could be improved, which is that if the form is based on the URL,
+  we pass in locationSearch, which is stable, and calculate the form state inside an effect. I know. Gross, right?
+  Is there a better approach?
+*/
+type UseLatestChangeMqlQueryParams = {
+  metricName: string;
+  queryInput?: CreateLatestMetricChangeMutationVariables;
+  skip?: boolean;
+  retries?: number;
+};
+
+// This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
+// data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
+// user updates their request while a query is in flight
+export default function useLatestChangeMqlQuery({
+  queryInput,
+  metricName,
+  skip,
+  retries = 5,
+}: UseLatestChangeMqlQueryParams) {
+  const { mqlServerUrl, } = useContext(MqlContext);
+
+  const reducer = mqlQueryReducer<CreateLatestMetricChangeMutation>((data: CreateLatestMetricChangeMutation) => data?.queryLatestMetricChange?.query);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {queryLatestMetricChange} = useCreateLatestChangeMqlQuery({metricName, dispatch, retries})
+
+  useEffect(() => {
+    if (!metricName || !mqlServerUrl || skip) {
+      return;
+    }
+    dispatch({ type: "postQueryStart" });
+    queryLatestMetricChange({stateRetries: state.retries});
+  }, [queryInput, metricName, mqlServerUrl, skip]);
+
+
+
+  const _skip =
+    skip ||
+    !state.queryId ||
+    state.cancelledQueries.includes(state.queryId); /* && !isRunning*/
+
+    useFetchMqlTimeSeries<CreateLatestMetricChangeMutation>({
+      state,
+      skip: _skip,
+      dispatch,
+      createQueryIdQuery: queryLatestMetricChange,
+      retries
+    });
+
+  return state;
+}

--- a/hooks/useLatestChangeMqlQuery/utils/useCreateLatestChangeMqlQuery.ts
+++ b/hooks/useLatestChangeMqlQuery/utils/useCreateLatestChangeMqlQuery.ts
@@ -1,0 +1,82 @@
+import { useContext, Dispatch } from 'react';
+import MqlContext from "../../../context/MqlContext/MqlContext";
+import CreateLatestMetricChange from "../../../mutations/mql/CreateLatestMetricChangeMutation";
+import {
+  CreateLatestMetricChangeMutation,
+  CreateLatestMetricChangeMutationVariables,
+} from "../../../mutations/mql/MqlMutationTypes";
+import { Action, RETRY_POLLING_MS } from '../../reducers/mqlQueryReducer';
+import getErrorMessage from '../../utils/getErrorMessage';
+import {
+  MqlQueryStatus,
+} from "../../../queries/mql/MqlQueryTypes";
+
+interface DoCreateLatestMetricChangeArgs {
+  stateRetries: number
+}
+
+interface UseCreateLatestMetricChangeArgs {
+  retries: number; // the number of retries passed as an arg from the client.
+  metricName: string;
+  dispatch: Dispatch<Action<CreateLatestMetricChangeMutation>>;
+}
+
+interface UseCreateLatestMetricChange {
+  queryLatestMetricChange: (args: DoCreateLatestMetricChangeArgs) => void;
+}
+
+const useCreateLatestMetricChange = ({metricName, dispatch, retries}: UseCreateLatestMetricChangeArgs): UseCreateLatestMetricChange => {
+  const {
+    useMutation,
+    handleCombinedError,
+  } = useContext(MqlContext);
+
+  const [{}, queryLatestMetricChangeMutation] = useMutation<
+    CreateLatestMetricChangeMutation,
+    CreateLatestMetricChangeMutationVariables
+  >(CreateLatestMetricChange);
+
+  const queryLatestMetricChange = ({stateRetries}:DoCreateLatestMetricChangeArgs) => {
+    queryLatestMetricChangeMutation({
+      metricName
+    }).then(({ data, error }) => {
+      if (data?.queryLatestMetricChange?.query?.status === MqlQueryStatus.Successful) {
+        dispatch({
+          type: "postQueryCachedResultsSuccess",
+          data,
+          handleCombinedError,
+        });
+      } else {
+        if (data?.queryLatestMetricChange?.id) {
+          dispatch({
+            type: "postQuerySuccess",
+            queryId: data?.queryLatestMetricChange?.id,
+          });
+        } else if (error) {
+          if (retries > 0 && stateRetries !== retries && stateRetries < retries) {
+            setTimeout(() => {
+              dispatch({ type: "retryFetchResults" });
+              queryLatestMetricChange({stateRetries: stateRetries + 1});
+            }, RETRY_POLLING_MS)
+          } else {
+            dispatch({
+              type: "postQueryFail",
+              errorMessage: getErrorMessage(error),
+            });
+          }
+          handleCombinedError(error);
+
+        }
+      }
+
+    });
+  };
+
+  return {
+    queryLatestMetricChange
+  }
+}
+
+
+
+export default useCreateLatestMetricChange;

--- a/hooks/useMqlQuery/index.ts
+++ b/hooks/useMqlQuery/index.ts
@@ -1,0 +1,3 @@
+import useMqlQuery from './useMqlQuery';
+
+export default useMqlQuery;

--- a/hooks/useMqlQuery/useMqlQuery.ts
+++ b/hooks/useMqlQuery/useMqlQuery.ts
@@ -1,0 +1,70 @@
+import { useEffect, useReducer, useContext } from "react";
+// import { CombinedError } from "urql";
+import MqlContext from "../../context/MqlContext/MqlContext";
+import {
+  CreateMqlQueryMutation,
+  CreateMqlQueryMutationVariables,
+} from "../../mutations/mql/MqlMutationTypes";
+import useCreateMqlQuery, {DoCreateMqlQueryArgs} from './utils/useCreateMqlQuery';
+import mqlQueryReducer, { initialState } from '../reducers/mqlQueryReducer';
+import useFetchMqlTimeSeries from '../utils/useFetchMqlTimeSeries';
+
+/*
+  Please Beware!
+  Here Be Dragons!
+
+  If `queryInput` is provided, it *must* be stable for this to work.
+  That means if the value is calculated and generating a fresh object every render,
+  this will result in an infinite loop!
+
+  So we are doing something that seems like it could be improved, which is that if the form is based on the URL,
+  we pass in locationSearch, which is stable, and calculate the form state inside an effect. I know. Gross, right?
+  Is there a better approach?
+*/
+type UseMqlQueryParams = {
+  metricName: string;
+  queryInput?: CreateMqlQueryMutationVariables;
+  skip?: boolean;
+  retries?: number;
+};
+
+// This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
+// data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
+// user updates their request while a query is in flight
+export default function useMqlQuery({
+  queryInput,
+  metricName,
+  skip,
+  retries = 5,
+}: UseMqlQueryParams) {
+  const {
+    mqlServerUrl,
+  } = useContext(MqlContext);
+
+  const reducer = mqlQueryReducer<CreateMqlQueryMutation>((data: CreateMqlQueryMutation) => data?.createMqlQuery?.query);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {createMqlQuery} = useCreateMqlQuery({metricName, formState: queryInput, dispatch, retries})
+
+  useEffect(() => {
+    if (!metricName || !mqlServerUrl || skip) {
+      return;
+    }
+    dispatch({ type: "postQueryStart" });
+    createMqlQuery({stateRetries: state.retries});
+  }, [queryInput, metricName, mqlServerUrl, skip]);
+
+  const _skip =
+    skip ||
+    !state.queryId ||
+    state.cancelledQueries.includes(state.queryId); /* && !isRunning*/
+
+  useFetchMqlTimeSeries<CreateMqlQueryMutation>({
+    state,
+    skip: _skip,
+    dispatch,
+    createQueryIdQuery: createMqlQuery,
+    retries
+  });
+
+  return state;
+}

--- a/hooks/useMqlQuery/utils/clearEmptyConstraints.ts
+++ b/hooks/useMqlQuery/utils/clearEmptyConstraints.ts
@@ -1,6 +1,6 @@
 import {
   ConstraintInput,
-} from "../../mutations/mql/MqlMutationTypes";
+} from "../../../mutations/mql/MqlMutationTypes";
 
 const EMPTY_CONSTRAINT: ConstraintInput = { constraint: null };
 

--- a/hooks/useMqlQuery/utils/useCreateMqlQuery.ts
+++ b/hooks/useMqlQuery/utils/useCreateMqlQuery.ts
@@ -1,18 +1,18 @@
 import { useContext, Dispatch } from 'react';
-import MqlContext from "../../context/MqlContext/MqlContext";
-import CreateMqlQuery from "../../mutations/mql/CreateMqlQuery";
+import MqlContext from "../../../context/MqlContext/MqlContext";
+import CreateMqlQuery from "../../../mutations/mql/CreateMqlQuery";
 import {
   CreateMqlQueryMutation,
   CreateMqlQueryMutationVariables,
-} from "../../mutations/mql/MqlMutationTypes";
+} from "../../../mutations/mql/MqlMutationTypes";
 import clearEmptyConstraints from './clearEmptyConstraints';
-import { Action as UseMqlQueryAction, UseMqlQueryState, RETRY_POLLING_MS } from '../useMqlQuery'
-import getErrorMessage from './getErrorMessage';
+import { Action as UseMqlQueryAction, RETRY_POLLING_MS } from '../../reducers/mqlQueryReducer';
+import getErrorMessage from '../../utils/getErrorMessage';
 import {
   MqlQueryStatus,
-} from "../../queries/mql/MqlQueryTypes";
+} from "../../../queries/mql/MqlQueryTypes";
 
-interface DoCreateMqlQueryArgs {
+export interface DoCreateMqlQueryArgs {
   stateRetries: number
 }
 
@@ -20,7 +20,7 @@ interface UseCreateMqlQueryArgs {
   retries: number; // the number of retries passed as an arg from the client.
   metricName: string;
   formState?: CreateMqlQueryMutationVariables;
-  dispatch: Dispatch<UseMqlQueryAction>;
+  dispatch: Dispatch<UseMqlQueryAction<CreateMqlQueryMutation>>;
 }
 
 interface UseCreateMqlQuery {

--- a/hooks/usePercentChangeMqlQuery/usePercentChangeMqlQuery.ts
+++ b/hooks/usePercentChangeMqlQuery/usePercentChangeMqlQuery.ts
@@ -1,0 +1,71 @@
+import { useEffect, useReducer, useContext } from "react";
+// import { CombinedError } from "urql";
+import MqlContext from "../../context/MqlContext/MqlContext";
+import {
+  CreatePercentChangeMutation,
+  CreatePercentChangeMutationVariables,
+} from "../../mutations/mql/MqlMutationTypes";
+import useCreatePercentChange from './utils/useCreatePercentChangeMqlQuery';
+import mqlQueryReducer, { initialState } from '../reducers/mqlQueryReducer';
+import useFetchMqlTimeSeries from '../utils/useFetchMqlTimeSeries';
+
+/*
+  Please Beware!
+  Here Be Dragons!
+
+  If `queryInput` is provided, it *must* be stable for this to work.
+  That means if the value is calculated and generating a fresh object every render,
+  this will result in an infinite loop!
+
+  So we are doing something that seems like it could be improved, which is that if the form is based on the URL,
+  we pass in locationSearch, which is stable, and calculate the form state inside an effect. I know. Gross, right?
+  Is there a better approach?
+*/
+type UsePercentChangeMqlQueryParams = {
+  metricName: string;
+  queryInput: CreatePercentChangeMutationVariables;
+  skip?: boolean;
+  retries?: number;
+};
+
+// This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
+// data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
+// user updates their request while a query is in flight
+export default function usePercentChangeMqlQuery({
+  queryInput,
+  metricName,
+  skip,
+  retries = 5,
+}: UsePercentChangeMqlQueryParams) {
+  const {
+    mqlServerUrl,
+  } = useContext(MqlContext);
+
+  const reducer = mqlQueryReducer<CreatePercentChangeMutation>((data: CreatePercentChangeMutation) => data?.pctChangeOverRange?.query);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  console.log('queryInput', queryInput)
+  const {queryPercentChange} = useCreatePercentChange({queryInput, dispatch, retries})
+
+  useEffect(() => {
+    if (!metricName || !mqlServerUrl || skip) {
+      return;
+    }
+    dispatch({ type: "postQueryStart" });
+    queryPercentChange({stateRetries: state.retries});
+  }, [queryInput, metricName, mqlServerUrl, skip]);
+
+  const _skip =
+    skip ||
+    !state.queryId ||
+    state.cancelledQueries.includes(state.queryId); /* && !isRunning*/
+
+  useFetchMqlTimeSeries<CreatePercentChangeMutation>({
+    state,
+    skip: _skip,
+    dispatch,
+    createQueryIdQuery: queryPercentChange,
+    retries
+  });
+
+  return state;
+}

--- a/hooks/usePercentChangeMqlQuery/utils/useCreatePercentChangeMqlQuery.ts
+++ b/hooks/usePercentChangeMqlQuery/utils/useCreatePercentChangeMqlQuery.ts
@@ -1,0 +1,80 @@
+import { useContext, Dispatch } from 'react';
+import MqlContext from "../../../context/MqlContext/MqlContext";
+import CreatePercentChange from "../../../mutations/mql/CreatePercentChangeMutation";
+import {
+  CreatePercentChangeMutation,
+  CreatePercentChangeMutationVariables,
+} from "../../../mutations/mql/MqlMutationTypes";
+import { Action, RETRY_POLLING_MS } from '../../reducers/mqlQueryReducer'
+import getErrorMessage from '../../utils/getErrorMessage';
+import {
+  MqlQueryStatus,
+} from "../../../queries/mql/MqlQueryTypes";
+
+interface DoCreatePercentChangeArgs {
+  stateRetries: number
+}
+
+interface UseCreatePercentChangeArgs {
+  retries: number; // the number of retries passed as an arg from the client.
+  queryInput: CreatePercentChangeMutationVariables;
+  dispatch: Dispatch<Action<CreatePercentChangeMutation>>;
+}
+
+interface UseCreatePercentChange {
+  queryPercentChange: (args: DoCreatePercentChangeArgs) => void;
+}
+
+const useCreatePercentChange = ({queryInput, dispatch, retries}: UseCreatePercentChangeArgs): UseCreatePercentChange => {
+  const {
+    useMutation,
+    handleCombinedError,
+  } = useContext(MqlContext);
+
+  const [{}, queryPercentChangeMutation] = useMutation<
+    CreatePercentChangeMutation,
+    CreatePercentChangeMutationVariables
+  >(CreatePercentChange);
+
+  const queryPercentChange = ({stateRetries}:DoCreatePercentChangeArgs) => {
+    queryPercentChangeMutation(queryInput).then(({ data, error }) => {
+      if (data?.pctChangeOverRange?.query?.status === MqlQueryStatus.Successful) {
+        dispatch({
+          type: "postQueryCachedResultsSuccess",
+          data,
+          handleCombinedError,
+        });
+      } else {
+        if (data?.pctChangeOverRange?.id) {
+          dispatch({
+            type: "postQuerySuccess",
+            queryId: data?.pctChangeOverRange?.id,
+          });
+        } else if (error) {
+          if (retries > 0 && stateRetries !== retries && stateRetries < retries) {
+            setTimeout(() => {
+              dispatch({ type: "retryFetchResults" });
+              queryPercentChange({stateRetries: stateRetries + 1});
+            }, RETRY_POLLING_MS)
+          } else {
+            dispatch({
+              type: "postQueryFail",
+              errorMessage: getErrorMessage(error),
+            });
+          }
+          handleCombinedError(error);
+
+        }
+      }
+
+    });
+  };
+
+  return {
+    queryPercentChange
+  }
+}
+
+
+
+export default useCreatePercentChange;

--- a/hooks/utils/useFetchMqlTimeSeries.ts
+++ b/hooks/utils/useFetchMqlTimeSeries.ts
@@ -1,0 +1,154 @@
+import { useEffect, useContext, Dispatch } from "react";
+import MqlContext from "../../context/MqlContext/MqlContext";
+import FetchMqlQueryTimeSeries from "../../queries/mql/FetchMqlQueryTimeSeries";
+import {
+  FetchMqlTimeSeriesQuery,
+  FetchMqlTimeSeriesQueryVariables,
+  MqlQueryStatus,
+} from "../../queries/mql/MqlQueryTypes";
+import {shouldRetryAfterExpiredQuery, doRetryAfterExpiredQueryAction} from '../actions';
+import getErrorMessage from '../utils/getErrorMessage';
+import {Action, UseMqlQueryState, QUERY_POLLING_MS, RETRY_POLLING_MS} from '../reducers/mqlQueryReducer';
+
+interface UseFetchMqlTimeSeriesArgs<CreateQueryDataType> {
+  state: UseMqlQueryState;
+  skip: boolean;
+  dispatch: Dispatch<Action<CreateQueryDataType>>
+  createQueryIdQuery: ({stateRetries}: {stateRetries: number}) => void;
+  retries: number;
+}
+
+const useFetchMqlTimeSeries = <CreateQueryDataType>({
+  state,
+  skip,
+  dispatch,
+  createQueryIdQuery,
+  retries
+}: UseFetchMqlTimeSeriesArgs<CreateQueryDataType>) => {
+  const {
+    useQuery,
+    handleCombinedError,
+  } = useContext(MqlContext);
+
+  const [{ data, error }, refetchMqlQuery] = useQuery<
+    FetchMqlTimeSeriesQuery,
+    FetchMqlTimeSeriesQueryVariables
+  >({
+    query: FetchMqlQueryTimeSeries,
+    variables: {
+      queryId: state.queryId || ""
+    },
+    pause: skip,
+  });
+
+
+  const retry = () => {
+    setTimeout(() => {
+      dispatch({ type: "retryFetchResults" });
+      refetchMqlQuery();
+    }, RETRY_POLLING_MS);
+  }
+
+  useEffect(() => {
+    if (error) {
+      // if error is an expired query id, the mql server may have been restarted, restart the entire query.
+      if (shouldRetryAfterExpiredQuery({
+            errorMessage: error?.message,
+            doRetryAfterExpiredQuery: state.doRetryAfterExpiredQuery
+          })
+        ) {
+          dispatch(doRetryAfterExpiredQueryAction(retries));
+          createQueryIdQuery({stateRetries: state.retries});
+      } else if (retries > 0 && state.retries !== retries) {
+        retry()
+
+      } else {
+        dispatch({
+          type: "fetchResultsFail",
+          errorMessage: getErrorMessage(error),
+        });
+        handleCombinedError(error);
+      }
+
+      return;
+    }
+
+    if (!data?.mqlQuery) {
+      return;
+    }
+
+    const { status, id } = data.mqlQuery;
+    if (id && state.cancelledQueries.includes(id) /*&& !isRunning*/) {
+      return;
+    }
+    if (status === MqlQueryStatus.Successful) {
+      dispatch({
+        type: "fetchResultsSuccess",
+        data,
+        handleCombinedError,
+      });
+    }
+
+    if (
+      // isRunning ||
+      status === MqlQueryStatus.Running ||
+      status === MqlQueryStatus.Pending
+    ) {
+      window.setTimeout(() => {
+        dispatch({ type: "fetchResultsRunning" });
+        refetchMqlQuery();
+      }, QUERY_POLLING_MS);
+    }
+
+    if (status === MqlQueryStatus.Failed) {
+      if (retries > 0 && state.retries !== retries) {
+        retry()
+      } else {
+        if (data?.mqlQuery?.error) {
+          const {error} = data.mqlQuery;
+          dispatch({
+            type: "fetchResultsFail",
+            errorMessage: error,
+          });
+
+          handleCombinedError({
+            name: "Unknown Error",
+            message: error,
+            graphQLErrors: [],
+          }, {
+            queryId: data?.mqlQuery?.id as string,
+            queryStatus: data?.mqlQuery?.status as string,
+            json: error
+          });
+        } else {
+          let jsonString: string;
+          try {
+            jsonString = JSON.stringify(data?.mqlQuery?.result);
+          } catch (e) {
+            jsonString = "Invalid data.mqlQuery.result";
+          }
+
+          const errorMessage = `This query failed for an unknown reason.`;
+
+          dispatch({
+            type: "fetchResultsFail",
+            errorMessage,
+          });
+
+          handleCombinedError({
+            name: "Unknown Error",
+            message: errorMessage,
+            graphQLErrors: [],
+          }, {
+            queryId: data?.mqlQuery?.id as string,
+            queryStatus: data?.mqlQuery?.status as string,
+            json: jsonString
+          });
+        }
+
+      }
+    }
+  }, [data, error, state.cancelledQueries, handleCombinedError]);
+}
+
+export default useFetchMqlTimeSeries;

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -59,6 +59,7 @@ export type Query = {
   boom?: Maybe<Scalars['Boolean']>;
   transformConfig?: Maybe<TransformConfig>;
   emailCanSignUp?: Maybe<Scalars['Boolean']>;
+  dwHealthCheck?: Maybe<Array<Maybe<MqlServerHealthItem>>>;
 };
 
 
@@ -80,10 +81,11 @@ export type QueryAuth0ProfileArgs = {
 export type QueryAllFeaturesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<FeatureStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<FeatureOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<FeatureOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -95,10 +97,11 @@ export type QueryAllFeaturesArgs = {
 export type QueryAllOrganizationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<OrganizationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<OrganizationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrganizationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -139,6 +142,18 @@ export type QueryBoomArgs = {
  */
 export type QueryEmailCanSignUpArgs = {
   email: Scalars['String'];
+};
+
+
+/**
+ * Base Query object exposed by GraphQL.
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryDwHealthCheckArgs = {
+  snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
+  redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
+  bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
 };
 
 /** A wrapper for the response we get from Auth0's user profile API */
@@ -187,6 +202,7 @@ export type Organization = {
   mqlHeartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   currentModel?: Maybe<Array<Maybe<Model>>>;
   teams?: Maybe<Array<Maybe<Team>>>;
+  prefs?: Maybe<Array<Maybe<OrgPref>>>;
   apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   metricViews?: Maybe<Array<Maybe<MetricView>>>;
   savedQueries?: Maybe<Array<Maybe<SavedQuery>>>;
@@ -221,6 +237,12 @@ export type Organization = {
   allowedEmailDomains?: Maybe<Array<Maybe<Scalars['String']>>>;
   tierTooltips?: Maybe<Scalars['GenericScalar']>;
   activeOrgAdmins?: Maybe<Array<Maybe<User>>>;
+  mqlServerConfig?: Maybe<DataWarehouseConfig>;
+  incompleteOnboardingTasks?: Maybe<Array<Maybe<Scalars['String']>>>;
+  samlConnectionName?: Maybe<Scalars['String']>;
+  sharedSlackChannelName?: Maybe<Scalars['String']>;
+  primaryMqlServer?: Maybe<OrgMqlServer>;
+  annotationsFeed?: Maybe<Array<Maybe<Annotation>>>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -229,20 +251,22 @@ export type OrganizationUsersArgs = {
   activeOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationMqlServersArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<OrgMqlServerStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<OrgMqlServerOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrgMqlServerOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -254,40 +278,56 @@ export type OrganizationModelsArgs = {
 export type OrganizationTeamsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationPrefsArgs = {
+  prefKey?: Maybe<Scalars['String']>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<OrgPrefStrColumns>>>;
+  orderBy?: Maybe<OrgPrefOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrgPrefOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationQuestionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -299,30 +339,33 @@ export type OrganizationQuestionArgs = {
 export type OrganizationAnnotationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<AnnotationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationRecentQuestionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationRecentAnnotationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<AnnotationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -332,10 +375,11 @@ export type OrganizationMetricsArgs = {
   types?: Maybe<Array<Maybe<MetricType>>>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -345,6 +389,13 @@ export type OrganizationTotalMetricsArgs = {
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
+};
+
+
+export type OrganizationTotalUsersArgs = {
+  activeOnly?: Maybe<Scalars['Boolean']>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
 };
 
 
@@ -386,10 +437,22 @@ export type OrganizationTierTooltipsArgs = {
 export type OrganizationActiveOrgAdminsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationMqlServerConfigArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type OrganizationAnnotationsFeedArgs = {
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 /** An enumeration. */
@@ -440,9 +503,14 @@ export type User = {
   totalViewedMetricCollections?: Maybe<Scalars['Int']>;
   totalActiveFeatures?: Maybe<Scalars['Int']>;
   hasAcceptedLatestTermsOfService?: Maybe<Scalars['Boolean']>;
+  acceptedTermsOfService?: Maybe<Scalars['Int']>;
+  totalFeaturedMetrics?: Maybe<Scalars['Int']>;
+  totalSubscribedMetrics?: Maybe<Scalars['Int']>;
   viewedMetrics?: Maybe<Array<Maybe<Metric>>>;
   newMetrics?: Maybe<Array<Maybe<Metric>>>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
+  featuredMetrics?: Maybe<Array<Maybe<Metric>>>;
+  subscribedMetrics?: Maybe<Array<Maybe<Metric>>>;
 };
 
 
@@ -450,10 +518,11 @@ export type UserTeamsArgs = {
   isAdminOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -461,70 +530,89 @@ export type UserApiKeysArgs = {
   activeOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<ApiKeyStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<ApiKeyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<ApiKeyOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserViewedTeamsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserViewedMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserViewedMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserNewMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type UserFeaturedMetricsArgs = {
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type UserSubscribedMetricsArgs = {
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type UserRole = {
@@ -591,40 +679,44 @@ export type Team = {
 
 
 export type TeamMembersArgs = {
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamMemberOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamMemberOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type TeamSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type TeamMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type TeamMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type TeamMember = {
@@ -642,22 +734,27 @@ export type TeamMember = {
 
 /** An enumeration. */
 export enum TeamMemberOrderBy {
-  JoinedAt = 'JOINED_AT',
+  TeamId = 'TEAM_ID',
   UserId = 'USER_ID',
   IsTeamAdmin = 'IS_TEAM_ADMIN',
-  TeamId = 'TEAM_ID',
-  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
+  JoinedAt = 'JOINED_AT',
   TeamMemberId = 'TeamMember_ID',
+  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
   UserOrganizationId = 'User_ORGANIZATION_ID',
-  AvatarUrl = 'AVATAR_URL',
-  CreatedAt = 'CREATED_AT',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UserName = 'USER_NAME',
   Email = 'EMAIL',
   UpdatedAt = 'UPDATED_AT',
-  UserName = 'USER_NAME',
   DeactivatedAt = 'DEACTIVATED_AT',
+  AvatarUrl = 'AVATAR_URL',
   Auth0Id = 'AUTH0_ID',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  CreatedAt = 'CREATED_AT'
 }
+
+export type TeamMemberOrderByInput = {
+  orderBy: TeamMemberOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type Dashboard = {
   __typename?: 'Dashboard';
@@ -730,18 +827,20 @@ export type MetricCollection = {
 
 
 export type MetricCollectionItemsArgs = {
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionMetricOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionMetricOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricCollectionCollectionItemsArgs = {
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionMetricOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionMetricOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type MetricCollectionView = {
@@ -793,9 +892,16 @@ export type MetricUserOwner = {
   userId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   isLocked: Scalars['Boolean'];
+  ownerType: OwnerType;
   user?: Maybe<User>;
   organization?: Maybe<Organization>;
 };
+
+/** An enumeration. */
+export enum OwnerType {
+  Business = 'BUSINESS',
+  Technical = 'TECHNICAL'
+}
 
 export type MetricTeamOwner = {
   __typename?: 'MetricTeamOwner';
@@ -805,6 +911,7 @@ export type MetricTeamOwner = {
   createdTs?: Maybe<Scalars['Int']>;
   orgMetricId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
+  ownerType: OwnerType;
   team?: Maybe<Team>;
   organization?: Maybe<Organization>;
 };
@@ -843,6 +950,7 @@ export type Metric = {
   displayNameWithLock?: Maybe<LockableParameter>;
   descriptionWithLock?: Maybe<LockableParameter>;
   valueFormatWithLock?: Maybe<LockableParameter>;
+  increaseIsGoodWithLock?: Maybe<LockableParameter>;
   latestApproval?: Maybe<MetricApproval>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
   currentDescription?: Maybe<Scalars['String']>;
@@ -868,10 +976,11 @@ export type Metric = {
 export type MetricQuestionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -882,50 +991,55 @@ export type MetricAnnotationsArgs = {
   priorities?: Maybe<Array<Maybe<Priority>>>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<AnnotationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricDataSourcesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<DataSourceVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<DataSourceVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<DataSourceVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricOwnerTeamsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricOwnerUsersArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -1021,10 +1135,11 @@ export type Question = {
 export type QuestionRepliesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionReplyStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionReplyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionReplyOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type QuestionReply = {
@@ -1050,36 +1165,46 @@ export enum QuestionReplyStrColumns {
 
 /** An enumeration. */
 export enum QuestionReplyOrderBy {
-  AuthorId = 'AUTHOR_ID',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  OrganizationId = 'ORGANIZATION_ID',
+  Text = 'TEXT',
   QuestionId = 'QUESTION_ID',
   UpdatedAt = 'UPDATED_AT',
-  Text = 'TEXT'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
+  AuthorId = 'AUTHOR_ID'
 }
+
+export type QuestionReplyOrderByInput = {
+  orderBy: QuestionReplyOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum QuestionStrColumns {
-  Priority = 'PRIORITY',
-  Text = 'TEXT'
+  Text = 'TEXT',
+  Priority = 'PRIORITY'
 }
 
 /** An enumeration. */
 export enum QuestionOrderBy {
+  Id = 'ID',
   ResolvedAt = 'RESOLVED_AT',
   ResolvedBy = 'RESOLVED_BY',
-  AuthorId = 'AUTHOR_ID',
-  CreatedAt = 'CREATED_AT',
-  Id = 'ID',
-  OrganizationId = 'ORGANIZATION_ID',
-  NotifiedAt = 'NOTIFIED_AT',
-  MetricId = 'METRIC_ID',
   Text = 'TEXT',
   UpdatedAt = 'UPDATED_AT',
+  AuthorId = 'AUTHOR_ID',
+  Priority = 'PRIORITY',
+  NotifiedAt = 'NOTIFIED_AT',
+  MetricId = 'METRIC_ID',
   Resolved = 'RESOLVED',
-  Priority = 'PRIORITY'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type QuestionOrderByInput = {
+  orderBy: QuestionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type LockableParameter = {
   __typename?: 'LockableParameter';
@@ -1161,58 +1286,68 @@ export enum Priority {
 
 /** An enumeration. */
 export enum AnnotationStrColumns {
-  Priority = 'PRIORITY',
-  Title = 'TITLE',
   ExpectedImpact = 'EXPECTED_IMPACT',
-  Text = 'TEXT'
+  Text = 'TEXT',
+  Priority = 'PRIORITY',
+  Title = 'TITLE'
 }
 
 /** An enumeration. */
 export enum AnnotationOrderBy {
-  AuthorId = 'AUTHOR_ID',
-  DateEndedAt = 'DATE_ENDED_AT',
   Id = 'ID',
-  ExpectedImpact = 'EXPECTED_IMPACT',
-  CreatedAt = 'CREATED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
-  NotifiedAt = 'NOTIFIED_AT',
   Text = 'TEXT',
-  UpdatedAt = 'UPDATED_AT',
-  Title = 'TITLE',
-  DateStartedAt = 'DATE_STARTED_AT',
   DeletedAt = 'DELETED_AT',
-  Priority = 'PRIORITY'
+  UpdatedAt = 'UPDATED_AT',
+  DateStartedAt = 'DATE_STARTED_AT',
+  AuthorId = 'AUTHOR_ID',
+  ExpectedImpact = 'EXPECTED_IMPACT',
+  Priority = 'PRIORITY',
+  DateEndedAt = 'DATE_ENDED_AT',
+  NotifiedAt = 'NOTIFIED_AT',
+  Title = 'TITLE',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type AnnotationOrderByInput = {
+  orderBy: AnnotationOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum DataSourceVersionStrColumns {
-  Connection = 'CONNECTION',
-  Hash = 'HASH',
   SqlTable = 'SQL_TABLE',
-  Name = 'NAME',
+  Hash = 'HASH',
   SqlQuery = 'SQL_QUERY',
-  Description = 'DESCRIPTION'
+  Connection = 'CONNECTION',
+  Description = 'DESCRIPTION',
+  Name = 'NAME'
 }
 
 /** An enumeration. */
 export enum DataSourceVersionOrderBy {
-  DataSourceMetadata = 'DATA_SOURCE_METADATA',
-  Name = 'NAME',
-  Identifiers = 'IDENTIFIERS',
-  CreatedAt = 'CREATED_AT',
-  SqlQuery = 'SQL_QUERY',
-  OrganizationId = 'ORGANIZATION_ID',
-  Connection = 'CONNECTION',
-  SqlTable = 'SQL_TABLE',
-  Dimensions = 'DIMENSIONS',
   Id = 'ID',
   Description = 'DESCRIPTION',
-  Mutability = 'MUTABILITY',
-  Hash = 'HASH',
+  Connection = 'CONNECTION',
+  Dimensions = 'DIMENSIONS',
+  Name = 'NAME',
+  SqlTable = 'SQL_TABLE',
   Constraint = 'CONSTRAINT',
+  Identifiers = 'IDENTIFIERS',
+  SqlQuery = 'SQL_QUERY',
+  Owners = 'OWNERS',
+  Hash = 'HASH',
+  DataSourceMetadata = 'DATA_SOURCE_METADATA',
   Measures = 'MEASURES',
-  Owners = 'OWNERS'
+  Mutability = 'MUTABILITY',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type DataSourceVersionOrderByInput = {
+  orderBy: DataSourceVersionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type SavedQuery = {
   __typename?: 'SavedQuery';
@@ -1237,49 +1372,57 @@ export type SavedQuery = {
 export type SavedQueryMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 /** An enumeration. */
 export enum MetricVersionStrColumns {
   Description = 'DESCRIPTION',
-  Hash = 'HASH',
   DisplayName = 'DISPLAY_NAME',
+  Hash = 'HASH',
   ValueFormat = 'VALUE_FORMAT'
 }
 
 /** An enumeration. */
 export enum MetricVersionOrderBy {
   Id = 'ID',
-  MetricType = 'METRIC_TYPE',
-  SourceDataSourceVersions = 'SOURCE_DATA_SOURCE_VERSIONS',
-  Params = 'PARAMS',
-  Description = 'DESCRIPTION',
-  OrganizationId = 'ORGANIZATION_ID',
-  OrgDataSourceId = 'ORG_DATA_SOURCE_ID',
-  Views = 'VIEWS',
-  Tier = 'TIER',
   Hash = 'HASH',
+  Description = 'DESCRIPTION',
+  OrgDataSourceId = 'ORG_DATA_SOURCE_ID',
   Metadata = 'METADATA',
+  Tier = 'TIER',
+  SourceDataSourceVersions = 'SOURCE_DATA_SOURCE_VERSIONS',
   DisplayName = 'DISPLAY_NAME',
-  MetricVersionCreatedAt = 'MetricVersion_CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
+  Params = 'PARAMS',
+  Views = 'VIEWS',
+  MetricType = 'METRIC_TYPE',
   MetricVersionMetricId = 'MetricVersion_METRIC_ID',
-  MetricMetadataCreatedAt = 'MetricMetadata_CREATED_AT',
+  MetricVersionCreatedAt = 'MetricVersion_CREATED_AT',
   MetricMetadataMetricId = 'MetricMetadata_METRIC_ID',
-  ExtraFields = 'EXTRA_FIELDS',
-  UpdatedBy = 'UPDATED_BY',
-  TierLock = 'TIER_LOCK',
-  ValueFormatLock = 'VALUE_FORMAT_LOCK',
+  MetricMetadataCreatedAt = 'MetricMetadata_CREATED_AT',
+  IncreaseIsGoodLock = 'INCREASE_IS_GOOD_LOCK',
   CreatedBy = 'CREATED_BY',
-  ValueFormat = 'VALUE_FORMAT',
   UpdatedAt = 'UPDATED_AT',
   DescriptionLock = 'DESCRIPTION_LOCK',
   DisplayNameLock = 'DISPLAY_NAME_LOCK',
-  IsNew = 'IS_NEW'
+  ExtraFields = 'EXTRA_FIELDS',
+  IsNew = 'IS_NEW',
+  ValueFormat = 'VALUE_FORMAT',
+  IncreaseIsGood = 'INCREASE_IS_GOOD',
+  ValueFormatLock = 'VALUE_FORMAT_LOCK',
+  TierLock = 'TIER_LOCK',
+  UpdatedBy = 'UPDATED_BY'
 }
+
+export type MetricVersionOrderByInput = {
+  orderBy: MetricVersionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum SavedQueryStrColumns {
@@ -1288,75 +1431,95 @@ export enum SavedQueryStrColumns {
 
 /** An enumeration. */
 export enum SavedQueryOrderBy {
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  SerializedQuery = 'SERIALIZED_QUERY',
-  OrganizationId = 'ORGANIZATION_ID',
+  DeletedAt = 'DELETED_AT',
+  OwnerTeamId = 'OWNER_TEAM_ID',
   CreatedBy = 'CREATED_BY',
   UpdatedAt = 'UPDATED_AT',
   Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
-  OwnerTeamId = 'OWNER_TEAM_ID'
+  SerializedQuery = 'SERIALIZED_QUERY',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type SavedQueryOrderByInput = {
+  orderBy: SavedQueryOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum TeamStrColumns {
-  Theme = 'THEME',
   Description = 'DESCRIPTION',
+  Slug = 'SLUG',
   Name = 'NAME',
-  Slug = 'SLUG'
+  Theme = 'THEME'
 }
 
 /** An enumeration. */
 export enum TeamOrderBy {
+  Id = 'ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  CreatedBy = 'CREATED_BY',
+  UpdatedAt = 'UPDATED_AT',
+  Description = 'DESCRIPTION',
+  DeactivatedAt = 'DEACTIVATED_AT',
   Theme = 'THEME',
   Name = 'NAME',
-  Id = 'ID',
-  CreatedAt = 'CREATED_AT',
-  Description = 'DESCRIPTION',
-  OrganizationId = 'ORGANIZATION_ID',
-  CreatedBy = 'CREATED_BY',
+  FeaturedMetricCollectionId = 'FEATURED_METRIC_COLLECTION_ID',
   Views = 'VIEWS',
   Slug = 'SLUG',
-  UpdatedAt = 'UPDATED_AT',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  FeaturedMetricCollectionId = 'FEATURED_METRIC_COLLECTION_ID',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type TeamOrderByInput = {
+  orderBy: TeamOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum UserStrColumns {
   AvatarUrl = 'AVATAR_URL',
+  UserName = 'USER_NAME',
   Email = 'EMAIL',
-  Auth0Id = 'AUTH0_ID',
-  UserName = 'USER_NAME'
+  Auth0Id = 'AUTH0_ID'
 }
 
 /** An enumeration. */
 export enum UserOrderBy {
-  AvatarUrl = 'AVATAR_URL',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  OrganizationId = 'ORGANIZATION_ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UserName = 'USER_NAME',
   Email = 'EMAIL',
   UpdatedAt = 'UPDATED_AT',
-  UserName = 'USER_NAME',
   DeactivatedAt = 'DEACTIVATED_AT',
+  AvatarUrl = 'AVATAR_URL',
   Auth0Id = 'AUTH0_ID',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type UserOrderByInput = {
+  orderBy: UserOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum MetricCollectionMetricOrderBy {
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  MetricId = 'METRIC_ID',
-  UpdatedAt = 'UPDATED_AT',
-  Emphasis = 'EMPHASIS',
   MetricCollectionId = 'METRIC_COLLECTION_ID',
   SavedQueryId = 'SAVED_QUERY_ID',
-  Position = 'POSITION'
+  UpdatedAt = 'UPDATED_AT',
+  Position = 'POSITION',
+  Emphasis = 'EMPHASIS',
+  MetricId = 'METRIC_ID',
+  CreatedAt = 'CREATED_AT'
 }
+
+export type MetricCollectionMetricOrderByInput = {
+  orderBy: MetricCollectionMetricOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type CollectionItem = {
   __typename?: 'CollectionItem';
@@ -1390,26 +1553,31 @@ export type TeamView = {
 /** An enumeration. */
 export enum MetricCollectionStrColumns {
   Description = 'DESCRIPTION',
-  Title = 'TITLE',
-  Slug = 'SLUG'
+  Slug = 'SLUG',
+  Title = 'TITLE'
 }
 
 /** An enumeration. */
 export enum MetricCollectionOrderBy {
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  Description = 'DESCRIPTION',
-  OrganizationId = 'ORGANIZATION_ID',
-  CreatedBy = 'CREATED_BY',
-  Views = 'VIEWS',
-  Slug = 'SLUG',
-  UpdatedAt = 'UPDATED_AT',
-  Title = 'TITLE',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   DeletedAt = 'DELETED_AT',
   OwnerTeamId = 'OWNER_TEAM_ID',
+  CreatedBy = 'CREATED_BY',
+  UpdatedAt = 'UPDATED_AT',
+  Description = 'DESCRIPTION',
   DefaultEmphasis = 'DEFAULT_EMPHASIS',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  Views = 'VIEWS',
+  Title = 'TITLE',
+  Slug = 'SLUG',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type MetricCollectionOrderByInput = {
+  orderBy: MetricCollectionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type ApiKey = {
   __typename?: 'ApiKey';
@@ -1431,24 +1599,29 @@ export type ApiKey = {
 /** An enumeration. */
 export enum ApiKeyStrColumns {
   Type = 'TYPE',
-  SecretHash = 'SECRET_HASH',
   Scope = 'SCOPE',
-  Prefix = 'PREFIX'
+  Prefix = 'PREFIX',
+  SecretHash = 'SECRET_HASH'
 }
 
 /** An enumeration. */
 export enum ApiKeyOrderBy {
-  Type = 'TYPE',
-  SecretHash = 'SECRET_HASH',
-  CreatedAt = 'CREATED_AT',
-  RevokedAt = 'REVOKED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
-  Scope = 'SCOPE',
-  UserId = 'USER_ID',
-  LastUsedAt = 'LAST_USED_AT',
+  Prefix = 'PREFIX',
   RevokerId = 'REVOKER_ID',
-  Prefix = 'PREFIX'
+  UserId = 'USER_ID',
+  SecretHash = 'SECRET_HASH',
+  LastUsedAt = 'LAST_USED_AT',
+  Scope = 'SCOPE',
+  Type = 'TYPE',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
+  RevokedAt = 'REVOKED_AT'
 }
+
+export type ApiKeyOrderByInput = {
+  orderBy: ApiKeyOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type Feature = {
   __typename?: 'Feature';
@@ -1467,47 +1640,54 @@ export type Feature = {
 export type FeatureOrganizationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<OrganizationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<OrganizationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrganizationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type FeatureUsersArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 /** An enumeration. */
 export enum OrganizationStrColumns {
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  Name = 'NAME',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
   LogoUrl = 'LOGO_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
   PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO'
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  Name = 'NAME'
 }
 
 /** An enumeration. */
 export enum OrganizationOrderBy {
-  Type = 'TYPE',
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  Name = 'NAME',
   Id = 'ID',
-  CreatedAt = 'CREATED_AT',
-  IsHosted = 'IS_HOSTED',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  UpdatedAt = 'UPDATED_AT',
   LogoUrl = 'LOGO_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
+  UpdatedAt = 'UPDATED_AT',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
-  DeactivatedAt = 'DEACTIVATED_AT'
+  DeactivatedAt = 'DEACTIVATED_AT',
+  Name = 'NAME',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  IsHosted = 'IS_HOSTED',
+  Type = 'TYPE',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  CreatedAt = 'CREATED_AT'
 }
+
+export type OrganizationOrderByInput = {
+  orderBy: OrganizationOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type OrgMqlServer = {
   __typename?: 'OrgMqlServer';
@@ -1520,9 +1700,11 @@ export type OrgMqlServer = {
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   configSecret?: Maybe<Scalars['String']>;
   dwEngine?: Maybe<DwEngine>;
+  deploymentStatus?: Maybe<DeploymentStatus>;
   heartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   organization?: Maybe<Organization>;
   latestHeartbeat?: Maybe<MqlHeartbeat>;
+  dwConfig?: Maybe<DataWarehouseConfig>;
 };
 
 /** An enumeration. */
@@ -1534,7 +1716,15 @@ export enum DwEngine {
   Mysql = 'MYSQL',
   Snowflake = 'SNOWFLAKE',
   Databricks = 'DATABRICKS',
-  Athena = 'ATHENA'
+  Athena = 'ATHENA',
+  Bigquery = 'BIGQUERY'
+}
+
+/** Enums to represent the status of the mql server deployment */
+export enum DeploymentStatus {
+  Paused = 'PAUSED',
+  Deploy = 'DEPLOY',
+  Never = 'NEVER'
 }
 
 export type MqlHeartbeat = {
@@ -1552,25 +1742,76 @@ export type MqlHeartbeat = {
   org?: Maybe<Organization>;
 };
 
+/** GQL object to represent configs for a given mql data warehouse. */
+export type DataWarehouseConfig = {
+  __typename?: 'DataWarehouseConfig';
+  host?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  database?: Maybe<Scalars['String']>;
+  port?: Maybe<Scalars['Int']>;
+  schema?: Maybe<Scalars['String']>;
+  query?: Maybe<Scalars['String']>;
+  dialect?: Maybe<Scalars['String']>;
+  isPasswordSet?: Maybe<Scalars['Boolean']>;
+};
+
 /** An enumeration. */
 export enum OrgMqlServerStrColumns {
+  Url = 'URL',
   ConfigSecret = 'CONFIG_SECRET',
-  Name = 'NAME',
-  Url = 'URL'
+  Name = 'NAME'
 }
 
 /** An enumeration. */
 export enum OrgMqlServerOrderBy {
-  ConfigSecret = 'CONFIG_SECRET',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  Url = 'URL',
-  OrganizationId = 'ORGANIZATION_ID',
-  UpdatedAt = 'UPDATED_AT',
   DwEngine = 'DW_ENGINE',
-  IsOrgDefault = 'IS_ORG_DEFAULT'
+  ConfigSecret = 'CONFIG_SECRET',
+  UpdatedAt = 'UPDATED_AT',
+  Name = 'NAME',
+  Url = 'URL',
+  IsOrgDefault = 'IS_ORG_DEFAULT',
+  DeploymentStatus = 'DEPLOYMENT_STATUS',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type OrgMqlServerOrderByInput = {
+  orderBy: OrgMqlServerOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+export type OrgPref = {
+  __typename?: 'OrgPref';
+  id: Scalars['ID'];
+  organizationId: Scalars['Int'];
+  prefKey: Scalars['String'];
+  prefValue: Scalars['String'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  organization?: Maybe<Organization>;
+};
+
+/** An enumeration. */
+export enum OrgPrefStrColumns {
+  PrefKey = 'PREF_KEY',
+  PrefValue = 'PREF_VALUE'
+}
+
+/** An enumeration. */
+export enum OrgPrefOrderBy {
+  Id = 'ID',
+  PrefValue = 'PREF_VALUE',
+  UpdatedAt = 'UPDATED_AT',
+  PrefKey = 'PREF_KEY',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
+}
+
+export type OrgPrefOrderByInput = {
+  orderBy: OrgPrefOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum MetricTier {
@@ -1594,12 +1835,17 @@ export enum FeatureStrColumns {
 
 /** An enumeration. */
 export enum FeatureOrderBy {
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT',
   RetiredAt = 'RETIRED_AT',
-  UpdatedAt = 'UPDATED_AT'
+  Name = 'NAME'
 }
+
+export type FeatureOrderByInput = {
+  orderBy: FeatureOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** Wrapper to contain queries related to transform settings & configs. */
 export type TransformConfig = {
@@ -1613,6 +1859,40 @@ export type TermsOfServiceVersion = {
   id: Scalars['ID'];
   pdfUrl: Scalars['String'];
   createdAt: Scalars['DateTime'];
+};
+
+export type MqlServerHealthItem = {
+  __typename?: 'MqlServerHealthItem';
+  name: Scalars['String'];
+  status: Scalars['String'];
+  errorMessage?: Maybe<Scalars['String']>;
+};
+
+/** GQL Input object for Snowflake connection details. */
+export type SnowflakeConnectionInput = {
+  host: Scalars['String'];
+  username: Scalars['String'];
+  password: Scalars['String'];
+  database: Scalars['String'];
+  schema: Scalars['String'];
+  warehouse?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+};
+
+/** GQL Input object for Redshift connection details. */
+export type RedshiftConnectionInput = {
+  host: Scalars['String'];
+  username: Scalars['String'];
+  password: Scalars['String'];
+  database: Scalars['String'];
+  schema: Scalars['String'];
+  port: Scalars['Int'];
+};
+
+/** GQL Input object for BigQuery connection details. */
+export type BigQueryConnectionInput = {
+  password: Scalars['String'];
+  schema: Scalars['String'];
 };
 
 /**
@@ -1652,6 +1932,8 @@ export type Mutation = {
   updateMqlServerConfig?: Maybe<UpdateMqlServerConfig>;
   /** Removes hosted MQL Server config using AWS Secrets Manager. */
   revokeMqlServerConfig?: Maybe<RevokeMqlServerConfig>;
+  /** Stores environment variables required to spin up the MQL server into AWS Secrets Manager. */
+  setMqlServerEnvConfig?: Maybe<SetMqlServerEnvConfig>;
   featuresCreate?: Maybe<Feature>;
   featuresUpdate?: Maybe<Feature>;
   featuresAddOrgs?: Maybe<Feature>;
@@ -1679,8 +1961,11 @@ export type Mutation = {
   teamsAssignAsMetricOwner?: Maybe<Team>;
   teamsRemoveAsMetricOwner?: Maybe<Team>;
   organizationsUpdate?: Maybe<Organization>;
+  organizationsCreateSharedSlack?: Maybe<Organization>;
+  organizationsCreateSamlConnection?: Maybe<Organization>;
   organizationsSetTierTooltip?: Maybe<Organization>;
   organizationsSetMfaPrefs?: Maybe<Organization>;
+  organizationsSetPref?: Maybe<Organization>;
   organizationsSetAllowedEmailDomains?: Maybe<Organization>;
   organizationsDelete?: Maybe<Organization>;
   metricsApprove?: Maybe<Metric>;
@@ -1699,6 +1984,7 @@ export type Mutation = {
   sendInvites?: Maybe<Organization>;
   acceptTermsOfService?: Maybe<User>;
   createTermsOfService?: Maybe<TermsOfServiceVersion>;
+  createSubscription?: Maybe<User>;
 };
 
 
@@ -1961,6 +2247,19 @@ export type MutationRevokeMqlServerConfigArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
+export type MutationSetMqlServerEnvConfigArgs = {
+  bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
+  redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
+  snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
 export type MutationFeaturesCreateArgs = {
   name: Scalars['String'];
 };
@@ -2173,6 +2472,7 @@ export type MutationOrgMqlServerUpdateArgs = {
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   configSecret?: Maybe<Scalars['String']>;
   dwEngine?: Maybe<Scalars['String']>;
+  deploymentStatus?: Maybe<Scalars['String']>;
 };
 
 
@@ -2200,6 +2500,7 @@ export type MutationOrgMqlServerCreateArgs = {
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   configSecret?: Maybe<Scalars['String']>;
   dwEngine?: Maybe<Scalars['String']>;
+  deploymentStatus?: Maybe<Scalars['String']>;
 };
 
 
@@ -2324,6 +2625,33 @@ export type MutationOrganizationsUpdateArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
+export type MutationOrganizationsCreateSharedSlackArgs = {
+  orgId: Scalars['ID'];
+  emails: Array<Maybe<Scalars['String']>>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationOrganizationsCreateSamlConnectionArgs = {
+  companyName: Scalars['String'];
+  signInUrl: Scalars['String'];
+  signingCertificate: Scalars['String'];
+  allowedEmailDomains: Array<Maybe<Scalars['String']>>;
+  orgId?: Maybe<Scalars['ID']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
 export type MutationOrganizationsSetTierTooltipArgs = {
   organizationId: Scalars['ID'];
   tooltip: Scalars['String'];
@@ -2340,6 +2668,19 @@ export type MutationOrganizationsSetTierTooltipArgs = {
 export type MutationOrganizationsSetMfaPrefsArgs = {
   organizationId: Scalars['ID'];
   mfaPref: MfaPref;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationOrganizationsSetPrefArgs = {
+  organizationId: Scalars['ID'];
+  prefKey: Scalars['String'];
+  prefValue: Scalars['String'];
 };
 
 
@@ -2419,6 +2760,7 @@ export type MutationTeamsLogViewArgs = {
 export type MutationMetricsAddUserOwnersArgs = {
   metricId: Scalars['ID'];
   userIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2431,6 +2773,7 @@ export type MutationMetricsAddUserOwnersArgs = {
 export type MutationMetricsRemoveUserOwnersArgs = {
   metricId: Scalars['ID'];
   userIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2443,6 +2786,7 @@ export type MutationMetricsRemoveUserOwnersArgs = {
 export type MutationMetricsAssignTeamOwnersArgs = {
   metricId: Scalars['ID'];
   teamIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2455,6 +2799,7 @@ export type MutationMetricsAssignTeamOwnersArgs = {
 export type MutationMetricsRemoveTeamOwnersArgs = {
   metricId: Scalars['ID'];
   teamIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2482,6 +2827,7 @@ export type MutationMetricsUpdateMetadataArgs = {
   tier?: Maybe<Scalars['Int']>;
   displayName?: Maybe<Scalars['String']>;
   valueFormat?: Maybe<Scalars['String']>;
+  increaseIsGood?: Maybe<Scalars['Boolean']>;
   extraFields?: Maybe<Scalars['JSONString']>;
 };
 
@@ -2559,6 +2905,18 @@ export type MutationAcceptTermsOfServiceArgs = {
  */
 export type MutationCreateTermsOfServiceArgs = {
   pdfUrl: Scalars['String'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationCreateSubscriptionArgs = {
+  userId: Scalars['ID'];
+  metricId: Scalars['ID'];
 };
 
 /** An enumeration. */
@@ -2684,6 +3042,12 @@ export type RevokeMqlServerConfig = {
   success?: Maybe<Scalars['Boolean']>;
 };
 
+/** Stores environment variables required to spin up the MQL server into AWS Secrets Manager. */
+export type SetMqlServerEnvConfig = {
+  __typename?: 'SetMqlServerEnvConfig';
+  success?: Maybe<Scalars['Boolean']>;
+};
+
 /** Graphene input object for a metric collection item. Essentially a dataclass. */
 export type MetricCollectionItem = {
   metricId?: Maybe<Scalars['ID']>;
@@ -2696,6 +3060,12 @@ export type MfaPref = {
   requireMfa: Scalars['Boolean'];
   allowMfaRememberBrowser: Scalars['Boolean'];
 };
+
+/** An enumeration. */
+export enum GOwnerType {
+  Business = 'business',
+  Technical = 'technical'
+}
 
 export type SetMqlServerMutationVariables = Exact<{
   newServerIdAsString: Scalars['String'];

--- a/mutations/mql/CreateLatestMetricChangeMutation.ts
+++ b/mutations/mql/CreateLatestMetricChangeMutation.ts
@@ -1,0 +1,20 @@
+import { gql } from "urql";
+
+const mutation = gql`
+  mutation CreateLatestMetricChange($metricName: String!) {
+    queryLatestMetricChange(input: {metricName: $metricName}) {
+      id
+      query {
+        status
+        result {
+          value
+          delta
+          pctChange
+        }
+
+      }
+    }
+  }
+`;
+
+export default mutation;

--- a/mutations/mql/CreatePercentChangeMutation.ts
+++ b/mutations/mql/CreatePercentChangeMutation.ts
@@ -1,0 +1,33 @@
+import { gql } from "urql";
+
+const mutation = gql`
+  mutation CreatePercentChange(
+    $metricName: String!
+    $startTime: String!
+    $endTime: String!
+  ) {
+    pctChangeOverRange(
+      input: {
+        metricName: $metricName
+        startTime: $startTime
+        endTime: $endTime
+      }
+    ) {
+      id
+      query {
+        id
+        status
+        error
+        chartValueMax
+        chartValueMin
+        result {
+          value
+          delta
+          pctChange
+        }
+      }
+    }
+  }
+`;
+
+export default mutation;

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -56,6 +56,7 @@ export type Query = {
   maxGranularityForMetrics?: Maybe<TimeGranularity>;
   queries?: Maybe<Array<Maybe<MqlQuery>>>;
   healthReport?: Maybe<Array<Maybe<MqlServerHealthItem>>>;
+  validations?: Maybe<Validations>;
 };
 
 
@@ -234,6 +235,16 @@ export type QueryQueriesArgs = {
   offset?: Maybe<Scalars['Int']>;
 };
 
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryValidationsArgs = {
+  modelKey?: Maybe<ModelKeyInput>;
+};
+
 /**
  * The MQL Query class is used to access the output of an MQL Query.
  *
@@ -331,6 +342,10 @@ export type MqlQueryResultSeries = {
   /** For queries without dimensional cuts, series_value will be `ALL`. For queries with dimensional cuts, one of these Result will be returned per dimension */
   seriesValue?: Maybe<Scalars['String']>;
   data?: Maybe<Array<ResultDatum>>;
+  isOtherCol?: Maybe<Scalars['Boolean']>;
+  value?: Maybe<Scalars['Float']>;
+  delta?: Maybe<Scalars['Float']>;
+  pctChange?: Maybe<Scalars['Float']>;
 };
 
 /** This interface is used to describe any type of MQL Query result data */
@@ -424,10 +439,12 @@ export type Metric = {
 
 export type MetricDimensionValuesArgs = {
   modelKey?: Maybe<ModelKeyInput>;
-  dimensionName?: Maybe<Scalars['String']>;
+  dimensionName: Scalars['String'];
   startTime?: Maybe<Scalars['String']>;
   endTime?: Maybe<Scalars['String']>;
   allowDynamicCache?: Maybe<Scalars['Boolean']>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -495,6 +512,12 @@ export type MqlServerHealthItem = {
   errorMessage?: Maybe<Scalars['String']>;
 };
 
+export type Validations = {
+  __typename?: 'Validations';
+  allIssues?: Maybe<Array<Scalars['String']>>;
+  dataSourceIssues?: Maybe<Array<Scalars['String']>>;
+};
+
 /** Base mutation object exposed by GraphQL. */
 export type Mutation = {
   __typename?: 'Mutation';
@@ -513,6 +536,10 @@ export type Mutation = {
   dropCache?: Maybe<DropCache>;
   /** Rewrites SQL containing an MQL(...) function invocation by expanding into generated SQL */
   rewriteMqlSql?: Maybe<RewriteMqlSql>;
+  /** For metric, get latest value, percent change from the previous granularity period, and delta between the two. */
+  queryLatestMetricChange?: Maybe<QueryLatestMetricChangePayload>;
+  /** Get percent change for given metric from start to end of date range (assuming daily granularity). */
+  pctChangeOverRange?: Maybe<PctChangeOverRangePayload>;
 };
 
 
@@ -554,6 +581,18 @@ export type MutationDropCacheArgs = {
 /** Base mutation object exposed by GraphQL. */
 export type MutationRewriteMqlSqlArgs = {
   sql: Scalars['String'];
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationQueryLatestMetricChangeArgs = {
+  input: QueryLatestMetricChangeInput;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationPctChangeOverRangeArgs = {
+  input: PctChangeOverRangeInput;
 };
 
 export type CreateMqlMaterializationNewPayload = {
@@ -675,10 +714,12 @@ export enum ResultFormat {
 
 /** An enumeration. */
 export enum PercentChange {
+  Dod = 'DOD',
   Wow = 'WOW',
   Mom = 'MOM',
   Qoq = 'QOQ',
-  Yoy = 'YOY'
+  Yoy = 'YOY',
+  DateRange = 'DATE_RANGE'
 }
 
 export type Materialize = {
@@ -699,12 +740,61 @@ export type RewriteMqlSql = {
   resultSql?: Maybe<Scalars['String']>;
 };
 
+/** For metric, get latest value, percent change from the previous granularity period, and delta between the two. */
+export type QueryLatestMetricChangePayload = {
+  __typename?: 'QueryLatestMetricChangePayload';
+  id: Scalars['ID'];
+  query?: Maybe<MqlQuery>;
+  clientMutationId?: Maybe<Scalars['String']>;
+};
+
+export type QueryLatestMetricChangeInput = {
+  metricName: Scalars['String'];
+  clientMutationId?: Maybe<Scalars['String']>;
+};
+
+/** Get percent change for given metric from start to end of date range (assuming daily granularity). */
+export type PctChangeOverRangePayload = {
+  __typename?: 'PctChangeOverRangePayload';
+  id: Scalars['ID'];
+  query?: Maybe<MqlQuery>;
+  clientMutationId?: Maybe<Scalars['String']>;
+};
+
+export type PctChangeOverRangeInput = {
+  metricName: Scalars['String'];
+  startTime: Scalars['String'];
+  endTime: Scalars['String'];
+  clientMutationId?: Maybe<Scalars['String']>;
+};
+
 /** MQL Query Result Data are expected to be plotted on a time series so this is the most common result type */
 export type TimeSeriesDatum = ResultDatum & {
   __typename?: 'TimeSeriesDatum';
   y?: Maybe<Scalars['GenericScalar']>;
   xDate: Scalars['DateTime'];
 };
+
+export type CreateLatestMetricChangeMutationVariables = Exact<{
+  metricName: Scalars['String'];
+}>;
+
+
+export type CreateLatestMetricChangeMutation = (
+  { __typename?: 'Mutation' }
+  & { queryLatestMetricChange?: Maybe<(
+    { __typename?: 'QueryLatestMetricChangePayload' }
+    & Pick<QueryLatestMetricChangePayload, 'id'>
+    & { query?: Maybe<(
+      { __typename?: 'MqlQuery' }
+      & Pick<MqlQuery, 'status'>
+      & { result?: Maybe<Array<(
+        { __typename?: 'MqlQueryResultSeries' }
+        & Pick<MqlQueryResultSeries, 'value' | 'delta' | 'pctChange'>
+      )>> }
+    )> }
+  )> }
+);
 
 export type CreateMqlQueryMutationVariables = Exact<{
   addTimeSeries?: Maybe<Scalars['Boolean']>;
@@ -729,6 +819,33 @@ export type CreateMqlQueryMutation = (
   & { createMqlQuery?: Maybe<(
     { __typename?: 'CreateMqlQueryPayload' }
     & Pick<CreateMqlQueryPayload, 'id'>
+    & { query?: Maybe<(
+      { __typename?: 'MqlQuery' }
+      & Pick<MqlQuery, 'id' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin'>
+      & { result?: Maybe<Array<(
+        { __typename?: 'MqlQueryResultSeries' }
+        & Pick<MqlQueryResultSeries, 'seriesValue'>
+        & { data?: Maybe<Array<(
+          { __typename?: 'TimeSeriesDatum' }
+          & Pick<TimeSeriesDatum, 'xDate' | 'y'>
+        )>> }
+      )>> }
+    )> }
+  )> }
+);
+
+export type CreatePercentChangeMutationVariables = Exact<{
+  metricName: Scalars['String'];
+  startTime: Scalars['String'];
+  endTime: Scalars['String'];
+}>;
+
+
+export type CreatePercentChangeMutation = (
+  { __typename?: 'Mutation' }
+  & { pctChangeOverRange?: Maybe<(
+    { __typename?: 'PctChangeOverRangePayload' }
+    & Pick<PctChangeOverRangePayload, 'id'>
     & { query?: Maybe<(
       { __typename?: 'MqlQuery' }
       & Pick<MqlQuery, 'id' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin'>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -59,6 +59,7 @@ export type Query = {
   boom?: Maybe<Scalars['Boolean']>;
   transformConfig?: Maybe<TransformConfig>;
   emailCanSignUp?: Maybe<Scalars['Boolean']>;
+  dwHealthCheck?: Maybe<Array<Maybe<MqlServerHealthItem>>>;
 };
 
 
@@ -80,10 +81,11 @@ export type QueryAuth0ProfileArgs = {
 export type QueryAllFeaturesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<FeatureStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<FeatureOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<FeatureOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -95,10 +97,11 @@ export type QueryAllFeaturesArgs = {
 export type QueryAllOrganizationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<OrganizationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<OrganizationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrganizationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -139,6 +142,18 @@ export type QueryBoomArgs = {
  */
 export type QueryEmailCanSignUpArgs = {
   email: Scalars['String'];
+};
+
+
+/**
+ * Base Query object exposed by GraphQL.
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryDwHealthCheckArgs = {
+  snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
+  redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
+  bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
 };
 
 /** A wrapper for the response we get from Auth0's user profile API */
@@ -187,6 +202,7 @@ export type Organization = {
   mqlHeartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   currentModel?: Maybe<Array<Maybe<Model>>>;
   teams?: Maybe<Array<Maybe<Team>>>;
+  prefs?: Maybe<Array<Maybe<OrgPref>>>;
   apiKeys?: Maybe<Array<Maybe<ApiKey>>>;
   metricViews?: Maybe<Array<Maybe<MetricView>>>;
   savedQueries?: Maybe<Array<Maybe<SavedQuery>>>;
@@ -221,6 +237,12 @@ export type Organization = {
   allowedEmailDomains?: Maybe<Array<Maybe<Scalars['String']>>>;
   tierTooltips?: Maybe<Scalars['GenericScalar']>;
   activeOrgAdmins?: Maybe<Array<Maybe<User>>>;
+  mqlServerConfig?: Maybe<DataWarehouseConfig>;
+  incompleteOnboardingTasks?: Maybe<Array<Maybe<Scalars['String']>>>;
+  samlConnectionName?: Maybe<Scalars['String']>;
+  sharedSlackChannelName?: Maybe<Scalars['String']>;
+  primaryMqlServer?: Maybe<OrgMqlServer>;
+  annotationsFeed?: Maybe<Array<Maybe<Annotation>>>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -229,20 +251,22 @@ export type OrganizationUsersArgs = {
   activeOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationMqlServersArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<OrgMqlServerStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<OrgMqlServerOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrgMqlServerOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -254,40 +278,56 @@ export type OrganizationModelsArgs = {
 export type OrganizationTeamsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationPrefsArgs = {
+  prefKey?: Maybe<Scalars['String']>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<OrgPrefStrColumns>>>;
+  orderBy?: Maybe<OrgPrefOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrgPrefOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationQuestionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -299,30 +339,33 @@ export type OrganizationQuestionArgs = {
 export type OrganizationAnnotationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<AnnotationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationRecentQuestionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type OrganizationRecentAnnotationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<AnnotationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -332,10 +375,11 @@ export type OrganizationMetricsArgs = {
   types?: Maybe<Array<Maybe<MetricType>>>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -345,6 +389,13 @@ export type OrganizationTotalMetricsArgs = {
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
+};
+
+
+export type OrganizationTotalUsersArgs = {
+  activeOnly?: Maybe<Scalars['Boolean']>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
 };
 
 
@@ -386,10 +437,22 @@ export type OrganizationTierTooltipsArgs = {
 export type OrganizationActiveOrgAdminsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationMqlServerConfigArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type OrganizationAnnotationsFeedArgs = {
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 /** An enumeration. */
@@ -440,9 +503,14 @@ export type User = {
   totalViewedMetricCollections?: Maybe<Scalars['Int']>;
   totalActiveFeatures?: Maybe<Scalars['Int']>;
   hasAcceptedLatestTermsOfService?: Maybe<Scalars['Boolean']>;
+  acceptedTermsOfService?: Maybe<Scalars['Int']>;
+  totalFeaturedMetrics?: Maybe<Scalars['Int']>;
+  totalSubscribedMetrics?: Maybe<Scalars['Int']>;
   viewedMetrics?: Maybe<Array<Maybe<Metric>>>;
   newMetrics?: Maybe<Array<Maybe<Metric>>>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
+  featuredMetrics?: Maybe<Array<Maybe<Metric>>>;
+  subscribedMetrics?: Maybe<Array<Maybe<Metric>>>;
 };
 
 
@@ -450,10 +518,11 @@ export type UserTeamsArgs = {
   isAdminOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -461,70 +530,89 @@ export type UserApiKeysArgs = {
   activeOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<ApiKeyStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<ApiKeyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<ApiKeyOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserViewedTeamsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserViewedMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserViewedMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type UserNewMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type UserFeaturedMetricsArgs = {
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type UserSubscribedMetricsArgs = {
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type UserRole = {
@@ -591,40 +679,44 @@ export type Team = {
 
 
 export type TeamMembersArgs = {
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamMemberOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamMemberOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type TeamSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type TeamMetricCollectionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricCollectionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type TeamMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type TeamMember = {
@@ -642,22 +734,27 @@ export type TeamMember = {
 
 /** An enumeration. */
 export enum TeamMemberOrderBy {
-  JoinedAt = 'JOINED_AT',
+  TeamId = 'TEAM_ID',
   UserId = 'USER_ID',
   IsTeamAdmin = 'IS_TEAM_ADMIN',
-  TeamId = 'TEAM_ID',
-  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
+  JoinedAt = 'JOINED_AT',
   TeamMemberId = 'TeamMember_ID',
+  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
   UserOrganizationId = 'User_ORGANIZATION_ID',
-  AvatarUrl = 'AVATAR_URL',
-  CreatedAt = 'CREATED_AT',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UserName = 'USER_NAME',
   Email = 'EMAIL',
   UpdatedAt = 'UPDATED_AT',
-  UserName = 'USER_NAME',
   DeactivatedAt = 'DEACTIVATED_AT',
+  AvatarUrl = 'AVATAR_URL',
   Auth0Id = 'AUTH0_ID',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  CreatedAt = 'CREATED_AT'
 }
+
+export type TeamMemberOrderByInput = {
+  orderBy: TeamMemberOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type Dashboard = {
   __typename?: 'Dashboard';
@@ -730,18 +827,20 @@ export type MetricCollection = {
 
 
 export type MetricCollectionItemsArgs = {
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionMetricOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionMetricOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricCollectionCollectionItemsArgs = {
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricCollectionMetricOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricCollectionMetricOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type MetricCollectionView = {
@@ -793,9 +892,16 @@ export type MetricUserOwner = {
   userId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
   isLocked: Scalars['Boolean'];
+  ownerType: OwnerType;
   user?: Maybe<User>;
   organization?: Maybe<Organization>;
 };
+
+/** An enumeration. */
+export enum OwnerType {
+  Business = 'BUSINESS',
+  Technical = 'TECHNICAL'
+}
 
 export type MetricTeamOwner = {
   __typename?: 'MetricTeamOwner';
@@ -805,6 +911,7 @@ export type MetricTeamOwner = {
   createdTs?: Maybe<Scalars['Int']>;
   orgMetricId: Scalars['Int'];
   createdAt?: Maybe<Scalars['DateTime']>;
+  ownerType: OwnerType;
   team?: Maybe<Team>;
   organization?: Maybe<Organization>;
 };
@@ -843,6 +950,7 @@ export type Metric = {
   displayNameWithLock?: Maybe<LockableParameter>;
   descriptionWithLock?: Maybe<LockableParameter>;
   valueFormatWithLock?: Maybe<LockableParameter>;
+  increaseIsGoodWithLock?: Maybe<LockableParameter>;
   latestApproval?: Maybe<MetricApproval>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
   currentDescription?: Maybe<Scalars['String']>;
@@ -868,10 +976,11 @@ export type Metric = {
 export type MetricQuestionsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -882,50 +991,55 @@ export type MetricAnnotationsArgs = {
   priorities?: Maybe<Array<Maybe<Priority>>>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<AnnotationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricDataSourcesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<DataSourceVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<DataSourceVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<DataSourceVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<SavedQueryOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<SavedQueryOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricOwnerTeamsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<TeamStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<TeamOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type MetricOwnerUsersArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -1021,10 +1135,11 @@ export type Question = {
 export type QuestionRepliesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<QuestionReplyStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<QuestionReplyOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<QuestionReplyOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 export type QuestionReply = {
@@ -1050,36 +1165,46 @@ export enum QuestionReplyStrColumns {
 
 /** An enumeration. */
 export enum QuestionReplyOrderBy {
-  AuthorId = 'AUTHOR_ID',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  OrganizationId = 'ORGANIZATION_ID',
+  Text = 'TEXT',
   QuestionId = 'QUESTION_ID',
   UpdatedAt = 'UPDATED_AT',
-  Text = 'TEXT'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
+  AuthorId = 'AUTHOR_ID'
 }
+
+export type QuestionReplyOrderByInput = {
+  orderBy: QuestionReplyOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum QuestionStrColumns {
-  Priority = 'PRIORITY',
-  Text = 'TEXT'
+  Text = 'TEXT',
+  Priority = 'PRIORITY'
 }
 
 /** An enumeration. */
 export enum QuestionOrderBy {
+  Id = 'ID',
   ResolvedAt = 'RESOLVED_AT',
   ResolvedBy = 'RESOLVED_BY',
-  AuthorId = 'AUTHOR_ID',
-  CreatedAt = 'CREATED_AT',
-  Id = 'ID',
-  OrganizationId = 'ORGANIZATION_ID',
-  NotifiedAt = 'NOTIFIED_AT',
-  MetricId = 'METRIC_ID',
   Text = 'TEXT',
   UpdatedAt = 'UPDATED_AT',
+  AuthorId = 'AUTHOR_ID',
+  Priority = 'PRIORITY',
+  NotifiedAt = 'NOTIFIED_AT',
+  MetricId = 'METRIC_ID',
   Resolved = 'RESOLVED',
-  Priority = 'PRIORITY'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type QuestionOrderByInput = {
+  orderBy: QuestionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type LockableParameter = {
   __typename?: 'LockableParameter';
@@ -1161,58 +1286,68 @@ export enum Priority {
 
 /** An enumeration. */
 export enum AnnotationStrColumns {
-  Priority = 'PRIORITY',
-  Title = 'TITLE',
   ExpectedImpact = 'EXPECTED_IMPACT',
-  Text = 'TEXT'
+  Text = 'TEXT',
+  Priority = 'PRIORITY',
+  Title = 'TITLE'
 }
 
 /** An enumeration. */
 export enum AnnotationOrderBy {
-  AuthorId = 'AUTHOR_ID',
-  DateEndedAt = 'DATE_ENDED_AT',
   Id = 'ID',
-  ExpectedImpact = 'EXPECTED_IMPACT',
-  CreatedAt = 'CREATED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
-  NotifiedAt = 'NOTIFIED_AT',
   Text = 'TEXT',
-  UpdatedAt = 'UPDATED_AT',
-  Title = 'TITLE',
-  DateStartedAt = 'DATE_STARTED_AT',
   DeletedAt = 'DELETED_AT',
-  Priority = 'PRIORITY'
+  UpdatedAt = 'UPDATED_AT',
+  DateStartedAt = 'DATE_STARTED_AT',
+  AuthorId = 'AUTHOR_ID',
+  ExpectedImpact = 'EXPECTED_IMPACT',
+  Priority = 'PRIORITY',
+  DateEndedAt = 'DATE_ENDED_AT',
+  NotifiedAt = 'NOTIFIED_AT',
+  Title = 'TITLE',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type AnnotationOrderByInput = {
+  orderBy: AnnotationOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum DataSourceVersionStrColumns {
-  Connection = 'CONNECTION',
-  Hash = 'HASH',
   SqlTable = 'SQL_TABLE',
-  Name = 'NAME',
+  Hash = 'HASH',
   SqlQuery = 'SQL_QUERY',
-  Description = 'DESCRIPTION'
+  Connection = 'CONNECTION',
+  Description = 'DESCRIPTION',
+  Name = 'NAME'
 }
 
 /** An enumeration. */
 export enum DataSourceVersionOrderBy {
-  DataSourceMetadata = 'DATA_SOURCE_METADATA',
-  Name = 'NAME',
-  Identifiers = 'IDENTIFIERS',
-  CreatedAt = 'CREATED_AT',
-  SqlQuery = 'SQL_QUERY',
-  OrganizationId = 'ORGANIZATION_ID',
-  Connection = 'CONNECTION',
-  SqlTable = 'SQL_TABLE',
-  Dimensions = 'DIMENSIONS',
   Id = 'ID',
   Description = 'DESCRIPTION',
-  Mutability = 'MUTABILITY',
-  Hash = 'HASH',
+  Connection = 'CONNECTION',
+  Dimensions = 'DIMENSIONS',
+  Name = 'NAME',
+  SqlTable = 'SQL_TABLE',
   Constraint = 'CONSTRAINT',
+  Identifiers = 'IDENTIFIERS',
+  SqlQuery = 'SQL_QUERY',
+  Owners = 'OWNERS',
+  Hash = 'HASH',
+  DataSourceMetadata = 'DATA_SOURCE_METADATA',
   Measures = 'MEASURES',
-  Owners = 'OWNERS'
+  Mutability = 'MUTABILITY',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type DataSourceVersionOrderByInput = {
+  orderBy: DataSourceVersionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type SavedQuery = {
   __typename?: 'SavedQuery';
@@ -1237,49 +1372,57 @@ export type SavedQuery = {
 export type SavedQueryMetricsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<MetricVersionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<MetricVersionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 /** An enumeration. */
 export enum MetricVersionStrColumns {
   Description = 'DESCRIPTION',
-  Hash = 'HASH',
   DisplayName = 'DISPLAY_NAME',
+  Hash = 'HASH',
   ValueFormat = 'VALUE_FORMAT'
 }
 
 /** An enumeration. */
 export enum MetricVersionOrderBy {
   Id = 'ID',
-  MetricType = 'METRIC_TYPE',
-  SourceDataSourceVersions = 'SOURCE_DATA_SOURCE_VERSIONS',
-  Params = 'PARAMS',
-  Description = 'DESCRIPTION',
-  OrganizationId = 'ORGANIZATION_ID',
-  OrgDataSourceId = 'ORG_DATA_SOURCE_ID',
-  Views = 'VIEWS',
-  Tier = 'TIER',
   Hash = 'HASH',
+  Description = 'DESCRIPTION',
+  OrgDataSourceId = 'ORG_DATA_SOURCE_ID',
   Metadata = 'METADATA',
+  Tier = 'TIER',
+  SourceDataSourceVersions = 'SOURCE_DATA_SOURCE_VERSIONS',
   DisplayName = 'DISPLAY_NAME',
-  MetricVersionCreatedAt = 'MetricVersion_CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
+  Params = 'PARAMS',
+  Views = 'VIEWS',
+  MetricType = 'METRIC_TYPE',
   MetricVersionMetricId = 'MetricVersion_METRIC_ID',
-  MetricMetadataCreatedAt = 'MetricMetadata_CREATED_AT',
+  MetricVersionCreatedAt = 'MetricVersion_CREATED_AT',
   MetricMetadataMetricId = 'MetricMetadata_METRIC_ID',
-  ExtraFields = 'EXTRA_FIELDS',
-  UpdatedBy = 'UPDATED_BY',
-  TierLock = 'TIER_LOCK',
-  ValueFormatLock = 'VALUE_FORMAT_LOCK',
+  MetricMetadataCreatedAt = 'MetricMetadata_CREATED_AT',
+  IncreaseIsGoodLock = 'INCREASE_IS_GOOD_LOCK',
   CreatedBy = 'CREATED_BY',
-  ValueFormat = 'VALUE_FORMAT',
   UpdatedAt = 'UPDATED_AT',
   DescriptionLock = 'DESCRIPTION_LOCK',
   DisplayNameLock = 'DISPLAY_NAME_LOCK',
-  IsNew = 'IS_NEW'
+  ExtraFields = 'EXTRA_FIELDS',
+  IsNew = 'IS_NEW',
+  ValueFormat = 'VALUE_FORMAT',
+  IncreaseIsGood = 'INCREASE_IS_GOOD',
+  ValueFormatLock = 'VALUE_FORMAT_LOCK',
+  TierLock = 'TIER_LOCK',
+  UpdatedBy = 'UPDATED_BY'
 }
+
+export type MetricVersionOrderByInput = {
+  orderBy: MetricVersionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum SavedQueryStrColumns {
@@ -1288,75 +1431,95 @@ export enum SavedQueryStrColumns {
 
 /** An enumeration. */
 export enum SavedQueryOrderBy {
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  SerializedQuery = 'SERIALIZED_QUERY',
-  OrganizationId = 'ORGANIZATION_ID',
+  DeletedAt = 'DELETED_AT',
+  OwnerTeamId = 'OWNER_TEAM_ID',
   CreatedBy = 'CREATED_BY',
   UpdatedAt = 'UPDATED_AT',
   Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
-  OwnerTeamId = 'OWNER_TEAM_ID'
+  SerializedQuery = 'SERIALIZED_QUERY',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type SavedQueryOrderByInput = {
+  orderBy: SavedQueryOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum TeamStrColumns {
-  Theme = 'THEME',
   Description = 'DESCRIPTION',
+  Slug = 'SLUG',
   Name = 'NAME',
-  Slug = 'SLUG'
+  Theme = 'THEME'
 }
 
 /** An enumeration. */
 export enum TeamOrderBy {
+  Id = 'ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  CreatedBy = 'CREATED_BY',
+  UpdatedAt = 'UPDATED_AT',
+  Description = 'DESCRIPTION',
+  DeactivatedAt = 'DEACTIVATED_AT',
   Theme = 'THEME',
   Name = 'NAME',
-  Id = 'ID',
-  CreatedAt = 'CREATED_AT',
-  Description = 'DESCRIPTION',
-  OrganizationId = 'ORGANIZATION_ID',
-  CreatedBy = 'CREATED_BY',
+  FeaturedMetricCollectionId = 'FEATURED_METRIC_COLLECTION_ID',
   Views = 'VIEWS',
   Slug = 'SLUG',
-  UpdatedAt = 'UPDATED_AT',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  FeaturedMetricCollectionId = 'FEATURED_METRIC_COLLECTION_ID',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type TeamOrderByInput = {
+  orderBy: TeamOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum UserStrColumns {
   AvatarUrl = 'AVATAR_URL',
+  UserName = 'USER_NAME',
   Email = 'EMAIL',
-  Auth0Id = 'AUTH0_ID',
-  UserName = 'USER_NAME'
+  Auth0Id = 'AUTH0_ID'
 }
 
 /** An enumeration. */
 export enum UserOrderBy {
-  AvatarUrl = 'AVATAR_URL',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  OrganizationId = 'ORGANIZATION_ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UserName = 'USER_NAME',
   Email = 'EMAIL',
   UpdatedAt = 'UPDATED_AT',
-  UserName = 'USER_NAME',
   DeactivatedAt = 'DEACTIVATED_AT',
+  AvatarUrl = 'AVATAR_URL',
   Auth0Id = 'AUTH0_ID',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type UserOrderByInput = {
+  orderBy: UserOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum MetricCollectionMetricOrderBy {
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  MetricId = 'METRIC_ID',
-  UpdatedAt = 'UPDATED_AT',
-  Emphasis = 'EMPHASIS',
   MetricCollectionId = 'METRIC_COLLECTION_ID',
   SavedQueryId = 'SAVED_QUERY_ID',
-  Position = 'POSITION'
+  UpdatedAt = 'UPDATED_AT',
+  Position = 'POSITION',
+  Emphasis = 'EMPHASIS',
+  MetricId = 'METRIC_ID',
+  CreatedAt = 'CREATED_AT'
 }
+
+export type MetricCollectionMetricOrderByInput = {
+  orderBy: MetricCollectionMetricOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type CollectionItem = {
   __typename?: 'CollectionItem';
@@ -1390,26 +1553,31 @@ export type TeamView = {
 /** An enumeration. */
 export enum MetricCollectionStrColumns {
   Description = 'DESCRIPTION',
-  Title = 'TITLE',
-  Slug = 'SLUG'
+  Slug = 'SLUG',
+  Title = 'TITLE'
 }
 
 /** An enumeration. */
 export enum MetricCollectionOrderBy {
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  Description = 'DESCRIPTION',
-  OrganizationId = 'ORGANIZATION_ID',
-  CreatedBy = 'CREATED_BY',
-  Views = 'VIEWS',
-  Slug = 'SLUG',
-  UpdatedAt = 'UPDATED_AT',
-  Title = 'TITLE',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   DeletedAt = 'DELETED_AT',
   OwnerTeamId = 'OWNER_TEAM_ID',
+  CreatedBy = 'CREATED_BY',
+  UpdatedAt = 'UPDATED_AT',
+  Description = 'DESCRIPTION',
   DefaultEmphasis = 'DEFAULT_EMPHASIS',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID'
+  Views = 'VIEWS',
+  Title = 'TITLE',
+  Slug = 'SLUG',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type MetricCollectionOrderByInput = {
+  orderBy: MetricCollectionOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type ApiKey = {
   __typename?: 'ApiKey';
@@ -1431,24 +1599,29 @@ export type ApiKey = {
 /** An enumeration. */
 export enum ApiKeyStrColumns {
   Type = 'TYPE',
-  SecretHash = 'SECRET_HASH',
   Scope = 'SCOPE',
-  Prefix = 'PREFIX'
+  Prefix = 'PREFIX',
+  SecretHash = 'SECRET_HASH'
 }
 
 /** An enumeration. */
 export enum ApiKeyOrderBy {
-  Type = 'TYPE',
-  SecretHash = 'SECRET_HASH',
-  CreatedAt = 'CREATED_AT',
-  RevokedAt = 'REVOKED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
-  Scope = 'SCOPE',
-  UserId = 'USER_ID',
-  LastUsedAt = 'LAST_USED_AT',
+  Prefix = 'PREFIX',
   RevokerId = 'REVOKER_ID',
-  Prefix = 'PREFIX'
+  UserId = 'USER_ID',
+  SecretHash = 'SECRET_HASH',
+  LastUsedAt = 'LAST_USED_AT',
+  Scope = 'SCOPE',
+  Type = 'TYPE',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
+  RevokedAt = 'REVOKED_AT'
 }
+
+export type ApiKeyOrderByInput = {
+  orderBy: ApiKeyOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type Feature = {
   __typename?: 'Feature';
@@ -1467,47 +1640,54 @@ export type Feature = {
 export type FeatureOrganizationsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<OrganizationStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<OrganizationOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<OrganizationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 
 export type FeatureUsersArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<UserStrColumns>>>;
-  pageNumber?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<UserOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<UserOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
 };
 
 /** An enumeration. */
 export enum OrganizationStrColumns {
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  Name = 'NAME',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
   LogoUrl = 'LOGO_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
   PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO'
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  Name = 'NAME'
 }
 
 /** An enumeration. */
 export enum OrganizationOrderBy {
-  Type = 'TYPE',
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  Name = 'NAME',
   Id = 'ID',
-  CreatedAt = 'CREATED_AT',
-  IsHosted = 'IS_HOSTED',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  UpdatedAt = 'UPDATED_AT',
   LogoUrl = 'LOGO_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
+  UpdatedAt = 'UPDATED_AT',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
-  DeactivatedAt = 'DEACTIVATED_AT'
+  DeactivatedAt = 'DEACTIVATED_AT',
+  Name = 'NAME',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  IsHosted = 'IS_HOSTED',
+  Type = 'TYPE',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  CreatedAt = 'CREATED_AT'
 }
+
+export type OrganizationOrderByInput = {
+  orderBy: OrganizationOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 export type OrgMqlServer = {
   __typename?: 'OrgMqlServer';
@@ -1520,9 +1700,11 @@ export type OrgMqlServer = {
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   configSecret?: Maybe<Scalars['String']>;
   dwEngine?: Maybe<DwEngine>;
+  deploymentStatus?: Maybe<DeploymentStatus>;
   heartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   organization?: Maybe<Organization>;
   latestHeartbeat?: Maybe<MqlHeartbeat>;
+  dwConfig?: Maybe<DataWarehouseConfig>;
 };
 
 /** An enumeration. */
@@ -1534,7 +1716,15 @@ export enum DwEngine {
   Mysql = 'MYSQL',
   Snowflake = 'SNOWFLAKE',
   Databricks = 'DATABRICKS',
-  Athena = 'ATHENA'
+  Athena = 'ATHENA',
+  Bigquery = 'BIGQUERY'
+}
+
+/** Enums to represent the status of the mql server deployment */
+export enum DeploymentStatus {
+  Paused = 'PAUSED',
+  Deploy = 'DEPLOY',
+  Never = 'NEVER'
 }
 
 export type MqlHeartbeat = {
@@ -1552,25 +1742,76 @@ export type MqlHeartbeat = {
   org?: Maybe<Organization>;
 };
 
+/** GQL object to represent configs for a given mql data warehouse. */
+export type DataWarehouseConfig = {
+  __typename?: 'DataWarehouseConfig';
+  host?: Maybe<Scalars['String']>;
+  username?: Maybe<Scalars['String']>;
+  database?: Maybe<Scalars['String']>;
+  port?: Maybe<Scalars['Int']>;
+  schema?: Maybe<Scalars['String']>;
+  query?: Maybe<Scalars['String']>;
+  dialect?: Maybe<Scalars['String']>;
+  isPasswordSet?: Maybe<Scalars['Boolean']>;
+};
+
 /** An enumeration. */
 export enum OrgMqlServerStrColumns {
+  Url = 'URL',
   ConfigSecret = 'CONFIG_SECRET',
-  Name = 'NAME',
-  Url = 'URL'
+  Name = 'NAME'
 }
 
 /** An enumeration. */
 export enum OrgMqlServerOrderBy {
-  ConfigSecret = 'CONFIG_SECRET',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
-  Url = 'URL',
-  OrganizationId = 'ORGANIZATION_ID',
-  UpdatedAt = 'UPDATED_AT',
   DwEngine = 'DW_ENGINE',
-  IsOrgDefault = 'IS_ORG_DEFAULT'
+  ConfigSecret = 'CONFIG_SECRET',
+  UpdatedAt = 'UPDATED_AT',
+  Name = 'NAME',
+  Url = 'URL',
+  IsOrgDefault = 'IS_ORG_DEFAULT',
+  DeploymentStatus = 'DEPLOYMENT_STATUS',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
 }
+
+export type OrgMqlServerOrderByInput = {
+  orderBy: OrgMqlServerOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+export type OrgPref = {
+  __typename?: 'OrgPref';
+  id: Scalars['ID'];
+  organizationId: Scalars['Int'];
+  prefKey: Scalars['String'];
+  prefValue: Scalars['String'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  organization?: Maybe<Organization>;
+};
+
+/** An enumeration. */
+export enum OrgPrefStrColumns {
+  PrefKey = 'PREF_KEY',
+  PrefValue = 'PREF_VALUE'
+}
+
+/** An enumeration. */
+export enum OrgPrefOrderBy {
+  Id = 'ID',
+  PrefValue = 'PREF_VALUE',
+  UpdatedAt = 'UPDATED_AT',
+  PrefKey = 'PREF_KEY',
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID'
+}
+
+export type OrgPrefOrderByInput = {
+  orderBy: OrgPrefOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** An enumeration. */
 export enum MetricTier {
@@ -1594,12 +1835,17 @@ export enum FeatureStrColumns {
 
 /** An enumeration. */
 export enum FeatureOrderBy {
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT',
   Id = 'ID',
+  CreatedAt = 'CREATED_AT',
+  UpdatedAt = 'UPDATED_AT',
   RetiredAt = 'RETIRED_AT',
-  UpdatedAt = 'UPDATED_AT'
+  Name = 'NAME'
 }
+
+export type FeatureOrderByInput = {
+  orderBy: FeatureOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** Wrapper to contain queries related to transform settings & configs. */
 export type TransformConfig = {
@@ -1613,6 +1859,40 @@ export type TermsOfServiceVersion = {
   id: Scalars['ID'];
   pdfUrl: Scalars['String'];
   createdAt: Scalars['DateTime'];
+};
+
+export type MqlServerHealthItem = {
+  __typename?: 'MqlServerHealthItem';
+  name: Scalars['String'];
+  status: Scalars['String'];
+  errorMessage?: Maybe<Scalars['String']>;
+};
+
+/** GQL Input object for Snowflake connection details. */
+export type SnowflakeConnectionInput = {
+  host: Scalars['String'];
+  username: Scalars['String'];
+  password: Scalars['String'];
+  database: Scalars['String'];
+  schema: Scalars['String'];
+  warehouse?: Maybe<Scalars['String']>;
+  role?: Maybe<Scalars['String']>;
+};
+
+/** GQL Input object for Redshift connection details. */
+export type RedshiftConnectionInput = {
+  host: Scalars['String'];
+  username: Scalars['String'];
+  password: Scalars['String'];
+  database: Scalars['String'];
+  schema: Scalars['String'];
+  port: Scalars['Int'];
+};
+
+/** GQL Input object for BigQuery connection details. */
+export type BigQueryConnectionInput = {
+  password: Scalars['String'];
+  schema: Scalars['String'];
 };
 
 /**
@@ -1652,6 +1932,8 @@ export type Mutation = {
   updateMqlServerConfig?: Maybe<UpdateMqlServerConfig>;
   /** Removes hosted MQL Server config using AWS Secrets Manager. */
   revokeMqlServerConfig?: Maybe<RevokeMqlServerConfig>;
+  /** Stores environment variables required to spin up the MQL server into AWS Secrets Manager. */
+  setMqlServerEnvConfig?: Maybe<SetMqlServerEnvConfig>;
   featuresCreate?: Maybe<Feature>;
   featuresUpdate?: Maybe<Feature>;
   featuresAddOrgs?: Maybe<Feature>;
@@ -1679,8 +1961,11 @@ export type Mutation = {
   teamsAssignAsMetricOwner?: Maybe<Team>;
   teamsRemoveAsMetricOwner?: Maybe<Team>;
   organizationsUpdate?: Maybe<Organization>;
+  organizationsCreateSharedSlack?: Maybe<Organization>;
+  organizationsCreateSamlConnection?: Maybe<Organization>;
   organizationsSetTierTooltip?: Maybe<Organization>;
   organizationsSetMfaPrefs?: Maybe<Organization>;
+  organizationsSetPref?: Maybe<Organization>;
   organizationsSetAllowedEmailDomains?: Maybe<Organization>;
   organizationsDelete?: Maybe<Organization>;
   metricsApprove?: Maybe<Metric>;
@@ -1699,6 +1984,7 @@ export type Mutation = {
   sendInvites?: Maybe<Organization>;
   acceptTermsOfService?: Maybe<User>;
   createTermsOfService?: Maybe<TermsOfServiceVersion>;
+  createSubscription?: Maybe<User>;
 };
 
 
@@ -1961,6 +2247,19 @@ export type MutationRevokeMqlServerConfigArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
+export type MutationSetMqlServerEnvConfigArgs = {
+  bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
+  redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
+  snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
 export type MutationFeaturesCreateArgs = {
   name: Scalars['String'];
 };
@@ -2173,6 +2472,7 @@ export type MutationOrgMqlServerUpdateArgs = {
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   configSecret?: Maybe<Scalars['String']>;
   dwEngine?: Maybe<Scalars['String']>;
+  deploymentStatus?: Maybe<Scalars['String']>;
 };
 
 
@@ -2200,6 +2500,7 @@ export type MutationOrgMqlServerCreateArgs = {
   isOrgDefault?: Maybe<Scalars['Boolean']>;
   configSecret?: Maybe<Scalars['String']>;
   dwEngine?: Maybe<Scalars['String']>;
+  deploymentStatus?: Maybe<Scalars['String']>;
 };
 
 
@@ -2324,6 +2625,33 @@ export type MutationOrganizationsUpdateArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
+export type MutationOrganizationsCreateSharedSlackArgs = {
+  orgId: Scalars['ID'];
+  emails: Array<Maybe<Scalars['String']>>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationOrganizationsCreateSamlConnectionArgs = {
+  companyName: Scalars['String'];
+  signInUrl: Scalars['String'];
+  signingCertificate: Scalars['String'];
+  allowedEmailDomains: Array<Maybe<Scalars['String']>>;
+  orgId?: Maybe<Scalars['ID']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
 export type MutationOrganizationsSetTierTooltipArgs = {
   organizationId: Scalars['ID'];
   tooltip: Scalars['String'];
@@ -2340,6 +2668,19 @@ export type MutationOrganizationsSetTierTooltipArgs = {
 export type MutationOrganizationsSetMfaPrefsArgs = {
   organizationId: Scalars['ID'];
   mfaPref: MfaPref;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationOrganizationsSetPrefArgs = {
+  organizationId: Scalars['ID'];
+  prefKey: Scalars['String'];
+  prefValue: Scalars['String'];
 };
 
 
@@ -2419,6 +2760,7 @@ export type MutationTeamsLogViewArgs = {
 export type MutationMetricsAddUserOwnersArgs = {
   metricId: Scalars['ID'];
   userIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2431,6 +2773,7 @@ export type MutationMetricsAddUserOwnersArgs = {
 export type MutationMetricsRemoveUserOwnersArgs = {
   metricId: Scalars['ID'];
   userIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2443,6 +2786,7 @@ export type MutationMetricsRemoveUserOwnersArgs = {
 export type MutationMetricsAssignTeamOwnersArgs = {
   metricId: Scalars['ID'];
   teamIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2455,6 +2799,7 @@ export type MutationMetricsAssignTeamOwnersArgs = {
 export type MutationMetricsRemoveTeamOwnersArgs = {
   metricId: Scalars['ID'];
   teamIds?: Maybe<Array<Maybe<Scalars['ID']>>>;
+  ownerType?: Maybe<GOwnerType>;
 };
 
 
@@ -2482,6 +2827,7 @@ export type MutationMetricsUpdateMetadataArgs = {
   tier?: Maybe<Scalars['Int']>;
   displayName?: Maybe<Scalars['String']>;
   valueFormat?: Maybe<Scalars['String']>;
+  increaseIsGood?: Maybe<Scalars['Boolean']>;
   extraFields?: Maybe<Scalars['JSONString']>;
 };
 
@@ -2559,6 +2905,18 @@ export type MutationAcceptTermsOfServiceArgs = {
  */
 export type MutationCreateTermsOfServiceArgs = {
   pdfUrl: Scalars['String'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationCreateSubscriptionArgs = {
+  userId: Scalars['ID'];
+  metricId: Scalars['ID'];
 };
 
 /** An enumeration. */
@@ -2684,6 +3042,12 @@ export type RevokeMqlServerConfig = {
   success?: Maybe<Scalars['Boolean']>;
 };
 
+/** Stores environment variables required to spin up the MQL server into AWS Secrets Manager. */
+export type SetMqlServerEnvConfig = {
+  __typename?: 'SetMqlServerEnvConfig';
+  success?: Maybe<Scalars['Boolean']>;
+};
+
 /** Graphene input object for a metric collection item. Essentially a dataclass. */
 export type MetricCollectionItem = {
   metricId?: Maybe<Scalars['ID']>;
@@ -2696,6 +3060,12 @@ export type MfaPref = {
   requireMfa: Scalars['Boolean'];
   allowMfaRememberBrowser: Scalars['Boolean'];
 };
+
+/** An enumeration. */
+export enum GOwnerType {
+  Business = 'business',
+  Technical = 'technical'
+}
 
 export type MqlServerUrlQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/queries/mql/FetchMqlQuery.ts
+++ b/queries/mql/FetchMqlQuery.ts
@@ -24,6 +24,11 @@ const query = gql`
       errorTraceback
       chartValueMin
       chartValueMax
+      result {
+        value
+        delta
+        pctChange
+      }
     }
   }
 `;

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -10,8 +10,8 @@ type Query {
   latestAvaticaServer: ServiceRelease
   myOrganization: Organization
   myUser: User
-  allFeatures(searchStr: String, searchColumns: [FeatureStrColumns], pageNumber: Int, pageSize: Int, orderBy: FeatureOrderBy, desc: Boolean): [Feature]
-  allOrganizations(searchStr: String, searchColumns: [OrganizationStrColumns], pageNumber: Int, pageSize: Int, orderBy: OrganizationOrderBy, desc: Boolean): [Organization]
+  allFeatures(searchStr: String, searchColumns: [FeatureStrColumns], orderBy: FeatureOrderBy, desc: Boolean, orderBys: [FeatureOrderByInput], pageNumber: Int, pageSize: Int): [Feature]
+  allOrganizations(searchStr: String, searchColumns: [OrganizationStrColumns], orderBy: OrganizationOrderBy, desc: Boolean, orderBys: [OrganizationOrderByInput], pageNumber: Int, pageSize: Int): [Organization]
   totalFeatures: Int
   totalOrganizations: Int
   organizationTest(id: ID!): Organization
@@ -20,6 +20,7 @@ type Query {
   boom(raise_: Boolean): Boolean
   transformConfig: TransformConfig
   emailCanSignUp(email: String!): Boolean
+  dwHealthCheck(snowflakeConnectionDetails: SnowflakeConnectionInput, redshiftConnectionDetails: RedshiftConnectionInput, bigQueryConnectionDetails: BigQueryConnectionInput): [MqlServerHealthItem]
 }
 
 """A wrapper for the response we get from Auth0's user profile API"""
@@ -64,30 +65,31 @@ type Organization {
   mqlServerLogs: String
   isHosted: Boolean!
   type: OrgType
-  users(activeOnly: Boolean, searchStr: String, searchColumns: [UserStrColumns], pageNumber: Int, pageSize: Int, orderBy: UserOrderBy, desc: Boolean): [User]
-  mqlServers(searchStr: String, searchColumns: [OrgMqlServerStrColumns], pageNumber: Int, pageSize: Int, orderBy: OrgMqlServerOrderBy, desc: Boolean): [OrgMqlServer]
+  users(activeOnly: Boolean, searchStr: String, searchColumns: [UserStrColumns], orderBy: UserOrderBy, desc: Boolean, orderBys: [UserOrderByInput], pageNumber: Int, pageSize: Int): [User]
+  mqlServers(searchStr: String, searchColumns: [OrgMqlServerStrColumns], orderBy: OrgMqlServerOrderBy, desc: Boolean, orderBys: [OrgMqlServerOrderByInput], pageNumber: Int, pageSize: Int): [OrgMqlServer]
   models(id: ID): [Model]
   orgMetrics: [OrgMetric]
   mqlHeartbeats: [MqlHeartbeat]
   currentModel: [Model]
-  teams(searchStr: String, searchColumns: [TeamStrColumns], pageNumber: Int, pageSize: Int, orderBy: TeamOrderBy, desc: Boolean): [Team]
+  teams(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
+  prefs(prefKey: String, searchStr: String, searchColumns: [OrgPrefStrColumns], orderBy: OrgPrefOrderBy, desc: Boolean, orderBys: [OrgPrefOrderByInput], pageNumber: Int, pageSize: Int): [OrgPref]
   apiKeys: [ApiKey]
   metricViews: [MetricView]
-  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], pageNumber: Int, pageSize: Int, orderBy: SavedQueryOrderBy, desc: Boolean): [SavedQuery]
+  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], orderBy: SavedQueryOrderBy, desc: Boolean, orderBys: [SavedQueryOrderByInput], pageNumber: Int, pageSize: Int): [SavedQuery]
   teamViews: [TeamView]
   dashboards: [Dashboard]
-  metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
-  questions(searchStr: String, searchColumns: [QuestionStrColumns], pageNumber: Int, pageSize: Int, orderBy: QuestionOrderBy, desc: Boolean): [Question]
+  metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], orderBy: MetricCollectionOrderBy, desc: Boolean, orderBys: [MetricCollectionOrderByInput], pageNumber: Int, pageSize: Int): [MetricCollection]
+  questions(searchStr: String, searchColumns: [QuestionStrColumns], orderBy: QuestionOrderBy, desc: Boolean, orderBys: [QuestionOrderByInput], pageNumber: Int, pageSize: Int): [Question]
   question(id: ID!): Question
-  annotations(searchStr: String, searchColumns: [AnnotationStrColumns], pageNumber: Int, pageSize: Int, orderBy: AnnotationOrderBy, desc: Boolean): [Annotation]
-  recentQuestions(searchStr: String, searchColumns: [QuestionStrColumns], pageNumber: Int, pageSize: Int, orderBy: QuestionOrderBy, desc: Boolean): [Question]
-  recentAnnotations(searchStr: String, searchColumns: [AnnotationStrColumns], pageNumber: Int, pageSize: Int, orderBy: AnnotationOrderBy, desc: Boolean): [Annotation]
+  annotations(searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
+  recentQuestions(searchStr: String, searchColumns: [QuestionStrColumns], orderBy: QuestionOrderBy, desc: Boolean, orderBys: [QuestionOrderByInput], pageNumber: Int, pageSize: Int): [Question]
+  recentAnnotations(searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
   totalQuestions: Int
   totalAnnotations: Int
-  metrics(names: [String], tiers: [MetricTier], types: [MetricType], searchStr: String, searchColumns: [MetricVersionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
+  metrics(names: [String], tiers: [MetricTier], types: [MetricType], searchStr: String, searchColumns: [MetricVersionStrColumns], orderBy: MetricVersionOrderBy, desc: Boolean, orderBys: [MetricVersionOrderByInput], pageNumber: Int, pageSize: Int): [Metric]
   totalMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], types: [MetricType]): Int
   latestMqlHeartbeat: MqlHeartbeat
-  totalUsers: Int
+  totalUsers(activeOnly: Boolean, searchStr: String, searchColumns: [UserStrColumns]): Int
   totalTeams: Int
   mqlServer(id: ID!): OrgMqlServer
   totalMqlServers: Int
@@ -104,7 +106,13 @@ type Organization {
   mqlServerUrl: String
   allowedEmailDomains: [String]
   tierTooltips(tiers: [Int]!): GenericScalar
-  activeOrgAdmins(searchStr: String, searchColumns: [UserStrColumns], pageNumber: Int, pageSize: Int, orderBy: UserOrderBy, desc: Boolean): [User]
+  activeOrgAdmins(searchStr: String, searchColumns: [UserStrColumns], orderBy: UserOrderBy, desc: Boolean, orderBys: [UserOrderByInput], pageNumber: Int, pageSize: Int): [User]
+  mqlServerConfig(id: ID!): DataWarehouseConfig
+  incompleteOnboardingTasks: [String]
+  samlConnectionName: String
+  sharedSlackChannelName: String
+  primaryMqlServer: OrgMqlServer
+  annotationsFeed(pageNumber: Int, pageSize: Int): [Annotation]
   activeFeatures: [Feature]
 }
 
@@ -130,15 +138,15 @@ type User {
   roles: [UserRole]
   prefs: [UserPref]
   activeUserRoles: [UserRole]
-  teams(isAdminOnly: Boolean, searchStr: String, searchColumns: [TeamStrColumns], pageNumber: Int, pageSize: Int, orderBy: TeamOrderBy, desc: Boolean): [Team]
+  teams(isAdminOnly: Boolean, searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
   teamMemberships: [TeamMember]
   dashboards: [Dashboard]
   primaryDashboard: Dashboard
-  apiKeys(activeOnly: Boolean, searchStr: String, searchColumns: [ApiKeyStrColumns], pageNumber: Int, pageSize: Int, orderBy: ApiKeyOrderBy, desc: Boolean): [ApiKey]
-  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], pageNumber: Int, pageSize: Int, orderBy: SavedQueryOrderBy, desc: Boolean): [SavedQuery]
+  apiKeys(activeOnly: Boolean, searchStr: String, searchColumns: [ApiKeyStrColumns], orderBy: ApiKeyOrderBy, desc: Boolean, orderBys: [ApiKeyOrderByInput], pageNumber: Int, pageSize: Int): [ApiKey]
+  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], orderBy: SavedQueryOrderBy, desc: Boolean, orderBys: [SavedQueryOrderByInput], pageNumber: Int, pageSize: Int): [SavedQuery]
   organization: Organization
   teamViews: [TeamView]
-  metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
+  metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], orderBy: MetricCollectionOrderBy, desc: Boolean, orderBys: [MetricCollectionOrderByInput], pageNumber: Int, pageSize: Int): [MetricCollection]
   mqlServerUrl: String
   activeRoles: [String]
   isAdmin: Boolean
@@ -149,15 +157,20 @@ type User {
   totalSavedQueries: Int
   totalViewedMetrics: Int
   totalMetricCollections: Int
-  viewedTeams(searchStr: String, searchColumns: [TeamStrColumns], pageNumber: Int, pageSize: Int, orderBy: TeamOrderBy, desc: Boolean): [Team]
+  viewedTeams(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
   totalViewedTeams: Int
-  viewedMetricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
+  viewedMetricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], orderBy: MetricCollectionOrderBy, desc: Boolean, orderBys: [MetricCollectionOrderByInput], pageNumber: Int, pageSize: Int): [MetricCollection]
   totalViewedMetricCollections: Int
   totalActiveFeatures: Int
   hasAcceptedLatestTermsOfService: Boolean
-  viewedMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
-  newMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
+  acceptedTermsOfService: Int
+  totalFeaturedMetrics: Int
+  totalSubscribedMetrics: Int
+  viewedMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], orderBy: MetricVersionOrderBy, desc: Boolean, orderBys: [MetricVersionOrderByInput], pageNumber: Int, pageSize: Int): [Metric]
+  newMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], orderBy: MetricVersionOrderBy, desc: Boolean, orderBys: [MetricVersionOrderByInput], pageNumber: Int, pageSize: Int): [Metric]
   activeFeatures: [Feature]
+  featuredMetrics(pageNumber: Int, pageSize: Int): [Metric]
+  subscribedMetrics(pageNumber: Int, pageSize: Int): [Metric]
 }
 
 type UserRole {
@@ -199,15 +212,15 @@ type Team {
   description: String
   createdByUser: User
   organization: Organization
-  members(pageNumber: Int, pageSize: Int, orderBy: TeamMemberOrderBy, desc: Boolean): [TeamMember]
+  members(orderBy: TeamMemberOrderBy, desc: Boolean, orderBys: [TeamMemberOrderByInput], pageNumber: Int, pageSize: Int): [TeamMember]
   adminMembers: [TeamMember]
   memberUsers: [User]
   dashboards: [Dashboard]
   primaryDashboard: Dashboard
   featuredMetricCollection: MetricCollection
-  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], pageNumber: Int, pageSize: Int, orderBy: SavedQueryOrderBy, desc: Boolean): [SavedQuery]
+  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], orderBy: SavedQueryOrderBy, desc: Boolean, orderBys: [SavedQueryOrderByInput], pageNumber: Int, pageSize: Int): [SavedQuery]
   views: [TeamView]
-  metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricCollectionOrderBy, desc: Boolean): [MetricCollection]
+  metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], orderBy: MetricCollectionOrderBy, desc: Boolean, orderBys: [MetricCollectionOrderByInput], pageNumber: Int, pageSize: Int): [MetricCollection]
   teamAdminIds: [Int]
   userIsTeamAdmin: Boolean
   totalMetrics: Int
@@ -216,7 +229,7 @@ type Team {
   totalMembers: Int
   totalRecentViews: Int
   totalRecentViewsForUser: Int
-  metrics(searchStr: String, searchColumns: [MetricVersionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
+  metrics(searchStr: String, searchColumns: [MetricVersionStrColumns], orderBy: MetricVersionOrderBy, desc: Boolean, orderBys: [MetricVersionOrderByInput], pageNumber: Int, pageSize: Int): [Metric]
 }
 
 type TeamMember {
@@ -233,21 +246,26 @@ type TeamMember {
 
 """An enumeration."""
 enum TeamMemberOrderBy {
-  JOINED_AT
+  TEAM_ID
   USER_ID
   IS_TEAM_ADMIN
-  TEAM_ID
-  TeamMember_ORGANIZATION_ID
+  JOINED_AT
   TeamMember_ID
+  TeamMember_ORGANIZATION_ID
   User_ORGANIZATION_ID
-  AVATAR_URL
-  CREATED_AT
+  PRIMARY_DASHBOARD_ID
+  USER_NAME
   EMAIL
   UPDATED_AT
-  USER_NAME
   DEACTIVATED_AT
+  AVATAR_URL
   AUTH0_ID
-  PRIMARY_DASHBOARD_ID
+  CREATED_AT
+}
+
+input TeamMemberOrderByInput {
+  orderBy: TeamMemberOrderBy!
+  desc: Boolean
 }
 
 type Dashboard {
@@ -307,8 +325,8 @@ type MetricCollection {
   teamOwner: Team
   primaryDashboard: Dashboard
   views: [MetricCollectionView]
-  items(pageNumber: Int, pageSize: Int, orderBy: MetricCollectionMetricOrderBy, desc: Boolean): [MetricCollectionMetric]
-  collectionItems(pageNumber: Int, pageSize: Int, orderBy: MetricCollectionMetricOrderBy, desc: Boolean): [CollectionItem]
+  items(orderBy: MetricCollectionMetricOrderBy, desc: Boolean, orderBys: [MetricCollectionMetricOrderByInput], pageNumber: Int, pageSize: Int): [MetricCollectionMetric]
+  collectionItems(orderBy: MetricCollectionMetricOrderBy, desc: Boolean, orderBys: [MetricCollectionMetricOrderByInput], pageNumber: Int, pageSize: Int): [CollectionItem]
   totalItems: Int
   totalRecentViews: Int
   totalRecentViewsForUser: Int
@@ -360,8 +378,15 @@ type MetricUserOwner {
   userId: Int!
   createdAt: DateTime
   isLocked: Boolean!
+  ownerType: OwnerType!
   user: User
   organization: Organization
+}
+
+"""An enumeration."""
+enum OwnerType {
+  BUSINESS
+  TECHNICAL
 }
 
 type MetricTeamOwner {
@@ -371,6 +396,7 @@ type MetricTeamOwner {
   createdTs: Int
   orgMetricId: Int!
   createdAt: DateTime
+  ownerType: OwnerType!
   team: Team
   organization: Organization
 }
@@ -395,7 +421,7 @@ type Metric {
   userOwners: [MetricUserOwner]
   teamOwners: [MetricTeamOwner]
   views: MetricView
-  questions(searchStr: String, searchColumns: [QuestionStrColumns], pageNumber: Int, pageSize: Int, orderBy: QuestionOrderBy, desc: Boolean): [Question]
+  questions(searchStr: String, searchColumns: [QuestionStrColumns], orderBy: QuestionOrderBy, desc: Boolean, orderBys: [QuestionOrderByInput], pageNumber: Int, pageSize: Int): [Question]
   resolvedQuestions: Question
   unresolvedQuestions: Question
   metadata: GenericScalar
@@ -408,22 +434,23 @@ type Metric {
   displayNameWithLock: LockableParameter
   descriptionWithLock: LockableParameter
   valueFormatWithLock: LockableParameter
+  increaseIsGoodWithLock: LockableParameter
   latestApproval: MetricApproval
-  annotations(dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority], searchStr: String, searchColumns: [AnnotationStrColumns], pageNumber: Int, pageSize: Int, orderBy: AnnotationOrderBy, desc: Boolean): [Annotation]
+  annotations(dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority], searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
   currentDescription: String
   totalRecentViews: Int
   totalRecentViewsForUser: Int
   userIsMetricOwner: Boolean
   userCanEdit: Boolean
-  dataSources(searchStr: String, searchColumns: [DataSourceVersionStrColumns], pageNumber: Int, pageSize: Int, orderBy: DataSourceVersionOrderBy, desc: Boolean): [DataSourceVersion]
+  dataSources(searchStr: String, searchColumns: [DataSourceVersionStrColumns], orderBy: DataSourceVersionOrderBy, desc: Boolean, orderBys: [DataSourceVersionOrderByInput], pageNumber: Int, pageSize: Int): [DataSourceVersion]
   totalDataSources: Int
-  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], pageNumber: Int, pageSize: Int, orderBy: SavedQueryOrderBy, desc: Boolean): [SavedQuery]
+  savedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], orderBy: SavedQueryOrderBy, desc: Boolean, orderBys: [SavedQueryOrderByInput], pageNumber: Int, pageSize: Int): [SavedQuery]
   totalSavedQueries: Int
   totalResolvedQuestions: Int
   totalUnresolvedQuestions: Int
-  ownerTeams(searchStr: String, searchColumns: [TeamStrColumns], pageNumber: Int, pageSize: Int, orderBy: TeamOrderBy, desc: Boolean): [Team]
+  ownerTeams(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
   totalOwnerTeams: Int
-  ownerUsers(searchStr: String, searchColumns: [UserStrColumns], pageNumber: Int, pageSize: Int, orderBy: UserOrderBy, desc: Boolean): [User]
+  ownerUsers(searchStr: String, searchColumns: [UserStrColumns], orderBy: UserOrderBy, desc: Boolean, orderBys: [UserOrderByInput], pageNumber: Int, pageSize: Int): [User]
   totalOwnerUsers: Int
   tierTooltip: String
   isAdditive: Boolean
@@ -511,7 +538,7 @@ type Question {
   updatedAt: DateTime
   metricId: Int!
   organization: Organization
-  replies(searchStr: String, searchColumns: [QuestionReplyStrColumns], pageNumber: Int, pageSize: Int, orderBy: QuestionReplyOrderBy, desc: Boolean): [QuestionReply]
+  replies(searchStr: String, searchColumns: [QuestionReplyStrColumns], orderBy: QuestionReplyOrderBy, desc: Boolean, orderBys: [QuestionReplyOrderByInput], pageNumber: Int, pageSize: Int): [QuestionReply]
   orgMetric: OrgMetric
   author: User
   resolvedByUser: User
@@ -548,35 +575,45 @@ enum QuestionReplyStrColumns {
 
 """An enumeration."""
 enum QuestionReplyOrderBy {
-  AUTHOR_ID
-  CREATED_AT
   ID
-  ORGANIZATION_ID
+  TEXT
   QUESTION_ID
   UPDATED_AT
-  TEXT
+  CREATED_AT
+  ORGANIZATION_ID
+  AUTHOR_ID
+}
+
+input QuestionReplyOrderByInput {
+  orderBy: QuestionReplyOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
 enum QuestionStrColumns {
-  PRIORITY
   TEXT
+  PRIORITY
 }
 
 """An enumeration."""
 enum QuestionOrderBy {
+  ID
   RESOLVED_AT
   RESOLVED_BY
-  AUTHOR_ID
-  CREATED_AT
-  ID
-  ORGANIZATION_ID
-  NOTIFIED_AT
-  METRIC_ID
   TEXT
   UPDATED_AT
-  RESOLVED
+  AUTHOR_ID
   PRIORITY
+  NOTIFIED_AT
+  METRIC_ID
+  RESOLVED
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input QuestionOrderByInput {
+  orderBy: QuestionOrderBy!
+  desc: Boolean
 }
 
 type LockableParameter {
@@ -660,57 +697,67 @@ enum Priority {
 
 """An enumeration."""
 enum AnnotationStrColumns {
-  PRIORITY
-  TITLE
   EXPECTED_IMPACT
   TEXT
+  PRIORITY
+  TITLE
 }
 
 """An enumeration."""
 enum AnnotationOrderBy {
-  AUTHOR_ID
-  DATE_ENDED_AT
   ID
+  TEXT
+  DELETED_AT
+  UPDATED_AT
+  DATE_STARTED_AT
+  AUTHOR_ID
   EXPECTED_IMPACT
+  PRIORITY
+  DATE_ENDED_AT
+  NOTIFIED_AT
+  TITLE
   CREATED_AT
   ORGANIZATION_ID
-  NOTIFIED_AT
-  TEXT
-  UPDATED_AT
-  TITLE
-  DATE_STARTED_AT
-  DELETED_AT
-  PRIORITY
+}
+
+input AnnotationOrderByInput {
+  orderBy: AnnotationOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
 enum DataSourceVersionStrColumns {
-  CONNECTION
-  HASH
   SQL_TABLE
-  NAME
+  HASH
   SQL_QUERY
+  CONNECTION
   DESCRIPTION
+  NAME
 }
 
 """An enumeration."""
 enum DataSourceVersionOrderBy {
-  DATA_SOURCE_METADATA
-  NAME
-  IDENTIFIERS
-  CREATED_AT
-  SQL_QUERY
-  ORGANIZATION_ID
-  CONNECTION
-  SQL_TABLE
-  DIMENSIONS
   ID
   DESCRIPTION
-  MUTABILITY
-  HASH
+  CONNECTION
+  DIMENSIONS
+  NAME
+  SQL_TABLE
   CONSTRAINT
-  MEASURES
+  IDENTIFIERS
+  SQL_QUERY
   OWNERS
+  HASH
+  DATA_SOURCE_METADATA
+  MEASURES
+  MUTABILITY
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input DataSourceVersionOrderByInput {
+  orderBy: DataSourceVersionOrderBy!
+  desc: Boolean
 }
 
 type SavedQuery {
@@ -728,45 +775,52 @@ type SavedQuery {
   ownerTeam: Team
   orgMetrics: [OrgMetric]
   totalMetrics: Int
-  metrics(searchStr: String, searchColumns: [MetricVersionStrColumns], pageNumber: Int, pageSize: Int, orderBy: MetricVersionOrderBy, desc: Boolean): [Metric]
+  metrics(searchStr: String, searchColumns: [MetricVersionStrColumns], orderBy: MetricVersionOrderBy, desc: Boolean, orderBys: [MetricVersionOrderByInput], pageNumber: Int, pageSize: Int): [Metric]
 }
 
 """An enumeration."""
 enum MetricVersionStrColumns {
   DESCRIPTION
-  HASH
   DISPLAY_NAME
+  HASH
   VALUE_FORMAT
 }
 
 """An enumeration."""
 enum MetricVersionOrderBy {
   ID
-  METRIC_TYPE
-  SOURCE_DATA_SOURCE_VERSIONS
-  PARAMS
-  DESCRIPTION
-  ORGANIZATION_ID
-  ORG_DATA_SOURCE_ID
-  VIEWS
-  TIER
   HASH
+  DESCRIPTION
+  ORG_DATA_SOURCE_ID
   METADATA
+  TIER
+  SOURCE_DATA_SOURCE_VERSIONS
   DISPLAY_NAME
-  MetricVersion_CREATED_AT
+  ORGANIZATION_ID
+  PARAMS
+  VIEWS
+  METRIC_TYPE
   MetricVersion_METRIC_ID
-  MetricMetadata_CREATED_AT
+  MetricVersion_CREATED_AT
   MetricMetadata_METRIC_ID
-  EXTRA_FIELDS
-  UPDATED_BY
-  TIER_LOCK
-  VALUE_FORMAT_LOCK
+  MetricMetadata_CREATED_AT
+  INCREASE_IS_GOOD_LOCK
   CREATED_BY
-  VALUE_FORMAT
   UPDATED_AT
   DESCRIPTION_LOCK
   DISPLAY_NAME_LOCK
+  EXTRA_FIELDS
   IS_NEW
+  VALUE_FORMAT
+  INCREASE_IS_GOOD
+  VALUE_FORMAT_LOCK
+  TIER_LOCK
+  UPDATED_BY
+}
+
+input MetricVersionOrderByInput {
+  orderBy: MetricVersionOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
@@ -776,74 +830,94 @@ enum SavedQueryStrColumns {
 
 """An enumeration."""
 enum SavedQueryOrderBy {
-  CREATED_AT
   ID
-  SERIALIZED_QUERY
-  ORGANIZATION_ID
+  DELETED_AT
+  OWNER_TEAM_ID
   CREATED_BY
   UPDATED_AT
   TITLE
-  DELETED_AT
-  OWNER_TEAM_ID
+  SERIALIZED_QUERY
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input SavedQueryOrderByInput {
+  orderBy: SavedQueryOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
 enum TeamStrColumns {
-  THEME
   DESCRIPTION
-  NAME
   SLUG
+  NAME
+  THEME
 }
 
 """An enumeration."""
 enum TeamOrderBy {
+  ID
+  PRIMARY_DASHBOARD_ID
+  CREATED_BY
+  UPDATED_AT
+  DESCRIPTION
+  DEACTIVATED_AT
   THEME
   NAME
-  ID
-  CREATED_AT
-  DESCRIPTION
-  ORGANIZATION_ID
-  CREATED_BY
+  FEATURED_METRIC_COLLECTION_ID
   VIEWS
   SLUG
-  UPDATED_AT
-  DEACTIVATED_AT
-  FEATURED_METRIC_COLLECTION_ID
-  PRIMARY_DASHBOARD_ID
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input TeamOrderByInput {
+  orderBy: TeamOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
 enum UserStrColumns {
   AVATAR_URL
+  USER_NAME
   EMAIL
   AUTH0_ID
-  USER_NAME
 }
 
 """An enumeration."""
 enum UserOrderBy {
-  AVATAR_URL
-  CREATED_AT
   ID
-  ORGANIZATION_ID
+  PRIMARY_DASHBOARD_ID
+  USER_NAME
   EMAIL
   UPDATED_AT
-  USER_NAME
   DEACTIVATED_AT
+  AVATAR_URL
   AUTH0_ID
-  PRIMARY_DASHBOARD_ID
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input UserOrderByInput {
+  orderBy: UserOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
 enum MetricCollectionMetricOrderBy {
-  CREATED_AT
   ID
-  METRIC_ID
-  UPDATED_AT
-  EMPHASIS
   METRIC_COLLECTION_ID
   SAVED_QUERY_ID
+  UPDATED_AT
   POSITION
+  EMPHASIS
+  METRIC_ID
+  CREATED_AT
+}
+
+input MetricCollectionMetricOrderByInput {
+  orderBy: MetricCollectionMetricOrderBy!
+  desc: Boolean
 }
 
 type CollectionItem {
@@ -876,25 +950,30 @@ type TeamView {
 """An enumeration."""
 enum MetricCollectionStrColumns {
   DESCRIPTION
-  TITLE
   SLUG
+  TITLE
 }
 
 """An enumeration."""
 enum MetricCollectionOrderBy {
-  CREATED_AT
   ID
-  DESCRIPTION
-  ORGANIZATION_ID
-  CREATED_BY
-  VIEWS
-  SLUG
-  UPDATED_AT
-  TITLE
+  PRIMARY_DASHBOARD_ID
   DELETED_AT
   OWNER_TEAM_ID
+  CREATED_BY
+  UPDATED_AT
+  DESCRIPTION
   DEFAULT_EMPHASIS
-  PRIMARY_DASHBOARD_ID
+  VIEWS
+  TITLE
+  SLUG
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input MetricCollectionOrderByInput {
+  orderBy: MetricCollectionOrderBy!
+  desc: Boolean
 }
 
 type ApiKey {
@@ -916,23 +995,28 @@ type ApiKey {
 """An enumeration."""
 enum ApiKeyStrColumns {
   TYPE
-  SECRET_HASH
   SCOPE
   PREFIX
+  SECRET_HASH
 }
 
 """An enumeration."""
 enum ApiKeyOrderBy {
-  TYPE
-  SECRET_HASH
-  CREATED_AT
-  REVOKED_AT
-  ORGANIZATION_ID
-  SCOPE
-  USER_ID
-  LAST_USED_AT
-  REVOKER_ID
   PREFIX
+  REVOKER_ID
+  USER_ID
+  SECRET_HASH
+  LAST_USED_AT
+  SCOPE
+  TYPE
+  CREATED_AT
+  ORGANIZATION_ID
+  REVOKED_AT
+}
+
+input ApiKeyOrderByInput {
+  orderBy: ApiKeyOrderBy!
+  desc: Boolean
 }
 
 type Feature {
@@ -941,36 +1025,41 @@ type Feature {
   updatedAt: DateTime
   name: String!
   retiredAt: DateTime
-  organizations(searchStr: String, searchColumns: [OrganizationStrColumns], pageNumber: Int, pageSize: Int, orderBy: OrganizationOrderBy, desc: Boolean): [Organization]
-  users(searchStr: String, searchColumns: [UserStrColumns], pageNumber: Int, pageSize: Int, orderBy: UserOrderBy, desc: Boolean): [User]
+  organizations(searchStr: String, searchColumns: [OrganizationStrColumns], orderBy: OrganizationOrderBy, desc: Boolean, orderBys: [OrganizationOrderByInput], pageNumber: Int, pageSize: Int): [Organization]
+  users(searchStr: String, searchColumns: [UserStrColumns], orderBy: UserOrderBy, desc: Boolean, orderBys: [UserOrderByInput], pageNumber: Int, pageSize: Int): [User]
   totalOrganizations: Int
   totalUsers: Int
 }
 
 """An enumeration."""
 enum OrganizationStrColumns {
-  MQL_SERVER_LOGS
-  NAME
-  SOURCE_CONTROL_URL
-  LOGO_URL
-  PRIMARY_CONFIG_BRANCH
   PRIMARY_CONFIG_REPO
+  LOGO_URL
+  MQL_SERVER_LOGS
+  PRIMARY_CONFIG_BRANCH
+  SOURCE_CONTROL_URL
+  NAME
 }
 
 """An enumeration."""
 enum OrganizationOrderBy {
-  TYPE
-  MQL_SERVER_LOGS
-  NAME
   ID
-  CREATED_AT
-  IS_HOSTED
-  PRIMARY_CONFIG_BRANCH
-  PRIMARY_CONFIG_REPO
-  UPDATED_AT
   LOGO_URL
+  MQL_SERVER_LOGS
+  UPDATED_AT
   SOURCE_CONTROL_URL
   DEACTIVATED_AT
+  NAME
+  PRIMARY_CONFIG_REPO
+  IS_HOSTED
+  TYPE
+  PRIMARY_CONFIG_BRANCH
+  CREATED_AT
+}
+
+input OrganizationOrderByInput {
+  orderBy: OrganizationOrderBy!
+  desc: Boolean
 }
 
 type OrgMqlServer {
@@ -983,9 +1072,11 @@ type OrgMqlServer {
   isOrgDefault: Boolean
   configSecret: String
   dwEngine: DWEngine
+  deploymentStatus: DeploymentStatus
   heartbeats: [MqlHeartbeat]
   organization: Organization
   latestHeartbeat: MqlHeartbeat
+  dwConfig: DataWarehouseConfig
 }
 
 """An enumeration."""
@@ -998,6 +1089,14 @@ enum DWEngine {
   SNOWFLAKE
   DATABRICKS
   ATHENA
+  BIGQUERY
+}
+
+"""Enums to represent the status of the mql server deployment"""
+enum DeploymentStatus {
+  PAUSED
+  DEPLOY
+  NEVER
 }
 
 type MqlHeartbeat {
@@ -1014,24 +1113,73 @@ type MqlHeartbeat {
   org: Organization
 }
 
+"""GQL object to represent configs for a given mql data warehouse."""
+type DataWarehouseConfig {
+  host: String
+  username: String
+  database: String
+  port: Int
+  schema: String
+  query: String
+  dialect: String
+  isPasswordSet: Boolean
+}
+
 """An enumeration."""
 enum OrgMqlServerStrColumns {
+  URL
   CONFIG_SECRET
   NAME
-  URL
 }
 
 """An enumeration."""
 enum OrgMqlServerOrderBy {
-  CONFIG_SECRET
-  NAME
-  CREATED_AT
   ID
-  URL
-  ORGANIZATION_ID
-  UPDATED_AT
   DW_ENGINE
+  CONFIG_SECRET
+  UPDATED_AT
+  NAME
+  URL
   IS_ORG_DEFAULT
+  DEPLOYMENT_STATUS
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input OrgMqlServerOrderByInput {
+  orderBy: OrgMqlServerOrderBy!
+  desc: Boolean
+}
+
+type OrgPref {
+  id: ID!
+  organizationId: Int!
+  prefKey: String!
+  prefValue: String!
+  createdAt: DateTime
+  updatedAt: DateTime
+  organization: Organization
+}
+
+"""An enumeration."""
+enum OrgPrefStrColumns {
+  PREF_KEY
+  PREF_VALUE
+}
+
+"""An enumeration."""
+enum OrgPrefOrderBy {
+  ID
+  PREF_VALUE
+  UPDATED_AT
+  PREF_KEY
+  CREATED_AT
+  ORGANIZATION_ID
+}
+
+input OrgPrefOrderByInput {
+  orderBy: OrgPrefOrderBy!
+  desc: Boolean
 }
 
 """An enumeration."""
@@ -1056,11 +1204,16 @@ enum FeatureStrColumns {
 
 """An enumeration."""
 enum FeatureOrderBy {
-  NAME
-  CREATED_AT
   ID
-  RETIRED_AT
+  CREATED_AT
   UPDATED_AT
+  RETIRED_AT
+  NAME
+}
+
+input FeatureOrderByInput {
+  orderBy: FeatureOrderBy!
+  desc: Boolean
 }
 
 """Wrapper to contain queries related to transform settings & configs."""
@@ -1073,6 +1226,39 @@ type TermsOfServiceVersion {
   id: ID!
   pdfUrl: String!
   createdAt: DateTime!
+}
+
+type MqlServerHealthItem {
+  name: String!
+  status: String!
+  errorMessage: String
+}
+
+"""GQL Input object for Snowflake connection details."""
+input SnowflakeConnectionInput {
+  host: String!
+  username: String!
+  password: String!
+  database: String!
+  schema: String!
+  warehouse: String
+  role: String
+}
+
+"""GQL Input object for Redshift connection details."""
+input RedshiftConnectionInput {
+  host: String!
+  username: String!
+  password: String!
+  database: String!
+  schema: String!
+  port: Int!
+}
+
+"""GQL Input object for BigQuery connection details."""
+input BigQueryConnectionInput {
+  password: String!
+  schema: String!
 }
 
 """
@@ -1127,6 +1313,11 @@ type Mutation {
 
   """Removes hosted MQL Server config using AWS Secrets Manager."""
   revokeMqlServerConfig(mqlServerId: Int): RevokeMqlServerConfig
+
+  """
+  Stores environment variables required to spin up the MQL server into AWS Secrets Manager.
+  """
+  setMqlServerEnvConfig(bigQueryConnectionDetails: BigQueryConnectionInput, redshiftConnectionDetails: RedshiftConnectionInput, snowflakeConnectionDetails: SnowflakeConnectionInput): SetMqlServerEnvConfig
   featuresCreate(name: String!): Feature
   featuresUpdate(id: ID!, name: String, retireFeature: Boolean): Feature
   featuresAddOrgs(featureId: ID!, organizationIds: [ID]!): Feature
@@ -1143,9 +1334,9 @@ type Mutation {
   metricCollectionCreate(title: String!, description: String!, slug: String!, defaultEmphasis: Int!, metrics: [ID], savedQueries: [ID], ownerTeamId: ID): MetricCollection
   metricCollectionUpdate(id: ID!, title: String, primaryDashboardId: ID, description: String, slug: String, defaultEmphasis: Int, items: [MetricCollectionItem], ownerTeamId: ID): MetricCollection
   metricCollectionDelete(id: ID!): MetricCollection
-  orgMqlServerUpdate(id: ID!, name: String, url: String, isOrgDefault: Boolean, configSecret: String, dwEngine: String): OrgMqlServer
+  orgMqlServerUpdate(id: ID!, name: String, url: String, isOrgDefault: Boolean, configSecret: String, dwEngine: String, deploymentStatus: String): OrgMqlServer
   orgMqlServerDelete(id: ID!): OrgMqlServer
-  orgMqlServerCreate(organizationId: ID, name: String!, url: String!, isOrgDefault: Boolean, configSecret: String, dwEngine: String): OrgMqlServer
+  orgMqlServerCreate(organizationId: ID, name: String!, url: String!, isOrgDefault: Boolean, configSecret: String, dwEngine: String, deploymentStatus: String): OrgMqlServer
   teamsCreate(name: String!, slug: String!, organizationId: ID, description: String, theme: String, regularMemberUserIds: [ID], teamAdminUserIds: [ID]): Team
   teamsUpdate(id: ID!, name: String, slug: String, description: String, theme: String, primaryDashboardId: Int, featuredMetricCollectionId: Int, deactivate: Boolean): Team
   teamsAddMember(teamId: ID!, regularMemberUserIds: [ID], teamAdminUserIds: [ID]): Team
@@ -1154,26 +1345,30 @@ type Mutation {
   teamsAssignAsMetricOwner(teamId: ID!, metricIds: [ID]): Team
   teamsRemoveAsMetricOwner(teamId: ID!, metricIds: [ID]): Team
   organizationsUpdate(id: ID!, name: String, logoUrl: String, primaryConfigRepo: String, primaryConfigBranch: String, sourceControlUrl: String, mqlServerLogs: String, isHosted: Boolean, orgType: GOrgType): Organization
+  organizationsCreateSharedSlack(orgId: ID!, emails: [String]!): Organization
+  organizationsCreateSamlConnection(companyName: String!, signInUrl: String!, signingCertificate: String!, allowedEmailDomains: [String]!, orgId: ID): Organization
   organizationsSetTierTooltip(organizationId: ID!, tooltip: String!, tier: MetricTier!): Organization
   organizationsSetMfaPrefs(organizationId: ID!, mfaPref: MFAPref!): Organization
+  organizationsSetPref(organizationId: ID!, prefKey: String!, prefValue: String!): Organization
   organizationsSetAllowedEmailDomains(organizationId: ID!, allowedEmailDomains: [String]!): Organization
   organizationsDelete(id: ID!): Organization
   metricsApprove(metricId: ID!): Metric
   metricsLogView(metricId: ID!): MetricView
   metricCollectionsLogView(metricCollectionId: ID!): MetricCollectionView
   teamsLogView(teamId: ID!): TeamView
-  metricsAddUserOwners(metricId: ID!, userIds: [ID]): Metric
-  metricsRemoveUserOwners(metricId: ID!, userIds: [ID]): Metric
-  metricsAssignTeamOwners(metricId: ID!, teamIds: [ID]): Metric
-  metricsRemoveTeamOwners(metricId: ID!, teamIds: [ID]): Metric
+  metricsAddUserOwners(metricId: ID!, userIds: [ID], ownerType: GOwnerType): Metric
+  metricsRemoveUserOwners(metricId: ID!, userIds: [ID], ownerType: GOwnerType): Metric
+  metricsAssignTeamOwners(metricId: ID!, teamIds: [ID], ownerType: GOwnerType): Metric
+  metricsRemoveTeamOwners(metricId: ID!, teamIds: [ID], ownerType: GOwnerType): Metric
   metricsAddDescription(metricId: ID!, description: String!): Metric
-  metricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, extraFields: JSONString): Metric
+  metricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, extraFields: JSONString): Metric
   savedQueryCreate(title: String!, serializedQuery: GenericScalar!, metricIds: [ID], ownerTeamId: ID): SavedQuery
   savedQueryUpdate(id: ID!, title: String, createdBy: Int, ownerTeamId: Int, serializedQuery: GenericScalar, metricIds: [ID]): SavedQuery
   savedQueryDeactivate(id: ID!): SavedQuery
   sendInvites(emails: [String]!, organizationId: ID): Organization
   acceptTermsOfService(userId: ID!, versionId: ID!): User
   createTermsOfService(pdfUrl: String!): TermsOfServiceVersion
+  createSubscription(userId: ID!, metricId: ID!): User
 }
 
 """An enumeration."""
@@ -1297,6 +1492,13 @@ type RevokeMqlServerConfig {
 }
 
 """
+Stores environment variables required to spin up the MQL server into AWS Secrets Manager.
+"""
+type SetMqlServerEnvConfig {
+  success: Boolean
+}
+
+"""
 Graphene input object for a metric collection item. Essentially a dataclass.
 """
 input MetricCollectionItem {
@@ -1309,4 +1511,10 @@ input MetricCollectionItem {
 input MFAPref {
   requireMfa: Boolean!
   allowMfaRememberBrowser: Boolean!
+}
+
+"""An enumeration."""
+enum GOwnerType {
+  business
+  technical
 }

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -22,6 +22,7 @@ type Query {
   maxGranularityForMetrics(metricNames: [String]!, modelKey: ModelKeyInput): TimeGranularity
   queries(activeOnly: Boolean, status: MqlQueryStatus, metricNames: [String], dateRangeStart: Date, dateRangeEnd: Date, minExecutionSeconds: Float, maxExecutionSeconds: Float, userIds: [Int], limit: Int, offset: Int): [MqlQuery]
   healthReport: [MqlServerHealthItem]
+  validations(modelKey: ModelKeyInput): Validations
 }
 
 """
@@ -107,6 +108,10 @@ type MqlQueryResultSeries {
   """
   seriesValue: String
   data: [ResultDatum!]
+  isOtherCol: Boolean
+  value: Float
+  delta: Float
+  pctChange: Float
 }
 
 """This interface is used to describe any type of MQL Query result data"""
@@ -208,7 +213,7 @@ type Metric {
   constraint: String
   dimensions: [String!]
   dimensionObjects: [Dimension!]
-  dimensionValues(modelKey: ModelKeyInput, dimensionName: String, startTime: String, endTime: String, allowDynamicCache: Boolean): [String]
+  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int): [String]
   maxGranularity(modelKey: ModelKeyInput): TimeGranularity
 }
 
@@ -263,6 +268,11 @@ type MqlServerHealthItem {
   errorMessage: String
 }
 
+type Validations {
+  allIssues: [String!]
+  dataSourceIssues: [String!]
+}
+
 """Base mutation object exposed by GraphQL."""
 type Mutation {
   createMqlMaterializationNew(input: CreateMqlMaterializationNewInput!): CreateMqlMaterializationNewPayload
@@ -286,6 +296,16 @@ type Mutation {
   Rewrites SQL containing an MQL(...) function invocation by expanding into generated SQL
   """
   rewriteMqlSql(sql: String!): RewriteMqlSql
+
+  """
+  For metric, get latest value, percent change from the previous granularity period, and delta between the two.
+  """
+  queryLatestMetricChange(input: QueryLatestMetricChangeInput!): QueryLatestMetricChangePayload
+
+  """
+  Get percent change for given metric from start to end of date range (assuming daily granularity).
+  """
+  pctChangeOverRange(input: PctChangeOverRangeInput!): PctChangeOverRangePayload
 }
 
 type CreateMqlMaterializationNewPayload {
@@ -440,10 +460,12 @@ enum ResultFormat {
 
 """An enumeration."""
 enum PercentChange {
+  DOD
   WOW
   MOM
   QOQ
   YOY
+  DATE_RANGE
 }
 
 type Materialize {
@@ -463,6 +485,36 @@ Rewrites SQL containing an MQL(...) function invocation by expanding into genera
 """
 type RewriteMqlSql {
   resultSql: String
+}
+
+"""
+For metric, get latest value, percent change from the previous granularity period, and delta between the two.
+"""
+type QueryLatestMetricChangePayload {
+  id: ID!
+  query: MqlQuery
+  clientMutationId: String
+}
+
+input QueryLatestMetricChangeInput {
+  metricName: String!
+  clientMutationId: String
+}
+
+"""
+Get percent change for given metric from start to end of date range (assuming daily granularity).
+"""
+type PctChangeOverRangePayload {
+  id: ID!
+  query: MqlQuery
+  clientMutationId: String
+}
+
+input PctChangeOverRangeInput {
+  metricName: String!
+  startTime: String!
+  endTime: String!
+  clientMutationId: String
 }
 
 """


### PR DESCRIPTION
# Changes
Add pctChange and latestChange query hooks.  Allows us to get the pctChange for an annotation, and show the latest change of a metric in subscriptions.

# Security Implications
None
