### PR TITLE
Expose retryWhileRunning

### DIFF
--- a/hooks/reducers/mqlQueryReducer.ts
+++ b/hooks/reducers/mqlQueryReducer.ts
@@ -43,6 +43,8 @@ export type UseMqlQueryState = {
   errorMessage?: string;
 
   doRetryAfterExpiredQuery: boolean;
+
+  retryWhileRunning?: () => void;
 };
 
 export const initialState: UseMqlQueryState = {
@@ -54,6 +56,7 @@ export const initialState: UseMqlQueryState = {
   fetchStartTime: null,
   isTakingForever: false,
   doRetryAfterExpiredQuery: false,
+  retryWhileRunning: undefined,
 };
 
 export type Action<CreateQueryDataType> =

--- a/hooks/useMqlQuery/useMqlQuery.ts
+++ b/hooks/useMqlQuery/useMqlQuery.ts
@@ -58,7 +58,7 @@ export default function useMqlQuery({
     !state.queryId ||
     state.cancelledQueries.includes(state.queryId); /* && !isRunning*/
 
-  useFetchMqlTimeSeries<CreateMqlQueryMutation>({
+  const { retryWhileRunning } = useFetchMqlTimeSeries<CreateMqlQueryMutation>({
     state,
     skip: _skip,
     dispatch,
@@ -66,5 +66,8 @@ export default function useMqlQuery({
     retries
   });
 
-  return state;
+  return {
+    ...state,
+    retryWhileRunning,
+  };
 }

--- a/hooks/utils/useFetchMqlTimeSeries.ts
+++ b/hooks/utils/useFetchMqlTimeSeries.ts
@@ -49,6 +49,11 @@ const useFetchMqlTimeSeries = <CreateQueryDataType>({
     }, RETRY_POLLING_MS);
   };
 
+  const retryWhileRunning = () => {
+    dispatch({ type: "fetchResultsRunning"});
+    refetchMqlQuery();
+  };
+
   useEffect(() => {
     if (error) {
       // if error is an expired query id, the mql server may have been restarted, restart the entire query.
@@ -93,10 +98,7 @@ const useFetchMqlTimeSeries = <CreateQueryDataType>({
       status === MqlQueryStatus.Running ||
       status === MqlQueryStatus.Pending
     ) {
-      setTimeout(() => {
-        dispatch({ type: "fetchResultsRunning"});
-        refetchMqlQuery();
-      }, QUERY_POLLING_MS);
+      setTimeout(retryWhileRunning, QUERY_POLLING_MS);
     }
 
     if (status === MqlQueryStatus.Failed) {
@@ -147,6 +149,8 @@ const useFetchMqlTimeSeries = <CreateQueryDataType>({
       }
     }
   }, [data, error, state.cancelledQueries, handleCombinedError]);
+
+  return { retryWhileRunning };
 }
 
 export default useFetchMqlTimeSeries;


### PR DESCRIPTION
This is so we can retry based on timing logic in our application

# Security Implications

"None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
