### PR TITLE
Ensure network-only fetch policy if explicitly refetching a query.

### DIFF
--- a/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
+++ b/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
@@ -73,7 +73,8 @@ export default function useMqlQueryFromDbId({
     dispatch,
     createQueryIdQuery: createMqlQueryFromDbId,
     retries,
-    fetchDataQuery: FetchMqlQueryTimeSeries
+    fetchDataQuery: FetchMqlQueryTimeSeries,
+    doRefetchMqlQuery,
   });
 
   return state;

--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -73,7 +73,8 @@ export default function useTimeSeriesMqlQuery({
     dispatch,
     createQueryIdQuery: createTimeSeriesMqlQuery,
     retries,
-    fetchDataQuery: FetchMqlQueryTimeSeries
+    fetchDataQuery: FetchMqlQueryTimeSeries,
+    doRefetchMqlQuery,
   });
 
   return state;

--- a/hooks/utils/useFetchMqlQuery.ts
+++ b/hooks/utils/useFetchMqlQuery.ts
@@ -19,7 +19,8 @@ interface UseFetchMqlTimeSeriesArgs<CreateQueryDataType, FetchDataType extends {
   dispatch: Dispatch<Action<CreateQueryDataType, FetchDataType>>
   createQueryIdQuery: ({stateRetries}: {stateRetries: number}) => void;
   retries: number;
-  fetchDataQuery: TypedDocumentNode
+  fetchDataQuery: TypedDocumentNode;
+  doRefetchMqlQuery?: boolean;
 }
 
 const useFetchMqlQuery = <CreateQueryDataType, FetchDataType extends {mqlQuery?: any}>({
@@ -28,7 +29,8 @@ const useFetchMqlQuery = <CreateQueryDataType, FetchDataType extends {mqlQuery?:
   dispatch,
   createQueryIdQuery,
   retries,
-  fetchDataQuery
+  fetchDataQuery,
+  doRefetchMqlQuery,
 }: UseFetchMqlTimeSeriesArgs<CreateQueryDataType, FetchDataType>) => {
   const {
     useQuery,
@@ -41,10 +43,11 @@ const useFetchMqlQuery = <CreateQueryDataType, FetchDataType extends {mqlQuery?:
   >({
     query: fetchDataQuery, //FetchMqlQueryTimeSeries,
     variables: {
-      queryId: state.queryId || "",
+      queryId: doRefetchMqlQuery ? "" : state.queryId || "",
       attemptNum: retries
     },
     pause: skip,
+    requestPolicy: doRefetchMqlQuery ? 'network-only' : undefined,
   });
 
   const retry = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes

We want to bypass the URQL cache in this case.

# Security Implications

None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
