### PR TITLE
Don't instantiate backend client / mql context unless we have a token

### DIFF
--- a/context/MqlContext/MqlContextProvider.tsx
+++ b/context/MqlContext/MqlContextProvider.tsx
@@ -33,20 +33,22 @@ function MqlContextProvider({
   coreApiUrl,
   mqlServerUrlOverride
 }: Props) {
-  const coreApiClient = buildMqlUrqlClient(coreApiUrl || CORE_API_URL, token);
-  return (
-    <Provider value={coreApiClient}>
-      <MqlContextProviderInternal
-        isAuthenticated={isAuthenticated}
-        token={token}
-        captureException={captureException}
-        coreApiUrl={coreApiUrl || CORE_API_URL}
-        mqlServerUrlOverride={mqlServerUrlOverride}
-      >
-        {children}
-      </MqlContextProviderInternal>
-    </Provider>
-  );
+  if (token) {
+    const coreApiClient = buildMqlUrqlClient(coreApiUrl || CORE_API_URL, token);
+    return (
+      <Provider value={coreApiClient}>
+        <MqlContextProviderInternal
+          isAuthenticated={isAuthenticated}
+          token={token}
+          captureException={captureException}
+          coreApiUrl={coreApiUrl || CORE_API_URL}
+          mqlServerUrlOverride={mqlServerUrlOverride}
+        >
+          {children}
+        </MqlContextProviderInternal>
+      </Provider>
+    );
+  }
 }
 
 function MqlContextProviderInternal({


### PR DESCRIPTION
# Changes
- Don't instantiate backend client if there's no token
- This component should rerun when the token gets returned from Auth0 and then behave properly

# Security Implications
* Please put any possible security-related concerns here. Feel free to @andykram if you're unsure. If none, please put "None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
