### PR TITLE
CreateMqlQueryFromDbId

### DIFF
--- a/hooks/useMqlQueryFromDbId/index.ts
+++ b/hooks/useMqlQueryFromDbId/index.ts
@@ -1,0 +1,3 @@
+import useMqlQueryFromDbId from './useMqlQueryFromDbId';
+
+export default useMqlQueryFromDbId;

--- a/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
+++ b/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
@@ -1,0 +1,78 @@
+import { useEffect, useReducer, useContext } from "react";
+// import { CombinedError } from "urql";
+import MqlContext from "../../context/MqlContext/MqlContext";
+import {
+  CreateMqlQueryFromDbIdMutation,
+  CreateMqlQueryFromDbIdMutationVariables,
+} from "../../mutations/mql/MqlMutationTypes";
+import {
+  FetchMqlTimeSeriesQuery,
+} from "../../queries/mql/MqlQueryTypes";
+import useCreateMqlQueryFromDbId from './utils/useCreateMqlQueryFromDbId';
+import mqlQueryReducer, { initialState, UseMqlQueryState } from '../reducers/mqlQueryReducer';
+import useFetchMqlQuery from '../utils/useFetchMqlQuery';
+import FetchMqlQueryTimeSeries from "../../queries/mql/FetchMqlQueryTimeSeries";
+
+/*
+  Please Beware!
+  Here Be Dragons!
+
+  If `queryInput` is provided, it *must* be stable for this to work.
+  That means if the value is calculated and generating a fresh object every render,
+  this will result in an infinite loop!
+
+  So we are doing something that seems like it could be improved, which is that if the form is based on the URL,
+  we pass in locationSearch, which is stable, and calculate the form state inside an effect. I know. Gross, right?
+  Is there a better approach?
+*/
+type UseMqlQueryParams = {
+  mqlQueryId: number;
+  // queryInput?: Omit<CreateMqlQueryFromDbIdMutationVariables, 'attemptNum'>;
+  skip?: boolean;
+  retries?: number;
+};
+
+export type UseTimeSeriesMqlQuery = UseMqlQueryState<FetchMqlTimeSeriesQuery>
+
+// This custom hook consists of two useHooks that should asynchronously handle all scenarios for this chained
+// data fetching we are doing. It should do it in a high performance way and in a way that is resilient to race conditions if the
+// user updates their request while a query is in flight
+export default function useMqlQueryFromDbId({
+  // queryInput,
+  mqlQueryId,
+  skip,
+  retries = 5,
+}: UseMqlQueryParams) {
+  const {
+    mqlServerUrl,
+  } = useContext(MqlContext);
+  const dataAccr = (data: CreateMqlQueryFromDbIdMutation) => data?.createMqlQueryFromDbId?.query;
+
+  const reducer = mqlQueryReducer<CreateMqlQueryFromDbIdMutation, FetchMqlTimeSeriesQuery>(dataAccr);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {createMqlQueryFromDbId} = useCreateMqlQueryFromDbId({mqlQueryId, dispatch, retries})
+
+  useEffect(() => {
+    if (!mqlQueryId || !mqlServerUrl || skip) {
+      return;
+    }
+    dispatch({ type: "postQueryStart" });
+    createMqlQueryFromDbId({stateRetries: state.retries});
+  }, [mqlQueryId, mqlServerUrl, skip]);
+
+  const _skip =
+    skip ||
+    !state.queryId ||
+    state.cancelledQueries.includes(state.queryId); /* && !isRunning*/
+
+  useFetchMqlQuery<CreateMqlQueryFromDbIdMutation, FetchMqlTimeSeriesQuery>({
+    state,
+    skip: _skip,
+    dispatch,
+    createQueryIdQuery: createMqlQueryFromDbId,
+    retries,
+    fetchDataQuery: FetchMqlQueryTimeSeries
+  });
+
+  return state;
+}

--- a/hooks/useMqlQueryFromDbId/utils/clearEmptyConstraints.ts
+++ b/hooks/useMqlQueryFromDbId/utils/clearEmptyConstraints.ts
@@ -1,0 +1,22 @@
+import {
+  ConstraintInput,
+} from "../../../mutations/mql/MqlMutationTypes";
+
+const EMPTY_CONSTRAINT: ConstraintInput = { constraint: null };
+
+// This filters out invalid WHERE clauses the consequence of janky form state;
+const clearEmptyConstraints = (where?: ConstraintInput | null | undefined) => {
+  if (!where) return EMPTY_CONSTRAINT;
+  if (where.And) {
+    const newAnd = where.And.filter((val) => (val.values || []).length > 0);
+    return newAnd.length > 0 ? { ...where, And: newAnd } : EMPTY_CONSTRAINT;
+  }
+  // if (where.Or) {
+  //   const newOr = where.Or.filter((val) => (val.values || []).length > 0);
+  //   return newOr.length > 0 ? { ...where, Or: newOr } : EMPTY_CONSTRAINT;
+  // }
+
+  return where;
+}
+
+export default clearEmptyConstraints;

--- a/hooks/useMqlQueryFromDbId/utils/useCreateMqlQueryFromDbId.ts
+++ b/hooks/useMqlQueryFromDbId/utils/useCreateMqlQueryFromDbId.ts
@@ -1,0 +1,83 @@
+import { useContext, Dispatch } from 'react';
+import MqlContext from "../../../context/MqlContext/MqlContext";
+import CreateMqlQueryFromDbId from "../../../mutations/mql/CreateMqlQueryFromDbId";
+import {
+  CreateMqlQueryFromDbIdMutation,
+  CreateMqlQueryFromDbIdMutationVariables,
+} from "../../../mutations/mql/MqlMutationTypes";
+import { Action as UseMqlQueryAction, getRetryPollingMS } from '../../reducers/mqlQueryReducer';
+import getErrorMessage from '../../utils/getErrorMessage';
+import {
+  FetchMqlTimeSeriesQuery,
+  MqlQueryStatus,
+} from "../../../queries/mql/MqlQueryTypes";
+
+export interface DoCreateMqlQueryFromDbIdArgs {
+  stateRetries: number
+}
+
+interface UseCreateMqlQueryFromDbIdArgs {
+  retries: number; // the number of retries passed as an arg from the client.
+  mqlQueryId: number;
+  dispatch: Dispatch<UseMqlQueryAction<CreateMqlQueryFromDbIdMutation, FetchMqlTimeSeriesQuery>>;
+}
+
+interface UseCreateMqlQueryFromDbId {
+  createMqlQueryFromDbId: (args: DoCreateMqlQueryFromDbIdArgs) => void;
+}
+
+const useCreateMqlQueryFromDbId = ({mqlQueryId,  dispatch, retries}: UseCreateMqlQueryFromDbIdArgs): UseCreateMqlQueryFromDbId => {
+  const {
+    useMutation,
+    handleCombinedError,
+  } = useContext(MqlContext);
+
+  const [{}, createMqlQueryFromDbIdMutation] = useMutation<
+    CreateMqlQueryFromDbIdMutation,
+    CreateMqlQueryFromDbIdMutationVariables
+  >(CreateMqlQueryFromDbId);
+  const createMqlQueryFromDbId = ({stateRetries}:DoCreateMqlQueryFromDbIdArgs) => {
+    createMqlQueryFromDbIdMutation({
+      dbId: mqlQueryId,
+      attemptNum: stateRetries,
+    }).then(({ data, error }) => {
+      if (data?.createMqlQueryFromDbId?.query?.status === MqlQueryStatus.Successful) {
+        dispatch({
+          type: "postQueryCachedResultsSuccess",
+          data,
+          handleCombinedError,
+        });
+      } else {
+        if (data?.createMqlQueryFromDbId?.id) {
+          dispatch({
+            type: "postQuerySuccess",
+            queryId: data?.createMqlQueryFromDbId?.id,
+          });
+        } else if (error) {
+          if (retries > 0 && stateRetries !== retries && stateRetries < retries) {
+            setTimeout(() => {
+              dispatch({ type: "retryFetchResults" });
+              createMqlQueryFromDbId({stateRetries: stateRetries + 1});
+            }, getRetryPollingMS())
+          } else {
+            dispatch({
+              type: "postQueryFail",
+              errorMessage: getErrorMessage(error),
+            });
+          }
+          handleCombinedError(error);
+
+        }
+      }
+
+    });
+  };
+
+  return {
+    createMqlQueryFromDbId
+  }
+}
+
+
+
+export default useCreateMqlQueryFromDbId;

--- a/mutations/mql/CreateMqlQueryFromDbId.ts
+++ b/mutations/mql/CreateMqlQueryFromDbId.ts
@@ -1,0 +1,70 @@
+import { gql } from "urql";
+
+const mutation = gql`
+  mutation CreateMqlQueryFromDbId(
+    $attemptNum: Int!
+    $dbId: Int!
+  ) {
+    createMqlQueryFromDbId(
+      input: {
+        attemptNum: $attemptNum
+        dbId: $dbId
+      }
+    ) {
+      id
+      query {
+        id
+        dbId
+        createdAt
+        status
+        metrics
+        dimensions
+        error
+        chartValueMax
+        chartValueMin
+
+        whereConstraint
+        requestedGranularity
+        groupBy
+        maxDimensionValues
+        constraint {
+          constraint {
+            constraintType
+            dimensionName
+            values
+            start
+            stop
+          }
+          And {
+            constraintType
+            dimensionName
+            values
+            start
+            stop
+          }
+        }
+        timeComparison
+        timeConstraint {
+          dimensionName
+          timeFormat
+          start
+          stop
+          timeGranularity
+        }
+        numPostprocessedResults
+        dbId
+        result {
+          seriesValue
+          data {
+            y
+            ... on TimeSeriesDatum {
+              xDate
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export default mutation;

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -1047,6 +1047,44 @@ export type CreateMqlQueryMutation = (
   )> }
 );
 
+export type CreateMqlQueryFromDbIdMutationVariables = Exact<{
+  attemptNum: Scalars['Int'];
+  dbId: Scalars['Int'];
+}>;
+
+
+export type CreateMqlQueryFromDbIdMutation = (
+  { __typename?: 'Mutation' }
+  & { createMqlQueryFromDbId?: Maybe<(
+    { __typename?: 'CreateMqlQueryFromDbIdPayload' }
+    & Pick<CreateMqlQueryFromDbIdPayload, 'id'>
+    & { query?: Maybe<(
+      { __typename?: 'MqlQuery' }
+      & Pick<MqlQuery, 'id' | 'dbId' | 'createdAt' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'maxDimensionValues' | 'timeComparison' | 'numPostprocessedResults'>
+      & { constraint?: Maybe<(
+        { __typename?: 'Constraint' }
+        & { constraint?: Maybe<(
+          { __typename?: 'SingleConstraint' }
+          & Pick<SingleConstraint, 'constraintType' | 'dimensionName' | 'values' | 'start' | 'stop'>
+        )>, And?: Maybe<Array<(
+          { __typename?: 'SingleConstraint' }
+          & Pick<SingleConstraint, 'constraintType' | 'dimensionName' | 'values' | 'start' | 'stop'>
+        )>> }
+      )>, timeConstraint?: Maybe<(
+        { __typename?: 'TimeConstraint' }
+        & Pick<TimeConstraint, 'dimensionName' | 'timeFormat' | 'start' | 'stop' | 'timeGranularity'>
+      )>, result?: Maybe<Array<(
+        { __typename?: 'MqlQueryResultSeries' }
+        & Pick<MqlQueryResultSeries, 'seriesValue'>
+        & { data?: Maybe<Array<(
+          { __typename?: 'TimeSeriesDatum' }
+          & Pick<TimeSeriesDatum, 'xDate' | 'y'>
+        )>> }
+      )>> }
+    )> }
+  )> }
+);
+
 export type CreatePercentChangeMutationVariables = Exact<{
   metricName: Scalars['String'];
   startTime: Scalars['String'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.27.2",
+  "version": "1.28.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
* Add hook for `CreateMqlQueryFromDbId` that will allow us to fetch chart data for saved queries using the saved query dbId.

# Security Implications
* None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
