### PR TITLE
[Refetch Data] Expose oldest source read time

### DIFF
--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -1876,6 +1876,7 @@ export type Board = {
   totalViews?: Maybe<Scalars['Int']>;
   totalFavorites?: Maybe<Scalars['Int']>;
   isFavoritedByUser?: Maybe<Scalars['Boolean']>;
+  lastWeekViews?: Maybe<Scalars['Int']>;
 };
 
 

--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -49,6 +49,7 @@ const mutation = gql`
         availableChartTypes
         createdAt
         status
+        oldestSourceReadTime
         metrics
         dimensions
         error

--- a/mutations/mql/CreateMqlQueryFromDbId.ts
+++ b/mutations/mql/CreateMqlQueryFromDbId.ts
@@ -10,12 +10,12 @@ const mutation = gql`
         availableChartTypes
         createdAt
         status
+        oldestSourceReadTime
         metrics
         dimensions
         error
         chartValueMax
         chartValueMin
-
         whereConstraint
         requestedGranularity
         groupBy

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -1226,7 +1226,7 @@ export type CreateMqlQueryMutation = (
     & Pick<CreateMqlQueryPayload, 'id'>
     & { query?: Maybe<(
       { __typename?: 'MqlQuery' }
-      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin'>
+      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'oldestSourceReadTime' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin'>
       & { resultTabular?: Maybe<(
         { __typename?: 'MqlQueryTabularResult' }
         & Pick<MqlQueryTabularResult, 'data'>
@@ -1255,7 +1255,7 @@ export type CreateMqlQueryFromDbIdMutation = (
     & Pick<CreateMqlQueryFromDbIdPayload, 'id'>
     & { query?: Maybe<(
       { __typename?: 'MqlQuery' }
-      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'latestXDays' | 'maxDimensionValues' | 'trimIncompletePeriods' | 'timeComparison' | 'numPostprocessedResults'>
+      & Pick<MqlQuery, 'id' | 'dbId' | 'availableChartTypes' | 'createdAt' | 'status' | 'oldestSourceReadTime' | 'metrics' | 'dimensions' | 'error' | 'chartValueMax' | 'chartValueMin' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'latestXDays' | 'maxDimensionValues' | 'trimIncompletePeriods' | 'timeComparison' | 'numPostprocessedResults'>
       & { constraint?: Maybe<(
         { __typename?: 'Constraint' }
         & { constraint?: Maybe<(

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -1876,6 +1876,7 @@ export type Board = {
   totalViews?: Maybe<Scalars['Int']>;
   totalFavorites?: Maybe<Scalars['Int']>;
   isFavoritedByUser?: Maybe<Scalars['Boolean']>;
+  lastWeekViews?: Maybe<Scalars['Int']>;
 };
 
 

--- a/queries/mql/FetchMqlQuery.ts
+++ b/queries/mql/FetchMqlQuery.ts
@@ -16,6 +16,7 @@ const query = gql`
       dimensions
       status
       completedAt
+      oldestSourceReadTime
       resultTableSchema
       resultTableName
       createdAt

--- a/queries/mql/FetchMqlQueryTimeSeries.ts
+++ b/queries/mql/FetchMqlQueryTimeSeries.ts
@@ -7,6 +7,7 @@ const query = gql`
       dbId
       status
       metrics
+      oldestSourceReadTime
       availableChartTypes
       dimensions
       error

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -1336,7 +1336,7 @@ export type FetchMqlQueryQuery = (
   { __typename?: 'Query' }
   & { mqlQuery?: Maybe<(
     { __typename?: 'MqlQuery' }
-    & Pick<MqlQuery, 'id' | 'availableChartTypes' | 'userId' | 'metrics' | 'dimensions' | 'status' | 'completedAt' | 'resultTableSchema' | 'resultTableName' | 'createdAt' | 'startedAt' | 'sql' | 'error' | 'errorTraceback' | 'chartValueMin' | 'chartValueMax'>
+    & Pick<MqlQuery, 'id' | 'availableChartTypes' | 'userId' | 'metrics' | 'dimensions' | 'status' | 'completedAt' | 'oldestSourceReadTime' | 'resultTableSchema' | 'resultTableName' | 'createdAt' | 'startedAt' | 'sql' | 'error' | 'errorTraceback' | 'chartValueMin' | 'chartValueMax'>
     & { modelKey?: Maybe<(
       { __typename?: 'ModelKey' }
       & Pick<ModelKey, 'branch' | 'commit'>
@@ -1382,7 +1382,7 @@ export type FetchMqlTimeSeriesQuery = (
   { __typename?: 'Query' }
   & { mqlQuery?: Maybe<(
     { __typename?: 'MqlQuery' }
-    & Pick<MqlQuery, 'id' | 'dbId' | 'status' | 'metrics' | 'availableChartTypes' | 'dimensions' | 'error' | 'chartValueMin' | 'chartValueMax' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'maxDimensionValues' | 'timeComparison' | 'trimIncompletePeriods'>
+    & Pick<MqlQuery, 'id' | 'dbId' | 'status' | 'metrics' | 'oldestSourceReadTime' | 'availableChartTypes' | 'dimensions' | 'error' | 'chartValueMin' | 'chartValueMax' | 'whereConstraint' | 'requestedGranularity' | 'groupBy' | 'maxDimensionValues' | 'timeComparison' | 'trimIncompletePeriods'>
     & { constraint?: Maybe<(
       { __typename?: 'Constraint' }
       & { constraint?: Maybe<(

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -1046,6 +1046,7 @@ type Board {
   totalViews: Int
   totalFavorites: Int
   isFavoritedByUser: Boolean
+  lastWeekViews: Int
 }
 
 """An enumeration."""


### PR DESCRIPTION
# Changes

Exposes the `oldestSourceReadTime` field on MQL queries

# Security Implications

None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
