### PR TITLE
[Bug] latestMetricChange hook Pending/Running State

### DIFF
--- a/hooks/useLatestChangeMqlQuery/utils/useCreateLatestChangeMqlQuery.ts
+++ b/hooks/useLatestChangeMqlQuery/utils/useCreateLatestChangeMqlQuery.ts
@@ -47,11 +47,8 @@ const useCreateLatestMetricChange = ({metricName, dispatch, retries}: UseCreateL
           data,
           handleCombinedError,
         });
-      } else if (data?.queryLatestMetricChange?.query?.status === MqlQueryStatus.Pending || data?.queryLatestMetricChange?.query?.status === MqlQueryStatus.Running) {
-        setTimeout(() => {
-          queryLatestMetricChange({stateRetries: stateRetries});
-        }, RETRY_POLLING_MS)
-      } else {
+      }
+      else {
         if (data?.queryLatestMetricChange?.id) {
           dispatch({
             type: "postQuerySuccess",

--- a/hooks/usePercentChangeMqlQuery/utils/useCreatePercentChangeMqlQuery.ts
+++ b/hooks/usePercentChangeMqlQuery/utils/useCreatePercentChangeMqlQuery.ts
@@ -45,11 +45,8 @@ const useCreatePercentChange = ({queryInput, dispatch, retries}: UseCreatePercen
           data,
           handleCombinedError,
         });
-      } else if (data?.pctChangeOverRange?.query?.status === MqlQueryStatus.Pending || data?.pctChangeOverRange?.query?.status === MqlQueryStatus.Running) {
-        setTimeout(() => {
-          queryPercentChange({stateRetries: stateRetries});
-        }, RETRY_POLLING_MS)
-      } else {
+      }
+      else {
         if (data?.pctChangeOverRange?.id) {
           dispatch({
             type: "postQuerySuccess",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
* Don't recreate latestMetricChange or pctChange mutations when mutation result is pending or running.  Instead use the queryId to query for results.

# Security Implications
None