### PR TITLE
[npm publish] Update publish steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "codegen:core:queries": "graphql-codegen --config codegen/core/queries.yml",
     "codegen": "yarn run codegen:mql:mutations && yarn run codegen:mql:queries && yarn run codegen:core:mutations && yarn run codegen:core:queries",
     "dev": "next dev",
-    "prepublish": "tsc",
+    "prepare": "tsc",
     "tsc": "tsc",
     "start": "next start",
     "schema:mql": "node scripts/schemaMql.js",


### PR DESCRIPTION
# Changes

Addresses this deprecation warning:

```
$ npm publish
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```

# Security Implications

"None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
