### PR TITLE
Allow for external configuration of the MQL Server URL

### DIFF
--- a/context/MqlContext/MqlContextProvider.tsx
+++ b/context/MqlContext/MqlContextProvider.tsx
@@ -89,7 +89,7 @@ function MqlContextProviderInternal({
     refetchMqlServerUrl,
   ] = useQuery<MqlServerUrlQueryType>({
     query: MqlServerUrlQuery,
-    pause: !isAuthenticated,
+    pause: !isAuthenticated || !token,
   });
   if (mqlServerUrlError) handleCombinedError(mqlServerUrlError);
 

--- a/context/MqlContext/MqlContextProvider.tsx
+++ b/context/MqlContext/MqlContextProvider.tsx
@@ -166,7 +166,6 @@ function MqlContextProviderInternal({
         );
       }
     } else if (externalConfig) {
-      console.log('CONFIG WORKS')
       if (externalConfig?.mqlServerUrl !== mqlContext.mqlServerUrl) {
         stateToUpdate.mqlServerUrl = externalConfig?.mqlServerUrl;
       }
@@ -177,7 +176,6 @@ function MqlContextProviderInternal({
         );
       }
     } else {
-      console.log('OH NO')
       if (mqlServerUrlData?.myUser?.mqlServerUrl !== mqlContext.mqlServerUrl) {
         stateToUpdate.mqlServerUrl = mqlServerUrlData?.myUser?.mqlServerUrl;
       }

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -708,21 +708,21 @@ export type TeamMember = {
 
 /** An enumeration. */
 export enum TeamMemberOrderBy {
-  UserId = 'USER_ID',
-  JoinedAt = 'JOINED_AT',
   TeamId = 'TEAM_ID',
   IsTeamAdmin = 'IS_TEAM_ADMIN',
-  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
+  JoinedAt = 'JOINED_AT',
+  UserId = 'USER_ID',
   TeamMemberId = 'TeamMember_ID',
+  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
   UserOrganizationId = 'User_ORGANIZATION_ID',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
   Auth0Id = 'AUTH0_ID',
-  UpdatedAt = 'UPDATED_AT',
   Email = 'EMAIL',
-  AvatarUrl = 'AVATAR_URL',
-  UserName = 'USER_NAME'
+  UserName = 'USER_NAME',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UpdatedAt = 'UPDATED_AT',
+  AvatarUrl = 'AVATAR_URL'
 }
 
 export type TeamMemberOrderByInput = {
@@ -1139,13 +1139,13 @@ export enum QuestionReplyStrColumns {
 
 /** An enumeration. */
 export enum QuestionReplyOrderBy {
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  QuestionId = 'QUESTION_ID',
+  CreatedAt = 'CREATED_AT',
+  Text = 'TEXT',
   OrganizationId = 'ORGANIZATION_ID',
   AuthorId = 'AUTHOR_ID',
-  Text = 'TEXT',
-  CreatedAt = 'CREATED_AT'
+  Id = 'ID',
+  QuestionId = 'QUESTION_ID',
+  UpdatedAt = 'UPDATED_AT'
 }
 
 export type QuestionReplyOrderByInput = {
@@ -1161,18 +1161,18 @@ export enum QuestionStrColumns {
 
 /** An enumeration. */
 export enum QuestionOrderBy {
+  CreatedAt = 'CREATED_AT',
+  ResolvedAt = 'RESOLVED_AT',
+  AuthorId = 'AUTHOR_ID',
+  Id = 'ID',
   Resolved = 'RESOLVED',
   Priority = 'PRIORITY',
-  MetricId = 'METRIC_ID',
-  AuthorId = 'AUTHOR_ID',
-  ResolvedBy = 'RESOLVED_BY',
-  CreatedAt = 'CREATED_AT',
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  NotifiedAt = 'NOTIFIED_AT',
   OrganizationId = 'ORGANIZATION_ID',
   Text = 'TEXT',
-  ResolvedAt = 'RESOLVED_AT'
+  NotifiedAt = 'NOTIFIED_AT',
+  MetricId = 'METRIC_ID',
+  UpdatedAt = 'UPDATED_AT',
+  ResolvedBy = 'RESOLVED_BY'
 }
 
 export type QuestionOrderByInput = {
@@ -1260,27 +1260,27 @@ export enum Priority {
 
 /** An enumeration. */
 export enum AnnotationStrColumns {
-  ExpectedImpact = 'EXPECTED_IMPACT',
+  Title = 'TITLE',
   Text = 'TEXT',
   Priority = 'PRIORITY',
-  Title = 'TITLE'
+  ExpectedImpact = 'EXPECTED_IMPACT'
 }
 
 /** An enumeration. */
 export enum AnnotationOrderBy {
+  CreatedAt = 'CREATED_AT',
+  AuthorId = 'AUTHOR_ID',
+  Id = 'ID',
   Priority = 'PRIORITY',
   DateStartedAt = 'DATE_STARTED_AT',
-  Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
-  AuthorId = 'AUTHOR_ID',
-  CreatedAt = 'CREATED_AT',
-  ExpectedImpact = 'EXPECTED_IMPACT',
-  Id = 'ID',
   UpdatedAt = 'UPDATED_AT',
-  NotifiedAt = 'NOTIFIED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
+  DeletedAt = 'DELETED_AT',
+  DateEndedAt = 'DATE_ENDED_AT',
   Text = 'TEXT',
-  DateEndedAt = 'DATE_ENDED_AT'
+  OrganizationId = 'ORGANIZATION_ID',
+  ExpectedImpact = 'EXPECTED_IMPACT',
+  NotifiedAt = 'NOTIFIED_AT',
+  Title = 'TITLE'
 }
 
 export type AnnotationOrderByInput = {
@@ -1290,32 +1290,32 @@ export type AnnotationOrderByInput = {
 
 /** An enumeration. */
 export enum DataSourceVersionStrColumns {
-  Description = 'DESCRIPTION',
-  Hash = 'HASH',
   Connection = 'CONNECTION',
-  SqlTable = 'SQL_TABLE',
+  Hash = 'HASH',
+  Description = 'DESCRIPTION',
   Name = 'NAME',
+  SqlTable = 'SQL_TABLE',
   SqlQuery = 'SQL_QUERY'
 }
 
 /** An enumeration. */
 export enum DataSourceVersionOrderBy {
-  Dimensions = 'DIMENSIONS',
-  Description = 'DESCRIPTION',
+  CreatedAt = 'CREATED_AT',
+  Hash = 'HASH',
+  Owners = 'OWNERS',
+  Id = 'ID',
+  Measures = 'MEASURES',
   Mutability = 'MUTABILITY',
-  Identifiers = 'IDENTIFIERS',
   SqlTable = 'SQL_TABLE',
   Constraint = 'CONSTRAINT',
-  CreatedAt = 'CREATED_AT',
-  Name = 'NAME',
-  SqlQuery = 'SQL_QUERY',
-  DataSourceMetadata = 'DATA_SOURCE_METADATA',
   Connection = 'CONNECTION',
-  Owners = 'OWNERS',
-  Measures = 'MEASURES',
-  Id = 'ID',
-  Hash = 'HASH',
-  OrganizationId = 'ORGANIZATION_ID'
+  Dimensions = 'DIMENSIONS',
+  Description = 'DESCRIPTION',
+  Name = 'NAME',
+  OrganizationId = 'ORGANIZATION_ID',
+  Identifiers = 'IDENTIFIERS',
+  DataSourceMetadata = 'DATA_SOURCE_METADATA',
+  SqlQuery = 'SQL_QUERY'
 }
 
 export type DataSourceVersionOrderByInput = {
@@ -1355,42 +1355,42 @@ export type SavedQueryMetricsArgs = {
 
 /** An enumeration. */
 export enum MetricVersionStrColumns {
+  Hash = 'HASH',
   DisplayName = 'DISPLAY_NAME',
   Description = 'DESCRIPTION',
-  Hash = 'HASH',
   ValueFormat = 'VALUE_FORMAT'
 }
 
 /** An enumeration. */
 export enum MetricVersionOrderBy {
-  Description = 'DESCRIPTION',
-  Metadata = 'METADATA',
-  Params = 'PARAMS',
+  Hash = 'HASH',
   MetricType = 'METRIC_TYPE',
-  DisplayName = 'DISPLAY_NAME',
   Id = 'ID',
   SourceDataSourceVersions = 'SOURCE_DATA_SOURCE_VERSIONS',
-  Hash = 'HASH',
-  Tier = 'TIER',
-  OrganizationId = 'ORGANIZATION_ID',
   OrgDataSourceId = 'ORG_DATA_SOURCE_ID',
+  Description = 'DESCRIPTION',
+  OrganizationId = 'ORGANIZATION_ID',
+  DisplayName = 'DISPLAY_NAME',
+  Params = 'PARAMS',
+  Metadata = 'METADATA',
+  Tier = 'TIER',
   Views = 'VIEWS',
-  MetricVersionMetricId = 'MetricVersion_METRIC_ID',
   MetricVersionCreatedAt = 'MetricVersion_CREATED_AT',
-  MetricMetadataMetricId = 'MetricMetadata_METRIC_ID',
+  MetricVersionMetricId = 'MetricVersion_METRIC_ID',
   MetricMetadataCreatedAt = 'MetricMetadata_CREATED_AT',
-  CreatedBy = 'CREATED_BY',
-  ExtraFields = 'EXTRA_FIELDS',
-  IsNew = 'IS_NEW',
+  MetricMetadataMetricId = 'MetricMetadata_METRIC_ID',
   IncreaseIsGoodLock = 'INCREASE_IS_GOOD_LOCK',
-  IncreaseIsGood = 'INCREASE_IS_GOOD',
-  ValueFormatLock = 'VALUE_FORMAT_LOCK',
-  DisplayNameLock = 'DISPLAY_NAME_LOCK',
-  UpdatedAt = 'UPDATED_AT',
+  IsNew = 'IS_NEW',
   DescriptionLock = 'DESCRIPTION_LOCK',
-  UpdatedBy = 'UPDATED_BY',
+  ExtraFields = 'EXTRA_FIELDS',
+  CreatedBy = 'CREATED_BY',
   ValueFormat = 'VALUE_FORMAT',
-  TierLock = 'TIER_LOCK'
+  DisplayNameLock = 'DISPLAY_NAME_LOCK',
+  TierLock = 'TIER_LOCK',
+  IncreaseIsGood = 'INCREASE_IS_GOOD',
+  UpdatedAt = 'UPDATED_AT',
+  ValueFormatLock = 'VALUE_FORMAT_LOCK',
+  UpdatedBy = 'UPDATED_BY'
 }
 
 export type MetricVersionOrderByInput = {
@@ -1405,15 +1405,15 @@ export enum SavedQueryStrColumns {
 
 /** An enumeration. */
 export enum SavedQueryOrderBy {
-  Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
   CreatedAt = 'CREATED_AT',
-  SerializedQuery = 'SERIALIZED_QUERY',
   Id = 'ID',
+  CreatedBy = 'CREATED_BY',
   UpdatedAt = 'UPDATED_AT',
+  DeletedAt = 'DELETED_AT',
   OrganizationId = 'ORGANIZATION_ID',
-  OwnerTeamId = 'OWNER_TEAM_ID',
-  CreatedBy = 'CREATED_BY'
+  SerializedQuery = 'SERIALIZED_QUERY',
+  Title = 'TITLE',
+  OwnerTeamId = 'OWNER_TEAM_ID'
 }
 
 export type SavedQueryOrderByInput = {
@@ -1423,27 +1423,27 @@ export type SavedQueryOrderByInput = {
 
 /** An enumeration. */
 export enum TeamStrColumns {
-  Slug = 'SLUG',
   Description = 'DESCRIPTION',
+  Slug = 'SLUG',
   Name = 'NAME',
   Theme = 'THEME'
 }
 
 /** An enumeration. */
 export enum TeamOrderBy {
-  Slug = 'SLUG',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  Description = 'DESCRIPTION',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
-  Theme = 'THEME',
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
   FeaturedMetricCollectionId = 'FEATURED_METRIC_COLLECTION_ID',
-  Views = 'VIEWS',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  Id = 'ID',
+  Slug = 'SLUG',
+  CreatedBy = 'CREATED_BY',
+  Description = 'DESCRIPTION',
   Name = 'NAME',
-  CreatedBy = 'CREATED_BY'
+  OrganizationId = 'ORGANIZATION_ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UpdatedAt = 'UPDATED_AT',
+  Theme = 'THEME',
+  Views = 'VIEWS'
 }
 
 export type TeamOrderByInput = {
@@ -1461,16 +1461,16 @@ export enum UserStrColumns {
 
 /** An enumeration. */
 export enum UserOrderBy {
-  DeactivatedAt = 'DEACTIVATED_AT',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
   Auth0Id = 'AUTH0_ID',
-  Id = 'ID',
   Email = 'EMAIL',
-  UpdatedAt = 'UPDATED_AT',
+  UserName = 'USER_NAME',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  Id = 'ID',
   OrganizationId = 'ORGANIZATION_ID',
-  AvatarUrl = 'AVATAR_URL',
-  UserName = 'USER_NAME'
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UpdatedAt = 'UPDATED_AT',
+  AvatarUrl = 'AVATAR_URL'
 }
 
 export type UserOrderByInput = {
@@ -1480,13 +1480,13 @@ export type UserOrderByInput = {
 
 /** An enumeration. */
 export enum MetricCollectionMetricOrderBy {
-  MetricId = 'METRIC_ID',
-  Emphasis = 'EMPHASIS',
   CreatedAt = 'CREATED_AT',
+  Emphasis = 'EMPHASIS',
   Position = 'POSITION',
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
   SavedQueryId = 'SAVED_QUERY_ID',
+  Id = 'ID',
+  MetricId = 'METRIC_ID',
+  UpdatedAt = 'UPDATED_AT',
   MetricCollectionId = 'METRIC_COLLECTION_ID'
 }
 
@@ -1526,26 +1526,26 @@ export type TeamView = {
 
 /** An enumeration. */
 export enum MetricCollectionStrColumns {
+  Title = 'TITLE',
   Slug = 'SLUG',
-  Description = 'DESCRIPTION',
-  Title = 'TITLE'
+  Description = 'DESCRIPTION'
 }
 
 /** An enumeration. */
 export enum MetricCollectionOrderBy {
-  Slug = 'SLUG',
-  Description = 'DESCRIPTION',
-  Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
-  DefaultEmphasis = 'DEFAULT_EMPHASIS',
   Id = 'ID',
+  Slug = 'SLUG',
+  CreatedBy = 'CREATED_BY',
   UpdatedAt = 'UPDATED_AT',
+  DeletedAt = 'DELETED_AT',
+  Description = 'DESCRIPTION',
+  DefaultEmphasis = 'DEFAULT_EMPHASIS',
   OrganizationId = 'ORGANIZATION_ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  Title = 'TITLE',
   OwnerTeamId = 'OWNER_TEAM_ID',
-  Views = 'VIEWS',
-  CreatedBy = 'CREATED_BY'
+  Views = 'VIEWS'
 }
 
 export type MetricCollectionOrderByInput = {
@@ -1572,24 +1572,24 @@ export type ApiKey = {
 
 /** An enumeration. */
 export enum ApiKeyStrColumns {
-  Type = 'TYPE',
-  Scope = 'SCOPE',
   SecretHash = 'SECRET_HASH',
+  Scope = 'SCOPE',
+  Type = 'TYPE',
   Prefix = 'PREFIX'
 }
 
 /** An enumeration. */
 export enum ApiKeyOrderBy {
+  CreatedAt = 'CREATED_AT',
+  RevokerId = 'REVOKER_ID',
   UserId = 'USER_ID',
   SecretHash = 'SECRET_HASH',
-  Prefix = 'PREFIX',
-  CreatedAt = 'CREATED_AT',
-  Type = 'TYPE',
   LastUsedAt = 'LAST_USED_AT',
-  RevokerId = 'REVOKER_ID',
-  RevokedAt = 'REVOKED_AT',
+  Prefix = 'PREFIX',
+  Scope = 'SCOPE',
   OrganizationId = 'ORGANIZATION_ID',
-  Scope = 'SCOPE'
+  Type = 'TYPE',
+  RevokedAt = 'REVOKED_AT'
 }
 
 export type ApiKeyOrderByInput = {
@@ -1634,28 +1634,28 @@ export type FeatureUsersArgs = {
 
 /** An enumeration. */
 export enum OrganizationStrColumns {
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  LogoUrl = 'LOGO_URL',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
   Name = 'NAME',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH'
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  LogoUrl = 'LOGO_URL'
 }
 
 /** An enumeration. */
 export enum OrganizationOrderBy {
-  DeactivatedAt = 'DEACTIVATED_AT',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  LogoUrl = 'LOGO_URL',
-  IsHosted = 'IS_HOSTED',
   CreatedAt = 'CREATED_AT',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
   MqlServerLogs = 'MQL_SERVER_LOGS',
+  DeactivatedAt = 'DEACTIVATED_AT',
   Id = 'ID',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  Name = 'NAME',
   UpdatedAt = 'UPDATED_AT',
   Type = 'TYPE',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
-  Name = 'NAME'
+  IsHosted = 'IS_HOSTED',
+  LogoUrl = 'LOGO_URL'
 }
 
 export type OrganizationOrderByInput = {
@@ -1731,23 +1731,23 @@ export type DataWarehouseConfig = {
 
 /** An enumeration. */
 export enum OrgMqlServerStrColumns {
-  Url = 'URL',
+  Name = 'NAME',
   ConfigSecret = 'CONFIG_SECRET',
-  Name = 'NAME'
+  Url = 'URL'
 }
 
 /** An enumeration. */
 export enum OrgMqlServerOrderBy {
-  ConfigSecret = 'CONFIG_SECRET',
   CreatedAt = 'CREATED_AT',
-  IsOrgDefault = 'IS_ORG_DEFAULT',
-  Url = 'URL',
-  DwEngine = 'DW_ENGINE',
   Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
+  IsOrgDefault = 'IS_ORG_DEFAULT',
+  DwEngine = 'DW_ENGINE',
   DeploymentStatus = 'DEPLOYMENT_STATUS',
+  Name = 'NAME',
   OrganizationId = 'ORGANIZATION_ID',
-  Name = 'NAME'
+  ConfigSecret = 'CONFIG_SECRET',
+  Url = 'URL',
+  UpdatedAt = 'UPDATED_AT'
 }
 
 export type OrgMqlServerOrderByInput = {
@@ -1768,18 +1768,18 @@ export type OrgPref = {
 
 /** An enumeration. */
 export enum OrgPrefStrColumns {
-  PrefValue = 'PREF_VALUE',
-  PrefKey = 'PREF_KEY'
+  PrefKey = 'PREF_KEY',
+  PrefValue = 'PREF_VALUE'
 }
 
 /** An enumeration. */
 export enum OrgPrefOrderBy {
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
   PrefValue = 'PREF_VALUE',
   Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
   PrefKey = 'PREF_KEY',
-  CreatedAt = 'CREATED_AT'
+  UpdatedAt = 'UPDATED_AT'
 }
 
 export type OrgPrefOrderByInput = {
@@ -1809,11 +1809,11 @@ export enum FeatureStrColumns {
 
 /** An enumeration. */
 export enum FeatureOrderBy {
+  CreatedAt = 'CREATED_AT',
+  Name = 'NAME',
   Id = 'ID',
   UpdatedAt = 'UPDATED_AT',
-  RetiredAt = 'RETIRED_AT',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT'
+  RetiredAt = 'RETIRED_AT'
 }
 
 export type FeatureOrderByInput = {
@@ -1879,7 +1879,6 @@ export type Mutation = {
   __typename?: 'Mutation';
   revokeApiKeyTest?: Maybe<ApiKey>;
   createOrganizationTest?: Maybe<Organization>;
-  logMqlLog?: Maybe<LogMqlLogs>;
   setOrgMqlServerConfigSecret?: Maybe<SetOrgMqlServerConfigSecretId>;
   sendMqlHeartbeat?: Maybe<SendMqlHeartbeat>;
   createAnnotationTest?: Maybe<CreateAnnotation>;
@@ -1993,19 +1992,6 @@ export type MutationCreateOrganizationTestArgs = {
   allowMfaRememberBrowser?: Maybe<Scalars['Boolean']>;
   allowedEmailDomains?: Maybe<Array<Maybe<Scalars['String']>>>;
   orgType?: Maybe<GOrgType>;
-};
-
-
-/**
- * Base mutation object exposed by GraphQL.
- *
- * Mutation names will be converted from snake_case to camelCase automatically
- * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
- */
-export type MutationLogMqlLogArgs = {
-  level?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -2900,11 +2886,6 @@ export enum GOrgType {
   Internal = 'INTERNAL',
   Test = 'TEST'
 }
-
-export type LogMqlLogs = {
-  __typename?: 'LogMQLLogs';
-  ok?: Maybe<Scalars['Boolean']>;
-};
 
 export type SetOrgMqlServerConfigSecretId = {
   __typename?: 'SetOrgMqlServerConfigSecretId';

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -383,6 +383,7 @@ export enum QueryResultSource {
   DynamicCache = 'DYNAMIC_CACHE',
   DwMaterialization = 'DW_MATERIALIZATION',
   FastCache = 'FAST_CACHE',
+  Metricflow = 'METRICFLOW',
   NotApplicable = 'NOT_APPLICABLE',
   NotSpecified = 'NOT_SPECIFIED'
 }
@@ -445,6 +446,7 @@ export type MetricDimensionValuesArgs = {
   allowDynamicCache?: Maybe<Scalars['Boolean']>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+  searchStr?: Maybe<Scalars['String']>;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -708,21 +708,21 @@ export type TeamMember = {
 
 /** An enumeration. */
 export enum TeamMemberOrderBy {
-  UserId = 'USER_ID',
-  JoinedAt = 'JOINED_AT',
   TeamId = 'TEAM_ID',
   IsTeamAdmin = 'IS_TEAM_ADMIN',
-  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
+  JoinedAt = 'JOINED_AT',
+  UserId = 'USER_ID',
   TeamMemberId = 'TeamMember_ID',
+  TeamMemberOrganizationId = 'TeamMember_ORGANIZATION_ID',
   UserOrganizationId = 'User_ORGANIZATION_ID',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
   Auth0Id = 'AUTH0_ID',
-  UpdatedAt = 'UPDATED_AT',
   Email = 'EMAIL',
-  AvatarUrl = 'AVATAR_URL',
-  UserName = 'USER_NAME'
+  UserName = 'USER_NAME',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UpdatedAt = 'UPDATED_AT',
+  AvatarUrl = 'AVATAR_URL'
 }
 
 export type TeamMemberOrderByInput = {
@@ -1139,13 +1139,13 @@ export enum QuestionReplyStrColumns {
 
 /** An enumeration. */
 export enum QuestionReplyOrderBy {
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  QuestionId = 'QUESTION_ID',
+  CreatedAt = 'CREATED_AT',
+  Text = 'TEXT',
   OrganizationId = 'ORGANIZATION_ID',
   AuthorId = 'AUTHOR_ID',
-  Text = 'TEXT',
-  CreatedAt = 'CREATED_AT'
+  Id = 'ID',
+  QuestionId = 'QUESTION_ID',
+  UpdatedAt = 'UPDATED_AT'
 }
 
 export type QuestionReplyOrderByInput = {
@@ -1161,18 +1161,18 @@ export enum QuestionStrColumns {
 
 /** An enumeration. */
 export enum QuestionOrderBy {
+  CreatedAt = 'CREATED_AT',
+  ResolvedAt = 'RESOLVED_AT',
+  AuthorId = 'AUTHOR_ID',
+  Id = 'ID',
   Resolved = 'RESOLVED',
   Priority = 'PRIORITY',
-  MetricId = 'METRIC_ID',
-  AuthorId = 'AUTHOR_ID',
-  ResolvedBy = 'RESOLVED_BY',
-  CreatedAt = 'CREATED_AT',
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  NotifiedAt = 'NOTIFIED_AT',
   OrganizationId = 'ORGANIZATION_ID',
   Text = 'TEXT',
-  ResolvedAt = 'RESOLVED_AT'
+  NotifiedAt = 'NOTIFIED_AT',
+  MetricId = 'METRIC_ID',
+  UpdatedAt = 'UPDATED_AT',
+  ResolvedBy = 'RESOLVED_BY'
 }
 
 export type QuestionOrderByInput = {
@@ -1260,27 +1260,27 @@ export enum Priority {
 
 /** An enumeration. */
 export enum AnnotationStrColumns {
-  ExpectedImpact = 'EXPECTED_IMPACT',
+  Title = 'TITLE',
   Text = 'TEXT',
   Priority = 'PRIORITY',
-  Title = 'TITLE'
+  ExpectedImpact = 'EXPECTED_IMPACT'
 }
 
 /** An enumeration. */
 export enum AnnotationOrderBy {
+  CreatedAt = 'CREATED_AT',
+  AuthorId = 'AUTHOR_ID',
+  Id = 'ID',
   Priority = 'PRIORITY',
   DateStartedAt = 'DATE_STARTED_AT',
-  Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
-  AuthorId = 'AUTHOR_ID',
-  CreatedAt = 'CREATED_AT',
-  ExpectedImpact = 'EXPECTED_IMPACT',
-  Id = 'ID',
   UpdatedAt = 'UPDATED_AT',
-  NotifiedAt = 'NOTIFIED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
+  DeletedAt = 'DELETED_AT',
+  DateEndedAt = 'DATE_ENDED_AT',
   Text = 'TEXT',
-  DateEndedAt = 'DATE_ENDED_AT'
+  OrganizationId = 'ORGANIZATION_ID',
+  ExpectedImpact = 'EXPECTED_IMPACT',
+  NotifiedAt = 'NOTIFIED_AT',
+  Title = 'TITLE'
 }
 
 export type AnnotationOrderByInput = {
@@ -1290,32 +1290,32 @@ export type AnnotationOrderByInput = {
 
 /** An enumeration. */
 export enum DataSourceVersionStrColumns {
-  Description = 'DESCRIPTION',
-  Hash = 'HASH',
   Connection = 'CONNECTION',
-  SqlTable = 'SQL_TABLE',
+  Hash = 'HASH',
+  Description = 'DESCRIPTION',
   Name = 'NAME',
+  SqlTable = 'SQL_TABLE',
   SqlQuery = 'SQL_QUERY'
 }
 
 /** An enumeration. */
 export enum DataSourceVersionOrderBy {
-  Dimensions = 'DIMENSIONS',
-  Description = 'DESCRIPTION',
+  CreatedAt = 'CREATED_AT',
+  Hash = 'HASH',
+  Owners = 'OWNERS',
+  Id = 'ID',
+  Measures = 'MEASURES',
   Mutability = 'MUTABILITY',
-  Identifiers = 'IDENTIFIERS',
   SqlTable = 'SQL_TABLE',
   Constraint = 'CONSTRAINT',
-  CreatedAt = 'CREATED_AT',
-  Name = 'NAME',
-  SqlQuery = 'SQL_QUERY',
-  DataSourceMetadata = 'DATA_SOURCE_METADATA',
   Connection = 'CONNECTION',
-  Owners = 'OWNERS',
-  Measures = 'MEASURES',
-  Id = 'ID',
-  Hash = 'HASH',
-  OrganizationId = 'ORGANIZATION_ID'
+  Dimensions = 'DIMENSIONS',
+  Description = 'DESCRIPTION',
+  Name = 'NAME',
+  OrganizationId = 'ORGANIZATION_ID',
+  Identifiers = 'IDENTIFIERS',
+  DataSourceMetadata = 'DATA_SOURCE_METADATA',
+  SqlQuery = 'SQL_QUERY'
 }
 
 export type DataSourceVersionOrderByInput = {
@@ -1355,42 +1355,42 @@ export type SavedQueryMetricsArgs = {
 
 /** An enumeration. */
 export enum MetricVersionStrColumns {
+  Hash = 'HASH',
   DisplayName = 'DISPLAY_NAME',
   Description = 'DESCRIPTION',
-  Hash = 'HASH',
   ValueFormat = 'VALUE_FORMAT'
 }
 
 /** An enumeration. */
 export enum MetricVersionOrderBy {
-  Description = 'DESCRIPTION',
-  Metadata = 'METADATA',
-  Params = 'PARAMS',
+  Hash = 'HASH',
   MetricType = 'METRIC_TYPE',
-  DisplayName = 'DISPLAY_NAME',
   Id = 'ID',
   SourceDataSourceVersions = 'SOURCE_DATA_SOURCE_VERSIONS',
-  Hash = 'HASH',
-  Tier = 'TIER',
-  OrganizationId = 'ORGANIZATION_ID',
   OrgDataSourceId = 'ORG_DATA_SOURCE_ID',
+  Description = 'DESCRIPTION',
+  OrganizationId = 'ORGANIZATION_ID',
+  DisplayName = 'DISPLAY_NAME',
+  Params = 'PARAMS',
+  Metadata = 'METADATA',
+  Tier = 'TIER',
   Views = 'VIEWS',
-  MetricVersionMetricId = 'MetricVersion_METRIC_ID',
   MetricVersionCreatedAt = 'MetricVersion_CREATED_AT',
-  MetricMetadataMetricId = 'MetricMetadata_METRIC_ID',
+  MetricVersionMetricId = 'MetricVersion_METRIC_ID',
   MetricMetadataCreatedAt = 'MetricMetadata_CREATED_AT',
-  CreatedBy = 'CREATED_BY',
-  ExtraFields = 'EXTRA_FIELDS',
-  IsNew = 'IS_NEW',
+  MetricMetadataMetricId = 'MetricMetadata_METRIC_ID',
   IncreaseIsGoodLock = 'INCREASE_IS_GOOD_LOCK',
-  IncreaseIsGood = 'INCREASE_IS_GOOD',
-  ValueFormatLock = 'VALUE_FORMAT_LOCK',
-  DisplayNameLock = 'DISPLAY_NAME_LOCK',
-  UpdatedAt = 'UPDATED_AT',
+  IsNew = 'IS_NEW',
   DescriptionLock = 'DESCRIPTION_LOCK',
-  UpdatedBy = 'UPDATED_BY',
+  ExtraFields = 'EXTRA_FIELDS',
+  CreatedBy = 'CREATED_BY',
   ValueFormat = 'VALUE_FORMAT',
-  TierLock = 'TIER_LOCK'
+  DisplayNameLock = 'DISPLAY_NAME_LOCK',
+  TierLock = 'TIER_LOCK',
+  IncreaseIsGood = 'INCREASE_IS_GOOD',
+  UpdatedAt = 'UPDATED_AT',
+  ValueFormatLock = 'VALUE_FORMAT_LOCK',
+  UpdatedBy = 'UPDATED_BY'
 }
 
 export type MetricVersionOrderByInput = {
@@ -1405,15 +1405,15 @@ export enum SavedQueryStrColumns {
 
 /** An enumeration. */
 export enum SavedQueryOrderBy {
-  Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
   CreatedAt = 'CREATED_AT',
-  SerializedQuery = 'SERIALIZED_QUERY',
   Id = 'ID',
+  CreatedBy = 'CREATED_BY',
   UpdatedAt = 'UPDATED_AT',
+  DeletedAt = 'DELETED_AT',
   OrganizationId = 'ORGANIZATION_ID',
-  OwnerTeamId = 'OWNER_TEAM_ID',
-  CreatedBy = 'CREATED_BY'
+  SerializedQuery = 'SERIALIZED_QUERY',
+  Title = 'TITLE',
+  OwnerTeamId = 'OWNER_TEAM_ID'
 }
 
 export type SavedQueryOrderByInput = {
@@ -1423,27 +1423,27 @@ export type SavedQueryOrderByInput = {
 
 /** An enumeration. */
 export enum TeamStrColumns {
-  Slug = 'SLUG',
   Description = 'DESCRIPTION',
+  Slug = 'SLUG',
   Name = 'NAME',
   Theme = 'THEME'
 }
 
 /** An enumeration. */
 export enum TeamOrderBy {
-  Slug = 'SLUG',
-  DeactivatedAt = 'DEACTIVATED_AT',
-  Description = 'DESCRIPTION',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
-  Theme = 'THEME',
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
   FeaturedMetricCollectionId = 'FEATURED_METRIC_COLLECTION_ID',
-  Views = 'VIEWS',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  Id = 'ID',
+  Slug = 'SLUG',
+  CreatedBy = 'CREATED_BY',
+  Description = 'DESCRIPTION',
   Name = 'NAME',
-  CreatedBy = 'CREATED_BY'
+  OrganizationId = 'ORGANIZATION_ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UpdatedAt = 'UPDATED_AT',
+  Theme = 'THEME',
+  Views = 'VIEWS'
 }
 
 export type TeamOrderByInput = {
@@ -1461,16 +1461,16 @@ export enum UserStrColumns {
 
 /** An enumeration. */
 export enum UserOrderBy {
-  DeactivatedAt = 'DEACTIVATED_AT',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
   Auth0Id = 'AUTH0_ID',
-  Id = 'ID',
   Email = 'EMAIL',
-  UpdatedAt = 'UPDATED_AT',
+  UserName = 'USER_NAME',
+  DeactivatedAt = 'DEACTIVATED_AT',
+  Id = 'ID',
   OrganizationId = 'ORGANIZATION_ID',
-  AvatarUrl = 'AVATAR_URL',
-  UserName = 'USER_NAME'
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  UpdatedAt = 'UPDATED_AT',
+  AvatarUrl = 'AVATAR_URL'
 }
 
 export type UserOrderByInput = {
@@ -1480,13 +1480,13 @@ export type UserOrderByInput = {
 
 /** An enumeration. */
 export enum MetricCollectionMetricOrderBy {
-  MetricId = 'METRIC_ID',
-  Emphasis = 'EMPHASIS',
   CreatedAt = 'CREATED_AT',
+  Emphasis = 'EMPHASIS',
   Position = 'POSITION',
-  Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
   SavedQueryId = 'SAVED_QUERY_ID',
+  Id = 'ID',
+  MetricId = 'METRIC_ID',
+  UpdatedAt = 'UPDATED_AT',
   MetricCollectionId = 'METRIC_COLLECTION_ID'
 }
 
@@ -1526,26 +1526,26 @@ export type TeamView = {
 
 /** An enumeration. */
 export enum MetricCollectionStrColumns {
+  Title = 'TITLE',
   Slug = 'SLUG',
-  Description = 'DESCRIPTION',
-  Title = 'TITLE'
+  Description = 'DESCRIPTION'
 }
 
 /** An enumeration. */
 export enum MetricCollectionOrderBy {
-  Slug = 'SLUG',
-  Description = 'DESCRIPTION',
-  Title = 'TITLE',
-  DeletedAt = 'DELETED_AT',
-  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
   CreatedAt = 'CREATED_AT',
-  DefaultEmphasis = 'DEFAULT_EMPHASIS',
   Id = 'ID',
+  Slug = 'SLUG',
+  CreatedBy = 'CREATED_BY',
   UpdatedAt = 'UPDATED_AT',
+  DeletedAt = 'DELETED_AT',
+  Description = 'DESCRIPTION',
+  DefaultEmphasis = 'DEFAULT_EMPHASIS',
   OrganizationId = 'ORGANIZATION_ID',
+  PrimaryDashboardId = 'PRIMARY_DASHBOARD_ID',
+  Title = 'TITLE',
   OwnerTeamId = 'OWNER_TEAM_ID',
-  Views = 'VIEWS',
-  CreatedBy = 'CREATED_BY'
+  Views = 'VIEWS'
 }
 
 export type MetricCollectionOrderByInput = {
@@ -1572,24 +1572,24 @@ export type ApiKey = {
 
 /** An enumeration. */
 export enum ApiKeyStrColumns {
-  Type = 'TYPE',
-  Scope = 'SCOPE',
   SecretHash = 'SECRET_HASH',
+  Scope = 'SCOPE',
+  Type = 'TYPE',
   Prefix = 'PREFIX'
 }
 
 /** An enumeration. */
 export enum ApiKeyOrderBy {
+  CreatedAt = 'CREATED_AT',
+  RevokerId = 'REVOKER_ID',
   UserId = 'USER_ID',
   SecretHash = 'SECRET_HASH',
-  Prefix = 'PREFIX',
-  CreatedAt = 'CREATED_AT',
-  Type = 'TYPE',
   LastUsedAt = 'LAST_USED_AT',
-  RevokerId = 'REVOKER_ID',
-  RevokedAt = 'REVOKED_AT',
+  Prefix = 'PREFIX',
+  Scope = 'SCOPE',
   OrganizationId = 'ORGANIZATION_ID',
-  Scope = 'SCOPE'
+  Type = 'TYPE',
+  RevokedAt = 'REVOKED_AT'
 }
 
 export type ApiKeyOrderByInput = {
@@ -1634,28 +1634,28 @@ export type FeatureUsersArgs = {
 
 /** An enumeration. */
 export enum OrganizationStrColumns {
-  MqlServerLogs = 'MQL_SERVER_LOGS',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  LogoUrl = 'LOGO_URL',
   SourceControlUrl = 'SOURCE_CONTROL_URL',
+  MqlServerLogs = 'MQL_SERVER_LOGS',
   Name = 'NAME',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH'
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  LogoUrl = 'LOGO_URL'
 }
 
 /** An enumeration. */
 export enum OrganizationOrderBy {
-  DeactivatedAt = 'DEACTIVATED_AT',
-  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
-  LogoUrl = 'LOGO_URL',
-  IsHosted = 'IS_HOSTED',
   CreatedAt = 'CREATED_AT',
-  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
   MqlServerLogs = 'MQL_SERVER_LOGS',
+  DeactivatedAt = 'DEACTIVATED_AT',
   Id = 'ID',
+  PrimaryConfigBranch = 'PRIMARY_CONFIG_BRANCH',
+  PrimaryConfigRepo = 'PRIMARY_CONFIG_REPO',
+  SourceControlUrl = 'SOURCE_CONTROL_URL',
+  Name = 'NAME',
   UpdatedAt = 'UPDATED_AT',
   Type = 'TYPE',
-  SourceControlUrl = 'SOURCE_CONTROL_URL',
-  Name = 'NAME'
+  IsHosted = 'IS_HOSTED',
+  LogoUrl = 'LOGO_URL'
 }
 
 export type OrganizationOrderByInput = {
@@ -1731,23 +1731,23 @@ export type DataWarehouseConfig = {
 
 /** An enumeration. */
 export enum OrgMqlServerStrColumns {
-  Url = 'URL',
+  Name = 'NAME',
   ConfigSecret = 'CONFIG_SECRET',
-  Name = 'NAME'
+  Url = 'URL'
 }
 
 /** An enumeration. */
 export enum OrgMqlServerOrderBy {
-  ConfigSecret = 'CONFIG_SECRET',
   CreatedAt = 'CREATED_AT',
-  IsOrgDefault = 'IS_ORG_DEFAULT',
-  Url = 'URL',
-  DwEngine = 'DW_ENGINE',
   Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
+  IsOrgDefault = 'IS_ORG_DEFAULT',
+  DwEngine = 'DW_ENGINE',
   DeploymentStatus = 'DEPLOYMENT_STATUS',
+  Name = 'NAME',
   OrganizationId = 'ORGANIZATION_ID',
-  Name = 'NAME'
+  ConfigSecret = 'CONFIG_SECRET',
+  Url = 'URL',
+  UpdatedAt = 'UPDATED_AT'
 }
 
 export type OrgMqlServerOrderByInput = {
@@ -1768,18 +1768,18 @@ export type OrgPref = {
 
 /** An enumeration. */
 export enum OrgPrefStrColumns {
-  PrefValue = 'PREF_VALUE',
-  PrefKey = 'PREF_KEY'
+  PrefKey = 'PREF_KEY',
+  PrefValue = 'PREF_VALUE'
 }
 
 /** An enumeration. */
 export enum OrgPrefOrderBy {
+  CreatedAt = 'CREATED_AT',
+  OrganizationId = 'ORGANIZATION_ID',
   PrefValue = 'PREF_VALUE',
   Id = 'ID',
-  UpdatedAt = 'UPDATED_AT',
-  OrganizationId = 'ORGANIZATION_ID',
   PrefKey = 'PREF_KEY',
-  CreatedAt = 'CREATED_AT'
+  UpdatedAt = 'UPDATED_AT'
 }
 
 export type OrgPrefOrderByInput = {
@@ -1809,11 +1809,11 @@ export enum FeatureStrColumns {
 
 /** An enumeration. */
 export enum FeatureOrderBy {
+  CreatedAt = 'CREATED_AT',
+  Name = 'NAME',
   Id = 'ID',
   UpdatedAt = 'UPDATED_AT',
-  RetiredAt = 'RETIRED_AT',
-  Name = 'NAME',
-  CreatedAt = 'CREATED_AT'
+  RetiredAt = 'RETIRED_AT'
 }
 
 export type FeatureOrderByInput = {
@@ -1879,7 +1879,6 @@ export type Mutation = {
   __typename?: 'Mutation';
   revokeApiKeyTest?: Maybe<ApiKey>;
   createOrganizationTest?: Maybe<Organization>;
-  logMqlLog?: Maybe<LogMqlLogs>;
   setOrgMqlServerConfigSecret?: Maybe<SetOrgMqlServerConfigSecretId>;
   sendMqlHeartbeat?: Maybe<SendMqlHeartbeat>;
   createAnnotationTest?: Maybe<CreateAnnotation>;
@@ -1993,19 +1992,6 @@ export type MutationCreateOrganizationTestArgs = {
   allowMfaRememberBrowser?: Maybe<Scalars['Boolean']>;
   allowedEmailDomains?: Maybe<Array<Maybe<Scalars['String']>>>;
   orgType?: Maybe<GOrgType>;
-};
-
-
-/**
- * Base mutation object exposed by GraphQL.
- *
- * Mutation names will be converted from snake_case to camelCase automatically
- * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
- */
-export type MutationLogMqlLogArgs = {
-  level?: Maybe<Scalars['String']>;
-  message?: Maybe<Scalars['String']>;
-  tags?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -2900,11 +2886,6 @@ export enum GOrgType {
   Internal = 'INTERNAL',
   Test = 'TEST'
 }
-
-export type LogMqlLogs = {
-  __typename?: 'LogMQLLogs';
-  ok?: Maybe<Scalars['Boolean']>;
-};
 
 export type SetOrgMqlServerConfigSecretId = {
   __typename?: 'SetOrgMqlServerConfigSecretId';

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -383,6 +383,7 @@ export enum QueryResultSource {
   DynamicCache = 'DYNAMIC_CACHE',
   DwMaterialization = 'DW_MATERIALIZATION',
   FastCache = 'FAST_CACHE',
+  Metricflow = 'METRICFLOW',
   NotApplicable = 'NOT_APPLICABLE',
   NotSpecified = 'NOT_SPECIFIED'
 }
@@ -445,6 +446,7 @@ export type MetricDimensionValuesArgs = {
   allowDynamicCache?: Maybe<Scalars['Boolean']>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+  searchStr?: Maybe<Scalars['String']>;
 };
 
 

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -242,21 +242,21 @@ type TeamMember {
 
 """An enumeration."""
 enum TeamMemberOrderBy {
-  USER_ID
-  JOINED_AT
   TEAM_ID
   IS_TEAM_ADMIN
-  TeamMember_ORGANIZATION_ID
+  JOINED_AT
+  USER_ID
   TeamMember_ID
+  TeamMember_ORGANIZATION_ID
   User_ORGANIZATION_ID
-  DEACTIVATED_AT
-  PRIMARY_DASHBOARD_ID
   CREATED_AT
   AUTH0_ID
-  UPDATED_AT
   EMAIL
-  AVATAR_URL
   USER_NAME
+  DEACTIVATED_AT
+  PRIMARY_DASHBOARD_ID
+  UPDATED_AT
+  AVATAR_URL
 }
 
 input TeamMemberOrderByInput {
@@ -571,13 +571,13 @@ enum QuestionReplyStrColumns {
 
 """An enumeration."""
 enum QuestionReplyOrderBy {
-  ID
-  UPDATED_AT
-  QUESTION_ID
+  CREATED_AT
+  TEXT
   ORGANIZATION_ID
   AUTHOR_ID
-  TEXT
-  CREATED_AT
+  ID
+  QUESTION_ID
+  UPDATED_AT
 }
 
 input QuestionReplyOrderByInput {
@@ -593,18 +593,18 @@ enum QuestionStrColumns {
 
 """An enumeration."""
 enum QuestionOrderBy {
+  CREATED_AT
+  RESOLVED_AT
+  AUTHOR_ID
+  ID
   RESOLVED
   PRIORITY
-  METRIC_ID
-  AUTHOR_ID
-  RESOLVED_BY
-  CREATED_AT
-  ID
-  UPDATED_AT
-  NOTIFIED_AT
   ORGANIZATION_ID
   TEXT
-  RESOLVED_AT
+  NOTIFIED_AT
+  METRIC_ID
+  UPDATED_AT
+  RESOLVED_BY
 }
 
 input QuestionOrderByInput {
@@ -693,27 +693,27 @@ enum Priority {
 
 """An enumeration."""
 enum AnnotationStrColumns {
-  EXPECTED_IMPACT
+  TITLE
   TEXT
   PRIORITY
-  TITLE
+  EXPECTED_IMPACT
 }
 
 """An enumeration."""
 enum AnnotationOrderBy {
+  CREATED_AT
+  AUTHOR_ID
+  ID
   PRIORITY
   DATE_STARTED_AT
-  TITLE
-  DELETED_AT
-  AUTHOR_ID
-  CREATED_AT
-  EXPECTED_IMPACT
-  ID
   UPDATED_AT
-  NOTIFIED_AT
-  ORGANIZATION_ID
-  TEXT
+  DELETED_AT
   DATE_ENDED_AT
+  TEXT
+  ORGANIZATION_ID
+  EXPECTED_IMPACT
+  NOTIFIED_AT
+  TITLE
 }
 
 input AnnotationOrderByInput {
@@ -723,32 +723,32 @@ input AnnotationOrderByInput {
 
 """An enumeration."""
 enum DataSourceVersionStrColumns {
-  DESCRIPTION
-  HASH
   CONNECTION
-  SQL_TABLE
+  HASH
+  DESCRIPTION
   NAME
+  SQL_TABLE
   SQL_QUERY
 }
 
 """An enumeration."""
 enum DataSourceVersionOrderBy {
-  DIMENSIONS
-  DESCRIPTION
+  CREATED_AT
+  HASH
+  OWNERS
+  ID
+  MEASURES
   MUTABILITY
-  IDENTIFIERS
   SQL_TABLE
   CONSTRAINT
-  CREATED_AT
-  NAME
-  SQL_QUERY
-  DATA_SOURCE_METADATA
   CONNECTION
-  OWNERS
-  MEASURES
-  ID
-  HASH
+  DIMENSIONS
+  DESCRIPTION
+  NAME
   ORGANIZATION_ID
+  IDENTIFIERS
+  DATA_SOURCE_METADATA
+  SQL_QUERY
 }
 
 input DataSourceVersionOrderByInput {
@@ -776,42 +776,42 @@ type SavedQuery {
 
 """An enumeration."""
 enum MetricVersionStrColumns {
+  HASH
   DISPLAY_NAME
   DESCRIPTION
-  HASH
   VALUE_FORMAT
 }
 
 """An enumeration."""
 enum MetricVersionOrderBy {
-  DESCRIPTION
-  METADATA
-  PARAMS
+  HASH
   METRIC_TYPE
-  DISPLAY_NAME
   ID
   SOURCE_DATA_SOURCE_VERSIONS
-  HASH
-  TIER
-  ORGANIZATION_ID
   ORG_DATA_SOURCE_ID
+  DESCRIPTION
+  ORGANIZATION_ID
+  DISPLAY_NAME
+  PARAMS
+  METADATA
+  TIER
   VIEWS
-  MetricVersion_METRIC_ID
   MetricVersion_CREATED_AT
-  MetricMetadata_METRIC_ID
+  MetricVersion_METRIC_ID
   MetricMetadata_CREATED_AT
-  CREATED_BY
-  EXTRA_FIELDS
-  IS_NEW
+  MetricMetadata_METRIC_ID
   INCREASE_IS_GOOD_LOCK
-  INCREASE_IS_GOOD
-  VALUE_FORMAT_LOCK
-  DISPLAY_NAME_LOCK
-  UPDATED_AT
+  IS_NEW
   DESCRIPTION_LOCK
-  UPDATED_BY
+  EXTRA_FIELDS
+  CREATED_BY
   VALUE_FORMAT
+  DISPLAY_NAME_LOCK
   TIER_LOCK
+  INCREASE_IS_GOOD
+  UPDATED_AT
+  VALUE_FORMAT_LOCK
+  UPDATED_BY
 }
 
 input MetricVersionOrderByInput {
@@ -826,15 +826,15 @@ enum SavedQueryStrColumns {
 
 """An enumeration."""
 enum SavedQueryOrderBy {
-  TITLE
-  DELETED_AT
   CREATED_AT
-  SERIALIZED_QUERY
   ID
-  UPDATED_AT
-  ORGANIZATION_ID
-  OWNER_TEAM_ID
   CREATED_BY
+  UPDATED_AT
+  DELETED_AT
+  ORGANIZATION_ID
+  SERIALIZED_QUERY
+  TITLE
+  OWNER_TEAM_ID
 }
 
 input SavedQueryOrderByInput {
@@ -844,27 +844,27 @@ input SavedQueryOrderByInput {
 
 """An enumeration."""
 enum TeamStrColumns {
-  SLUG
   DESCRIPTION
+  SLUG
   NAME
   THEME
 }
 
 """An enumeration."""
 enum TeamOrderBy {
-  SLUG
-  DEACTIVATED_AT
-  DESCRIPTION
-  PRIMARY_DASHBOARD_ID
   CREATED_AT
-  THEME
-  ID
-  UPDATED_AT
-  ORGANIZATION_ID
   FEATURED_METRIC_COLLECTION_ID
-  VIEWS
-  NAME
+  DEACTIVATED_AT
+  ID
+  SLUG
   CREATED_BY
+  DESCRIPTION
+  NAME
+  ORGANIZATION_ID
+  PRIMARY_DASHBOARD_ID
+  UPDATED_AT
+  THEME
+  VIEWS
 }
 
 input TeamOrderByInput {
@@ -882,16 +882,16 @@ enum UserStrColumns {
 
 """An enumeration."""
 enum UserOrderBy {
-  DEACTIVATED_AT
-  PRIMARY_DASHBOARD_ID
   CREATED_AT
   AUTH0_ID
-  ID
   EMAIL
-  UPDATED_AT
-  ORGANIZATION_ID
-  AVATAR_URL
   USER_NAME
+  DEACTIVATED_AT
+  ID
+  ORGANIZATION_ID
+  PRIMARY_DASHBOARD_ID
+  UPDATED_AT
+  AVATAR_URL
 }
 
 input UserOrderByInput {
@@ -901,13 +901,13 @@ input UserOrderByInput {
 
 """An enumeration."""
 enum MetricCollectionMetricOrderBy {
-  METRIC_ID
-  EMPHASIS
   CREATED_AT
+  EMPHASIS
   POSITION
-  ID
-  UPDATED_AT
   SAVED_QUERY_ID
+  ID
+  METRIC_ID
+  UPDATED_AT
   METRIC_COLLECTION_ID
 }
 
@@ -945,26 +945,26 @@ type TeamView {
 
 """An enumeration."""
 enum MetricCollectionStrColumns {
+  TITLE
   SLUG
   DESCRIPTION
-  TITLE
 }
 
 """An enumeration."""
 enum MetricCollectionOrderBy {
-  SLUG
-  DESCRIPTION
-  TITLE
-  DELETED_AT
-  PRIMARY_DASHBOARD_ID
   CREATED_AT
-  DEFAULT_EMPHASIS
   ID
+  SLUG
+  CREATED_BY
   UPDATED_AT
+  DELETED_AT
+  DESCRIPTION
+  DEFAULT_EMPHASIS
   ORGANIZATION_ID
+  PRIMARY_DASHBOARD_ID
+  TITLE
   OWNER_TEAM_ID
   VIEWS
-  CREATED_BY
 }
 
 input MetricCollectionOrderByInput {
@@ -990,24 +990,24 @@ type ApiKey {
 
 """An enumeration."""
 enum ApiKeyStrColumns {
-  TYPE
-  SCOPE
   SECRET_HASH
+  SCOPE
+  TYPE
   PREFIX
 }
 
 """An enumeration."""
 enum ApiKeyOrderBy {
+  CREATED_AT
+  REVOKER_ID
   USER_ID
   SECRET_HASH
-  PREFIX
-  CREATED_AT
-  TYPE
   LAST_USED_AT
-  REVOKER_ID
-  REVOKED_AT
-  ORGANIZATION_ID
+  PREFIX
   SCOPE
+  ORGANIZATION_ID
+  TYPE
+  REVOKED_AT
 }
 
 input ApiKeyOrderByInput {
@@ -1029,28 +1029,28 @@ type Feature {
 
 """An enumeration."""
 enum OrganizationStrColumns {
-  MQL_SERVER_LOGS
-  PRIMARY_CONFIG_REPO
-  LOGO_URL
   SOURCE_CONTROL_URL
+  MQL_SERVER_LOGS
   NAME
   PRIMARY_CONFIG_BRANCH
+  PRIMARY_CONFIG_REPO
+  LOGO_URL
 }
 
 """An enumeration."""
 enum OrganizationOrderBy {
-  DEACTIVATED_AT
-  PRIMARY_CONFIG_REPO
-  LOGO_URL
-  IS_HOSTED
   CREATED_AT
-  PRIMARY_CONFIG_BRANCH
   MQL_SERVER_LOGS
+  DEACTIVATED_AT
   ID
-  UPDATED_AT
-  TYPE
+  PRIMARY_CONFIG_BRANCH
+  PRIMARY_CONFIG_REPO
   SOURCE_CONTROL_URL
   NAME
+  UPDATED_AT
+  TYPE
+  IS_HOSTED
+  LOGO_URL
 }
 
 input OrganizationOrderByInput {
@@ -1123,23 +1123,23 @@ type DataWarehouseConfig {
 
 """An enumeration."""
 enum OrgMqlServerStrColumns {
-  URL
-  CONFIG_SECRET
   NAME
+  CONFIG_SECRET
+  URL
 }
 
 """An enumeration."""
 enum OrgMqlServerOrderBy {
-  CONFIG_SECRET
   CREATED_AT
-  IS_ORG_DEFAULT
-  URL
-  DW_ENGINE
   ID
-  UPDATED_AT
+  IS_ORG_DEFAULT
+  DW_ENGINE
   DEPLOYMENT_STATUS
-  ORGANIZATION_ID
   NAME
+  ORGANIZATION_ID
+  CONFIG_SECRET
+  URL
+  UPDATED_AT
 }
 
 input OrgMqlServerOrderByInput {
@@ -1159,18 +1159,18 @@ type OrgPref {
 
 """An enumeration."""
 enum OrgPrefStrColumns {
-  PREF_VALUE
   PREF_KEY
+  PREF_VALUE
 }
 
 """An enumeration."""
 enum OrgPrefOrderBy {
+  CREATED_AT
+  ORGANIZATION_ID
   PREF_VALUE
   ID
-  UPDATED_AT
-  ORGANIZATION_ID
   PREF_KEY
-  CREATED_AT
+  UPDATED_AT
 }
 
 input OrgPrefOrderByInput {
@@ -1200,11 +1200,11 @@ enum FeatureStrColumns {
 
 """An enumeration."""
 enum FeatureOrderBy {
+  CREATED_AT
+  NAME
   ID
   UPDATED_AT
   RETIRED_AT
-  NAME
-  CREATED_AT
 }
 
 input FeatureOrderByInput {
@@ -1266,7 +1266,6 @@ Mutation names will be converted from snake_case to camelCase automatically
 type Mutation {
   revokeApiKeyTest(prefix: String!): ApiKey
   createOrganizationTest(name: String!, primaryConfigRepo: String, primaryConfigBranch: String, mqlServerUrl: String, sourceControlUrl: String, mqlServerLogs: String, isHosted: Boolean, dwEngine: String, mqlServerName: String, requireMfa: Boolean, allowMfaRememberBrowser: Boolean, allowedEmailDomains: [String], orgType: GOrgType): Organization
-  logMqlLog(level: String, message: String, tags: [String!]): LogMQLLogs
   setOrgMqlServerConfigSecret(clientConfigSecretId: String, mqlServerId: Int): SetOrgMqlServerConfigSecretId
   sendMqlHeartbeat(mqlServerId: Int, sha: String!): SendMqlHeartbeat
   createAnnotationTest(dateEndedAt: Date!, dateStartedAt: Date!, expectedImpact: String!, metricInputs: [GMetricAnnotationInput]!, priority: Priority!, text: String!, title: String!): CreateAnnotation
@@ -1373,10 +1372,6 @@ enum GOrgType {
   TRIAL
   INTERNAL
   TEST
-}
-
-type LogMQLLogs {
-  ok: Boolean
 }
 
 type SetOrgMqlServerConfigSecretId {

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -165,6 +165,7 @@ enum QueryResultSource {
   DYNAMIC_CACHE
   DW_MATERIALIZATION
   FAST_CACHE
+  METRICFLOW
   NOT_APPLICABLE
   NOT_SPECIFIED
 }
@@ -213,7 +214,7 @@ type Metric {
   constraint: String
   dimensions: [String!]
   dimensionObjects: [Dimension!]
-  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int): [String]
+  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int, searchStr: String): [String]
   maxGranularity(modelKey: ModelKeyInput): TimeGranularity
 }
 


### PR DESCRIPTION
# Changes
* Adds an option to provide an `externalConfig` to define the MQL Server URL & method to refetch it on update, outside the package

# Security Implications
* None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
