### PR TITLE
Added query to get MQL server success rates

### DIFF
--- a/queries/mql/FetchMQLQuerySuccessRates.ts
+++ b/queries/mql/FetchMQLQuerySuccessRates.ts
@@ -1,0 +1,11 @@
+import { gql } from "urql";
+
+const query = gql`
+  query MqlQuerySuccessRates {
+    oneHourSuccessRate
+    oneDaySuccessRate
+    oneWeekSuccessRate
+  }
+`;
+
+export default query;


### PR DESCRIPTION
# Changes
Added a new query to get the MQL server success rates, using the following fields:
- oneHourSuccessRate
- oneDaySuccessRate
- oneWeekSuccessRate

# Security Implications
"None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
