### PR TITLE
[Refetch Query] Add parameter to force refetch

### DIFF
--- a/hooks/reducers/mqlQueryReducer.ts
+++ b/hooks/reducers/mqlQueryReducer.ts
@@ -60,7 +60,9 @@ export const initialState: UseMqlQueryState<{}> = {
 };
 
 export type Action<CreateQueryDataType, FetchQueryDataType> =
-  | { type: "postQueryStart" }
+  | { type: "postQueryStart";
+      doRefetchMqlQuery?: boolean;
+    }
   | { type: "postQueryFail";
       errorMessage: string
     }
@@ -105,7 +107,7 @@ const mqlQueryReducer = <CreateQueryDataType extends unknown, FetchQueryDataType
     case "postQueryStart": {
       // This condition is triggered when there is already a queryId being fetched.
       // In this case we want to add "cancel" that query by adding it to the cancelledQueries list
-      if (state.queryId) {
+      if (state.queryId && !action.doRefetchMqlQuery) {
         return {
           ...state,
           queryStatus: MqlQueryStatus.Running,
@@ -121,6 +123,7 @@ const mqlQueryReducer = <CreateQueryDataType extends unknown, FetchQueryDataType
       }
       return {
         ...state,
+        queryId: null,
         queryStatus: MqlQueryStatus.Running,
         fetchStartTime: Date.now(),
         isTakingForever: false,

--- a/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
+++ b/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
@@ -30,6 +30,7 @@ export type UseMqlQueryFromDbIdParams = {
   // queryInput?: Omit<CreateMqlQueryFromDbIdMutationVariables, 'attemptNum'>;
   skip?: boolean;
   retries?: number;
+  doRefetchMqlQuery?: boolean;
 };
 
 export type UseMqlQueryFromDbIdQuery = UseMqlQueryState<FetchMqlTimeSeriesQuery>
@@ -42,6 +43,7 @@ export default function useMqlQueryFromDbId({
   mqlQueryId,
   skip,
   retries = 5,
+  doRefetchMqlQuery,
 }: UseMqlQueryFromDbIdParams) {
   const {
     mqlServerUrl,
@@ -56,9 +58,9 @@ export default function useMqlQueryFromDbId({
     if (!mqlQueryId || !mqlServerUrl || skip) {
       return;
     }
-    dispatch({ type: "postQueryStart" });
+    dispatch({ type: "postQueryStart", doRefetchMqlQuery });
     createMqlQueryFromDbId({stateRetries: state.retries});
-  }, [mqlQueryId, mqlServerUrl, skip]);
+  }, [mqlQueryId, mqlServerUrl, skip, doRefetchMqlQuery]);
 
   const _skip =
     skip ||

--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -30,6 +30,7 @@ type UseMqlQueryParams = {
   queryInput?: Omit<CreateMqlQueryMutationVariables, 'attemptNum'>;
   skip?: boolean;
   retries?: number;
+  doRefetchMqlQuery?: boolean;
 };
 
 export type UseTimeSeriesMqlQuery = UseMqlQueryState<FetchMqlTimeSeriesQuery>
@@ -42,6 +43,7 @@ export default function useTimeSeriesMqlQuery({
   metricName,
   skip,
   retries = 5,
+  doRefetchMqlQuery,
 }: UseMqlQueryParams) {
   const {
     mqlServerUrl,
@@ -56,9 +58,9 @@ export default function useTimeSeriesMqlQuery({
     if (!metricName || !mqlServerUrl || skip) {
       return;
     }
-    dispatch({ type: "postQueryStart" });
+    dispatch({ type: "postQueryStart", doRefetchMqlQuery });
     createTimeSeriesMqlQuery({stateRetries: state.retries});
-  }, [queryInput, metricName, mqlServerUrl, skip]);
+  }, [queryInput, metricName, mqlServerUrl, skip, doRefetchMqlQuery]);
 
   const _skip =
     skip ||

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -1876,6 +1876,7 @@ export type Board = {
   totalViews?: Maybe<Scalars['Int']>;
   totalFavorites?: Maybe<Scalars['Int']>;
   isFavoritedByUser?: Maybe<Scalars['Boolean']>;
+  lastWeekViews?: Maybe<Scalars['Int']>;
 };
 
 

--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -49,6 +49,7 @@ const mutation = gql`
         availableChartTypes
         createdAt
         status
+        oldestSourceReadTime
         metrics
         dimensions
         error

--- a/mutations/mql/CreateMqlQueryFromDbId.ts
+++ b/mutations/mql/CreateMqlQueryFromDbId.ts
@@ -10,12 +10,12 @@ const mutation = gql`
         availableChartTypes
         createdAt
         status
+        oldestSourceReadTime
         metrics
         dimensions
         error
         chartValueMax
         chartValueMin
-
         whereConstraint
         requestedGranularity
         groupBy

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -1226,7 +1226,7 @@ export type CreateMqlQueryMutation = (
     & Pick<CreateMqlQueryPayload, 'id'>
     & { query?: Maybe<(
       { __typename?: 'MqlQuery' }
-      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin'>
+      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'oldestSourceReadTime' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin'>
       & { resultTabular?: Maybe<(
         { __typename?: 'MqlQueryTabularResult' }
         & Pick<MqlQueryTabularResult, 'data'>
@@ -1255,7 +1255,7 @@ export type CreateMqlQueryFromDbIdMutation = (
     & Pick<CreateMqlQueryFromDbIdPayload, 'id'>
     & { query?: Maybe<(
       { __typename?: 'MqlQuery' }
-      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'latestXDays' | 'maxDimensionValues' | 'trimIncompletePeriods' | 'timeComparison' | 'numPostprocessedResults'>
+      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'oldestSourceReadTime' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'latestXDays' | 'maxDimensionValues' | 'trimIncompletePeriods' | 'timeComparison' | 'numPostprocessedResults'>
       & { constraint?: Maybe<(
         { __typename?: 'Constraint' }
         & { constraint?: Maybe<(

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -24,13 +24,6 @@ export type Scalars = {
    */
   Date: any;
   /**
-   * Allows use of a JSON String for input / output from the GraphQL schema.
-   *
-   * Use of this type is *not recommended* as you lose the benefits of having a defined, static
-   * schema (one of the key benefits of GraphQL).
-   */
-  JSONString: any;
-  /**
    * Limit is a GraphQL Scalar that can take in inf or positive integers.
    *
    * This class helps us normalize a API limit input into the Optional[int] type expected by library code
@@ -348,6 +341,8 @@ export type MqlQuery = {
   createdAt?: Maybe<Scalars['DateTime']>;
   /** Time the MQL Server start query execution */
   startedAt?: Maybe<Scalars['DateTime']>;
+  /** The build time of the oldest source cache used by this query. */
+  oldestSourceReadTime?: Maybe<Scalars['DateTime']>;
   sql?: Maybe<Scalars['String']>;
   error?: Maybe<Scalars['String']>;
   errorTraceback?: Maybe<Scalars['String']>;
@@ -754,13 +749,12 @@ export type Validations = {
   metricIssues?: Maybe<Array<Scalars['String']>>;
   /** @deprecated Use `dimensionResults` */
   dimensionIssues?: Maybe<Array<Scalars['String']>>;
-  dataSourceResults: Scalars['JSONString'];
-  dimensionResults: Scalars['JSONString'];
-  identifierResults: Scalars['JSONString'];
-  measureResults: Scalars['JSONString'];
-  metricResults: Scalars['JSONString'];
+  dataSourceResults: Scalars['String'];
+  dimensionResults: Scalars['String'];
+  identifierResults: Scalars['String'];
+  measureResults: Scalars['String'];
+  metricResults: Scalars['String'];
 };
-
 
 /** The meta information we track of dbt models */
 export type DbtModelMeta = {

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -1876,6 +1876,7 @@ export type Board = {
   totalViews?: Maybe<Scalars['Int']>;
   totalFavorites?: Maybe<Scalars['Int']>;
   isFavoritedByUser?: Maybe<Scalars['Boolean']>;
+  lastWeekViews?: Maybe<Scalars['Int']>;
 };
 
 

--- a/queries/mql/FetchMqlQuery.ts
+++ b/queries/mql/FetchMqlQuery.ts
@@ -16,6 +16,7 @@ const query = gql`
       dimensions
       status
       completedAt
+      oldestSourceReadTime
       resultTableSchema
       resultTableName
       createdAt

--- a/queries/mql/FetchMqlQueryTimeSeries.ts
+++ b/queries/mql/FetchMqlQueryTimeSeries.ts
@@ -7,6 +7,7 @@ const query = gql`
       dbId
       status
       metrics
+      oldestSourceReadTime
       availableChartTypes
       dimensions
       error

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -1336,7 +1336,7 @@ export type FetchMqlQueryQuery = (
   { __typename?: 'Query' }
   & { mqlQuery?: Maybe<(
     { __typename?: 'MqlQuery' }
-    & Pick<MqlQuery, 'id' | 'availableChartTypes' | 'userId' | 'metrics' | 'dimensions' | 'status' | 'completedAt' | 'resultTableSchema' | 'resultTableName' | 'createdAt' | 'startedAt' | 'sql' | 'error' | 'errorTraceback' | 'chartValueMin' | 'chartValueMax'>
+    & Pick<MqlQuery, 'id' | 'availableChartTypes' | 'userId' | 'metrics' | 'dimensions' | 'status' | 'completedAt' | 'oldestSourceReadTime' | 'resultTableSchema' | 'resultTableName' | 'createdAt' | 'startedAt' | 'sql' | 'error' | 'errorTraceback' | 'chartValueMin' | 'chartValueMax'>
     & { modelKey?: Maybe<(
       { __typename?: 'ModelKey' }
       & Pick<ModelKey, 'branch' | 'commit'>
@@ -1382,7 +1382,7 @@ export type FetchMqlTimeSeriesQuery = (
   { __typename?: 'Query' }
   & { mqlQuery?: Maybe<(
     { __typename?: 'MqlQuery' }
-    & Pick<MqlQuery, 'id' | 'dbId' | 'status' | 'metrics' | 'availableChartTypes' | 'dimensions' | 'error' | 'chartValueMin' | 'chartValueMax' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'maxDimensionValues' | 'timeComparison' | 'trimIncompletePeriods'>
+    & Pick<MqlQuery, 'id' | 'dbId' | 'status' | 'metrics' | 'oldestSourceReadTime' | 'availableChartTypes' | 'dimensions' | 'error' | 'chartValueMin' | 'chartValueMax' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'maxDimensionValues' | 'timeComparison' | 'trimIncompletePeriods'>
     & { constraint?: Maybe<(
       { __typename?: 'Constraint' }
       & { constraint?: Maybe<(

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -24,13 +24,6 @@ export type Scalars = {
    */
   Date: any;
   /**
-   * Allows use of a JSON String for input / output from the GraphQL schema.
-   *
-   * Use of this type is *not recommended* as you lose the benefits of having a defined, static
-   * schema (one of the key benefits of GraphQL).
-   */
-  JSONString: any;
-  /**
    * Limit is a GraphQL Scalar that can take in inf or positive integers.
    *
    * This class helps us normalize a API limit input into the Optional[int] type expected by library code
@@ -348,6 +341,8 @@ export type MqlQuery = {
   createdAt?: Maybe<Scalars['DateTime']>;
   /** Time the MQL Server start query execution */
   startedAt?: Maybe<Scalars['DateTime']>;
+  /** The build time of the oldest source cache used by this query. */
+  oldestSourceReadTime?: Maybe<Scalars['DateTime']>;
   sql?: Maybe<Scalars['String']>;
   error?: Maybe<Scalars['String']>;
   errorTraceback?: Maybe<Scalars['String']>;
@@ -754,13 +749,12 @@ export type Validations = {
   metricIssues?: Maybe<Array<Scalars['String']>>;
   /** @deprecated Use `dimensionResults` */
   dimensionIssues?: Maybe<Array<Scalars['String']>>;
-  dataSourceResults: Scalars['JSONString'];
-  dimensionResults: Scalars['JSONString'];
-  identifierResults: Scalars['JSONString'];
-  measureResults: Scalars['JSONString'];
-  metricResults: Scalars['JSONString'];
+  dataSourceResults: Scalars['String'];
+  dimensionResults: Scalars['String'];
+  identifierResults: Scalars['String'];
+  measureResults: Scalars['String'];
+  metricResults: Scalars['String'];
 };
-
 
 /** The meta information we track of dbt models */
 export type DbtModelMeta = {

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -1046,6 +1046,7 @@ type Board {
   totalViews: Int
   totalFavorites: Int
   isFavoritedByUser: Boolean
+  lastWeekViews: Int
 }
 
 """An enumeration."""

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -83,6 +83,9 @@ type MqlQuery {
 
   """Time the MQL Server start query execution"""
   startedAt: DateTime
+
+  """The build time of the oldest source cache used by this query."""
+  oldestSourceReadTime: DateTime
   sql: String
   error: String
   errorTraceback: String
@@ -423,20 +426,12 @@ type Validations {
   dataSourceIssues: [String!] @deprecated(reason: "Use `dataSourceResults`")
   metricIssues: [String!] @deprecated(reason: "Use `metricResults`")
   dimensionIssues: [String!] @deprecated(reason: "Use `dimensionResults`")
-  dataSourceResults: JSONString!
-  dimensionResults: JSONString!
-  identifierResults: JSONString!
-  measureResults: JSONString!
-  metricResults: JSONString!
+  dataSourceResults: String!
+  dimensionResults: String!
+  identifierResults: String!
+  measureResults: String!
+  metricResults: String!
 }
-
-"""
-Allows use of a JSON String for input / output from the GraphQL schema.
-
-Use of this type is *not recommended* as you lose the benefits of having a defined, static
-schema (one of the key benefits of GraphQL).
-"""
-scalar JSONString
 
 """The meta information we track of dbt models"""
 type DbtModelMeta {


### PR DESCRIPTION
# Changes
Adds a new `doRefetchMqlQuery` parameter so that, if `true`, it triggers a new MQL Query fetch.

# Security Implications

None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
