### PR TITLE
Change check of running and pending queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes

If none of the properties in the `useFetchMqlTimeSeries` `useEffect` hook change, the retry for Pending/Running state never gets rechecked. This updates the check to more assertively poll.
 

# Security Implications

"None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
