### PR TITLE
mqlQuery dbId

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -46,7 +46,6 @@ export default function useTimeSeriesMqlQuery({
   const {
     mqlServerUrl,
   } = useContext(MqlContext);
-
   const dataAccr = (data: CreateMqlQueryMutation) => data?.createMqlQuery?.query;
 
   const reducer = mqlQueryReducer<CreateMqlQueryMutation, FetchMqlTimeSeriesQuery>(dataAccr);

--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -43,6 +43,7 @@ const mutation = gql`
       id
       query {
         id
+        dbId
         createdAt
         status
         metrics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/mql/FetchMqlQueryTimeSeries.ts
+++ b/queries/mql/FetchMqlQueryTimeSeries.ts
@@ -4,6 +4,7 @@ const query = gql`
   query FetchMqlTimeSeries($queryId: ID!) {
     mqlQuery(id: $queryId) {
       id
+      dbId
       status
       metrics
       dimensions


### PR DESCRIPTION
# Changes
* Add dbId to createMqlQuery and fetchMqlTimeSeries
* We can store the dbId on SavedQueries then use it to fetch the query without having to pass filter params

# Security Implications
* Please put any possible security-related concerns here. Feel free to @andykram if you're unsure. If none, please put "None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
