### PR TITLE
Added UserId field to FetchMQLQueryLogs

### DIFF
--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -221,6 +221,7 @@ export type Organization = {
   metricViews?: Maybe<Array<Maybe<MetricView>>>;
   teamViews?: Maybe<Array<Maybe<TeamView>>>;
   integrations?: Maybe<Integrations>;
+  modelsV2?: Maybe<Array<Maybe<Model>>>;
   questions?: Maybe<Array<Maybe<Question>>>;
   question?: Maybe<Question>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
@@ -279,6 +280,8 @@ export type Organization = {
   metricNamesInBoards?: Maybe<Array<Maybe<Scalars['String']>>>;
   currentModel?: Maybe<Array<Maybe<Model>>>;
   historyOfCurrentModels?: Maybe<Array<Maybe<CurrentModelHistory>>>;
+  annotationsForMetrics?: Maybe<Array<Maybe<Annotation>>>;
+  totalAnnotationsForMetrics?: Maybe<Scalars['Int']>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -372,6 +375,17 @@ export type OrganizationMetricCollectionsArgs = {
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
   orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationModelsV2Args = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<ModelStrColumns>>>;
+  orderBy?: Maybe<ModelOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<ModelOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
 };
@@ -637,6 +651,31 @@ export type OrganizationBoardArgs = {
 export type OrganizationHistoryOfCurrentModelsArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationAnnotationsForMetricsArgs = {
+  metrics: Array<Maybe<Scalars['String']>>;
+  dimensions?: Maybe<Array<Maybe<GMetricAnnotationDimensionInput>>>;
+  startDate?: Maybe<Scalars['Date']>;
+  endDate?: Maybe<Scalars['Date']>;
+  priorities?: Maybe<Array<Maybe<Priority>>>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
+  orderBy?: Maybe<AnnotationOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationTotalAnnotationsForMetricsArgs = {
+  metrics: Array<Maybe<Scalars['String']>>;
+  dimensions?: Maybe<Array<Maybe<GMetricAnnotationDimensionInput>>>;
+  startDate?: Maybe<Scalars['Date']>;
+  endDate?: Maybe<Scalars['Date']>;
+  priorities?: Maybe<Array<Maybe<Priority>>>;
 };
 
 /** An enumeration. */
@@ -1579,6 +1618,13 @@ export type ModelDataSource = {
   dataSourceVersionId: Scalars['ID'];
   dataSourceVersion?: Maybe<DataSourceVersion>;
   model?: Maybe<Model>;
+  joinableDataSources?: Maybe<Array<Maybe<ModelDataSource>>>;
+};
+
+
+export type ModelDataSourceJoinableDataSourcesArgs = {
+  identifiers?: Maybe<Array<Maybe<Scalars['String']>>>;
+  primaryOnly?: Maybe<Scalars['Boolean']>;
 };
 
 export type DataSourceVersion = {
@@ -1601,6 +1647,7 @@ export type DataSourceVersion = {
   hash: Scalars['String'];
   organizationId: Scalars['Int'];
   organization?: Maybe<Organization>;
+  modelDataSource?: Maybe<Array<Maybe<ModelDataSource>>>;
   dbtModelMeta?: Maybe<DbtModelMeta>;
 };
 
@@ -1767,6 +1814,7 @@ export type MetricMetadata = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   updatedBy: Scalars['Int'];
   isPrivate: Scalars['Boolean'];
+  isPrivateLock: Scalars['Boolean'];
   orgMetric?: Maybe<OrgMetric>;
   createdByUser?: Maybe<User>;
   updatedByUser?: Maybe<User>;
@@ -2009,6 +2057,7 @@ export enum OrgMetricOrderBy {
   MetricMetadataIncreaseIsGoodLock = 'MetricMetadata__INCREASE_IS_GOOD_LOCK',
   MetricMetadataIsNew = 'MetricMetadata__IS_NEW',
   MetricMetadataIsPrivate = 'MetricMetadata__IS_PRIVATE',
+  MetricMetadataIsPrivateLock = 'MetricMetadata__IS_PRIVATE_LOCK',
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
@@ -2110,6 +2159,7 @@ export enum MetricVersionOrderBy {
   MetricMetadataIncreaseIsGoodLock = 'MetricMetadata__INCREASE_IS_GOOD_LOCK',
   MetricMetadataIsNew = 'MetricMetadata__IS_NEW',
   MetricMetadataIsPrivate = 'MetricMetadata__IS_PRIVATE',
+  MetricMetadataIsPrivateLock = 'MetricMetadata__IS_PRIVATE_LOCK',
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
@@ -2149,6 +2199,7 @@ export type Board = {
   teamOwners?: Maybe<Array<Maybe<Team>>>;
   userCanEditContent?: Maybe<Scalars['Boolean']>;
   userCanDeactivate?: Maybe<Scalars['Boolean']>;
+  userHasAccess?: Maybe<Scalars['Boolean']>;
   items?: Maybe<Array<BoardItem>>;
   totalViews?: Maybe<Scalars['Int']>;
   myViews?: Maybe<Scalars['Int']>;
@@ -2315,6 +2366,7 @@ export enum SavedQueryOrderBy {
   MetricMetadataIncreaseIsGoodLock = 'MetricMetadata__INCREASE_IS_GOOD_LOCK',
   MetricMetadataIsNew = 'MetricMetadata__IS_NEW',
   MetricMetadataIsPrivate = 'MetricMetadata__IS_PRIVATE',
+  MetricMetadataIsPrivateLock = 'MetricMetadata__IS_PRIVATE_LOCK',
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
@@ -3024,6 +3076,34 @@ export enum SlackConversationType {
   Dm = 'DM',
   GroupDm = 'GROUP_DM'
 }
+
+/** An enumeration. */
+export enum ModelStrColumns {
+  ExecutionContext = 'EXECUTION_CONTEXT',
+  GitBranch = 'GIT_BRANCH',
+  GitCommit = 'GIT_COMMIT',
+  GitRepo = 'GIT_REPO'
+}
+
+/** An enumeration. */
+export enum ModelOrderBy {
+  CreatedAt = 'CREATED_AT',
+  ExecutionContext = 'EXECUTION_CONTEXT',
+  GitBranch = 'GIT_BRANCH',
+  GitCommit = 'GIT_COMMIT',
+  GitIsDirty = 'GIT_IS_DIRTY',
+  GitRepo = 'GIT_REPO',
+  Id = 'ID',
+  IsCurrent = 'IS_CURRENT',
+  IsValidation = 'IS_VALIDATION',
+  OrganizationId = 'ORGANIZATION_ID',
+  UploaderId = 'UPLOADER_ID'
+}
+
+export type ModelOrderByInput = {
+  orderBy: ModelOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** Filters supported for metric search. */
 export type MetricFilter = {
@@ -4676,6 +4756,7 @@ export type MutationOrgMetricsUpdateMetadataArgs = {
   defaultGranularity?: Maybe<TimeGranularity>;
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
 };
 
 

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -46,6 +46,7 @@ export type Query = {
   materializations?: Maybe<Array<Materialization>>;
   metrics?: Maybe<Array<Metric>>;
   metricByName?: Maybe<Metric>;
+  metricsByName?: Maybe<Array<Maybe<Metric>>>;
   measures?: Maybe<Array<Measure>>;
   measureByName?: Maybe<Measure>;
   dimensionNamesForMetrics?: Maybe<Array<Maybe<Scalars['String']>>>;
@@ -141,6 +142,17 @@ export type QueryMetricsArgs = {
 export type QueryMetricByNameArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   name: Scalars['String'];
+};
+
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryMetricsByNameArgs = {
+  modelKey?: Maybe<ModelKeyInput>;
+  names: Array<Maybe<Scalars['String']>>;
 };
 
 
@@ -355,6 +367,8 @@ export type MqlQuery = {
   logsByLine?: Maybe<Scalars['String']>;
   chartValueMin?: Maybe<Scalars['Float']>;
   chartValueMax?: Maybe<Scalars['Float']>;
+  columnMinChartValues?: Maybe<Scalars['GenericScalar']>;
+  columnMaxChartValues?: Maybe<Scalars['GenericScalar']>;
   latestResultValues?: Maybe<Array<Maybe<QueryResultValue>>>;
   whereConstraint?: Maybe<Scalars['String']>;
   requestedGranularity?: Maybe<TimeGranularity>;
@@ -638,6 +652,7 @@ export type Metric = {
   maxGranularity?: Maybe<TimeGranularity>;
   newDataIsAvailable?: Maybe<Scalars['Boolean']>;
   canLimitDimensionValues?: Maybe<Scalars['Boolean']>;
+  valueFormat?: Maybe<Scalars['String']>;
 };
 
 
@@ -849,6 +864,8 @@ export type Mutation = {
   pctChangeOverRange?: Maybe<PctChangeOverRangePayload>;
   /** Invalidate cache for a given metric. */
   invalidateCacheForMetric?: Maybe<InvalidateCacheForMetric>;
+  /** Invalidate cache for a given metric. */
+  invalidateCacheForMetrics?: Maybe<InvalidateCacheForMetrics>;
   /** Invalidate all cache. */
   invalidateAllCaches?: Maybe<InvalidateAllCaches>;
   /** Submits an async data warehouse validations query. */
@@ -928,6 +945,13 @@ export type MutationPctChangeOverRangeArgs = {
 /** Base mutation object exposed by GraphQL. */
 export type MutationInvalidateCacheForMetricArgs = {
   metricName: Scalars['String'];
+  modelKey?: Maybe<ModelKeyInput>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationInvalidateCacheForMetricsArgs = {
+  metricNames: Array<Maybe<Scalars['String']>>;
   modelKey?: Maybe<ModelKeyInput>;
 };
 
@@ -1167,6 +1191,12 @@ export type PctChangeOverRangeInput = {
 /** Invalidate cache for a given metric. */
 export type InvalidateCacheForMetric = {
   __typename?: 'InvalidateCacheForMetric';
+  success?: Maybe<Scalars['String']>;
+};
+
+/** Invalidate cache for a given metric. */
+export type InvalidateCacheForMetrics = {
+  __typename?: 'InvalidateCacheForMetrics';
   success?: Maybe<Scalars['String']>;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.36.0",
+  "version": "1.37.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -221,6 +221,7 @@ export type Organization = {
   metricViews?: Maybe<Array<Maybe<MetricView>>>;
   teamViews?: Maybe<Array<Maybe<TeamView>>>;
   integrations?: Maybe<Integrations>;
+  modelsV2?: Maybe<Array<Maybe<Model>>>;
   questions?: Maybe<Array<Maybe<Question>>>;
   question?: Maybe<Question>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
@@ -279,6 +280,8 @@ export type Organization = {
   metricNamesInBoards?: Maybe<Array<Maybe<Scalars['String']>>>;
   currentModel?: Maybe<Array<Maybe<Model>>>;
   historyOfCurrentModels?: Maybe<Array<Maybe<CurrentModelHistory>>>;
+  annotationsForMetrics?: Maybe<Array<Maybe<Annotation>>>;
+  totalAnnotationsForMetrics?: Maybe<Scalars['Int']>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -372,6 +375,17 @@ export type OrganizationMetricCollectionsArgs = {
   orderBy?: Maybe<MetricCollectionOrderBy>;
   desc?: Maybe<Scalars['Boolean']>;
   orderBys?: Maybe<Array<Maybe<MetricCollectionOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationModelsV2Args = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<ModelStrColumns>>>;
+  orderBy?: Maybe<ModelOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<ModelOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
 };
@@ -637,6 +651,31 @@ export type OrganizationBoardArgs = {
 export type OrganizationHistoryOfCurrentModelsArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationAnnotationsForMetricsArgs = {
+  metrics: Array<Maybe<Scalars['String']>>;
+  dimensions?: Maybe<Array<Maybe<GMetricAnnotationDimensionInput>>>;
+  startDate?: Maybe<Scalars['Date']>;
+  endDate?: Maybe<Scalars['Date']>;
+  priorities?: Maybe<Array<Maybe<Priority>>>;
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<AnnotationStrColumns>>>;
+  orderBy?: Maybe<AnnotationOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<AnnotationOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type OrganizationTotalAnnotationsForMetricsArgs = {
+  metrics: Array<Maybe<Scalars['String']>>;
+  dimensions?: Maybe<Array<Maybe<GMetricAnnotationDimensionInput>>>;
+  startDate?: Maybe<Scalars['Date']>;
+  endDate?: Maybe<Scalars['Date']>;
+  priorities?: Maybe<Array<Maybe<Priority>>>;
 };
 
 /** An enumeration. */
@@ -1579,6 +1618,13 @@ export type ModelDataSource = {
   dataSourceVersionId: Scalars['ID'];
   dataSourceVersion?: Maybe<DataSourceVersion>;
   model?: Maybe<Model>;
+  joinableDataSources?: Maybe<Array<Maybe<ModelDataSource>>>;
+};
+
+
+export type ModelDataSourceJoinableDataSourcesArgs = {
+  identifiers?: Maybe<Array<Maybe<Scalars['String']>>>;
+  primaryOnly?: Maybe<Scalars['Boolean']>;
 };
 
 export type DataSourceVersion = {
@@ -1601,6 +1647,7 @@ export type DataSourceVersion = {
   hash: Scalars['String'];
   organizationId: Scalars['Int'];
   organization?: Maybe<Organization>;
+  modelDataSource?: Maybe<Array<Maybe<ModelDataSource>>>;
   dbtModelMeta?: Maybe<DbtModelMeta>;
 };
 
@@ -1767,6 +1814,7 @@ export type MetricMetadata = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   updatedBy: Scalars['Int'];
   isPrivate: Scalars['Boolean'];
+  isPrivateLock: Scalars['Boolean'];
   orgMetric?: Maybe<OrgMetric>;
   createdByUser?: Maybe<User>;
   updatedByUser?: Maybe<User>;
@@ -2009,6 +2057,7 @@ export enum OrgMetricOrderBy {
   MetricMetadataIncreaseIsGoodLock = 'MetricMetadata__INCREASE_IS_GOOD_LOCK',
   MetricMetadataIsNew = 'MetricMetadata__IS_NEW',
   MetricMetadataIsPrivate = 'MetricMetadata__IS_PRIVATE',
+  MetricMetadataIsPrivateLock = 'MetricMetadata__IS_PRIVATE_LOCK',
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
@@ -2110,6 +2159,7 @@ export enum MetricVersionOrderBy {
   MetricMetadataIncreaseIsGoodLock = 'MetricMetadata__INCREASE_IS_GOOD_LOCK',
   MetricMetadataIsNew = 'MetricMetadata__IS_NEW',
   MetricMetadataIsPrivate = 'MetricMetadata__IS_PRIVATE',
+  MetricMetadataIsPrivateLock = 'MetricMetadata__IS_PRIVATE_LOCK',
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
@@ -2149,6 +2199,7 @@ export type Board = {
   teamOwners?: Maybe<Array<Maybe<Team>>>;
   userCanEditContent?: Maybe<Scalars['Boolean']>;
   userCanDeactivate?: Maybe<Scalars['Boolean']>;
+  userHasAccess?: Maybe<Scalars['Boolean']>;
   items?: Maybe<Array<BoardItem>>;
   totalViews?: Maybe<Scalars['Int']>;
   myViews?: Maybe<Scalars['Int']>;
@@ -2315,6 +2366,7 @@ export enum SavedQueryOrderBy {
   MetricMetadataIncreaseIsGoodLock = 'MetricMetadata__INCREASE_IS_GOOD_LOCK',
   MetricMetadataIsNew = 'MetricMetadata__IS_NEW',
   MetricMetadataIsPrivate = 'MetricMetadata__IS_PRIVATE',
+  MetricMetadataIsPrivateLock = 'MetricMetadata__IS_PRIVATE_LOCK',
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
@@ -3024,6 +3076,34 @@ export enum SlackConversationType {
   Dm = 'DM',
   GroupDm = 'GROUP_DM'
 }
+
+/** An enumeration. */
+export enum ModelStrColumns {
+  ExecutionContext = 'EXECUTION_CONTEXT',
+  GitBranch = 'GIT_BRANCH',
+  GitCommit = 'GIT_COMMIT',
+  GitRepo = 'GIT_REPO'
+}
+
+/** An enumeration. */
+export enum ModelOrderBy {
+  CreatedAt = 'CREATED_AT',
+  ExecutionContext = 'EXECUTION_CONTEXT',
+  GitBranch = 'GIT_BRANCH',
+  GitCommit = 'GIT_COMMIT',
+  GitIsDirty = 'GIT_IS_DIRTY',
+  GitRepo = 'GIT_REPO',
+  Id = 'ID',
+  IsCurrent = 'IS_CURRENT',
+  IsValidation = 'IS_VALIDATION',
+  OrganizationId = 'ORGANIZATION_ID',
+  UploaderId = 'UPLOADER_ID'
+}
+
+export type ModelOrderByInput = {
+  orderBy: ModelOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
 
 /** Filters supported for metric search. */
 export type MetricFilter = {
@@ -4676,6 +4756,7 @@ export type MutationOrgMetricsUpdateMetadataArgs = {
   defaultGranularity?: Maybe<TimeGranularity>;
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
 };
 
 

--- a/queries/mql/FetchMQLQueryLogs.ts
+++ b/queries/mql/FetchMQLQueryLogs.ts
@@ -20,6 +20,7 @@ const query = gql`
       completedAt
       startedAt
       metrics
+      userId
     }
   }
 `;

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -46,6 +46,7 @@ export type Query = {
   materializations?: Maybe<Array<Materialization>>;
   metrics?: Maybe<Array<Metric>>;
   metricByName?: Maybe<Metric>;
+  metricsByName?: Maybe<Array<Maybe<Metric>>>;
   measures?: Maybe<Array<Measure>>;
   measureByName?: Maybe<Measure>;
   dimensionNamesForMetrics?: Maybe<Array<Maybe<Scalars['String']>>>;
@@ -141,6 +142,17 @@ export type QueryMetricsArgs = {
 export type QueryMetricByNameArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   name: Scalars['String'];
+};
+
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryMetricsByNameArgs = {
+  modelKey?: Maybe<ModelKeyInput>;
+  names: Array<Maybe<Scalars['String']>>;
 };
 
 
@@ -355,6 +367,8 @@ export type MqlQuery = {
   logsByLine?: Maybe<Scalars['String']>;
   chartValueMin?: Maybe<Scalars['Float']>;
   chartValueMax?: Maybe<Scalars['Float']>;
+  columnMinChartValues?: Maybe<Scalars['GenericScalar']>;
+  columnMaxChartValues?: Maybe<Scalars['GenericScalar']>;
   latestResultValues?: Maybe<Array<Maybe<QueryResultValue>>>;
   whereConstraint?: Maybe<Scalars['String']>;
   requestedGranularity?: Maybe<TimeGranularity>;
@@ -638,6 +652,7 @@ export type Metric = {
   maxGranularity?: Maybe<TimeGranularity>;
   newDataIsAvailable?: Maybe<Scalars['Boolean']>;
   canLimitDimensionValues?: Maybe<Scalars['Boolean']>;
+  valueFormat?: Maybe<Scalars['String']>;
 };
 
 
@@ -849,6 +864,8 @@ export type Mutation = {
   pctChangeOverRange?: Maybe<PctChangeOverRangePayload>;
   /** Invalidate cache for a given metric. */
   invalidateCacheForMetric?: Maybe<InvalidateCacheForMetric>;
+  /** Invalidate cache for a given metric. */
+  invalidateCacheForMetrics?: Maybe<InvalidateCacheForMetrics>;
   /** Invalidate all cache. */
   invalidateAllCaches?: Maybe<InvalidateAllCaches>;
   /** Submits an async data warehouse validations query. */
@@ -928,6 +945,13 @@ export type MutationPctChangeOverRangeArgs = {
 /** Base mutation object exposed by GraphQL. */
 export type MutationInvalidateCacheForMetricArgs = {
   metricName: Scalars['String'];
+  modelKey?: Maybe<ModelKeyInput>;
+};
+
+
+/** Base mutation object exposed by GraphQL. */
+export type MutationInvalidateCacheForMetricsArgs = {
+  metricNames: Array<Maybe<Scalars['String']>>;
   modelKey?: Maybe<ModelKeyInput>;
 };
 
@@ -1170,6 +1194,12 @@ export type InvalidateCacheForMetric = {
   success?: Maybe<Scalars['String']>;
 };
 
+/** Invalidate cache for a given metric. */
+export type InvalidateCacheForMetrics = {
+  __typename?: 'InvalidateCacheForMetrics';
+  success?: Maybe<Scalars['String']>;
+};
+
 /** Invalidate all cache. */
 export type InvalidateAllCaches = {
   __typename?: 'InvalidateAllCaches';
@@ -1339,7 +1369,7 @@ export type FetchMqlQueryLogsQuery = (
   { __typename?: 'Query' }
   & { queries?: Maybe<Array<Maybe<(
     { __typename?: 'MqlQuery' }
-    & Pick<MqlQuery, 'id' | 'status' | 'completedAt' | 'startedAt' | 'metrics'>
+    & Pick<MqlQuery, 'id' | 'status' | 'completedAt' | 'startedAt' | 'metrics' | 'userId'>
   )>>> }
 );
 

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -81,6 +81,7 @@ type Organization {
   metricViews: [MetricView]
   teamViews: [TeamView]
   integrations: Integrations
+  modelsV2(searchStr: String, searchColumns: [ModelStrColumns], orderBy: ModelOrderBy, desc: Boolean, orderBys: [ModelOrderByInput], pageNumber: Int, pageSize: Int): [Model]
   questions(searchStr: String, searchColumns: [QuestionStrColumns], orderBy: QuestionOrderBy, desc: Boolean, orderBys: [QuestionOrderByInput], pageNumber: Int, pageSize: Int): [Question]
   question(id: ID!): Question
   annotations(searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
@@ -139,6 +140,8 @@ type Organization {
   metricNamesInBoards: [String]
   currentModel: [Model]
   historyOfCurrentModels(pageNumber: Int, pageSize: Int): [CurrentModelHistory]
+  annotationsForMetrics(metrics: [String]!, dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority], searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
+  totalAnnotationsForMetrics(metrics: [String]!, dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority]): Int
   activeFeatures: [Feature]
 }
 
@@ -597,6 +600,7 @@ type ModelDataSource {
   dataSourceVersionId: ID!
   dataSourceVersion: DataSourceVersion
   model: Model
+  joinableDataSources(identifiers: [String] = [], primaryOnly: Boolean = false): [ModelDataSource]
 }
 
 type DataSourceVersion {
@@ -618,6 +622,7 @@ type DataSourceVersion {
   hash: String!
   organizationId: Int!
   organization: Organization
+  modelDataSource: [ModelDataSource]
   dbtModelMeta: DbtModelMeta
 }
 
@@ -767,6 +772,7 @@ type MetricMetadata {
   updatedAt: DateTime
   updatedBy: Int!
   isPrivate: Boolean!
+  isPrivateLock: Boolean!
   orgMetric: OrgMetric
   createdByUser: User
   updatedByUser: User
@@ -987,6 +993,7 @@ enum OrgMetricOrderBy {
   MetricMetadata__INCREASE_IS_GOOD_LOCK
   MetricMetadata__IS_NEW
   MetricMetadata__IS_PRIVATE
+  MetricMetadata__IS_PRIVATE_LOCK
   MetricMetadata__METRIC_ID
   MetricMetadata__TIER
   MetricMetadata__TIER_LOCK
@@ -1088,6 +1095,7 @@ enum MetricVersionOrderBy {
   MetricMetadata__INCREASE_IS_GOOD_LOCK
   MetricMetadata__IS_NEW
   MetricMetadata__IS_PRIVATE
+  MetricMetadata__IS_PRIVATE_LOCK
   MetricMetadata__METRIC_ID
   MetricMetadata__TIER
   MetricMetadata__TIER_LOCK
@@ -1126,6 +1134,7 @@ type Board {
   teamOwners(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
   userCanEditContent: Boolean
   userCanDeactivate: Boolean
+  userHasAccess: Boolean
   items: [BoardItem!]
   totalViews: Int
   myViews: Int
@@ -1268,6 +1277,7 @@ enum SavedQueryOrderBy {
   MetricMetadata__INCREASE_IS_GOOD_LOCK
   MetricMetadata__IS_NEW
   MetricMetadata__IS_PRIVATE
+  MetricMetadata__IS_PRIVATE_LOCK
   MetricMetadata__METRIC_ID
   MetricMetadata__TIER
   MetricMetadata__TIER_LOCK
@@ -1853,6 +1863,34 @@ enum SlackConversationType {
   GROUP_DM
 }
 
+"""An enumeration."""
+enum ModelStrColumns {
+  EXECUTION_CONTEXT
+  GIT_BRANCH
+  GIT_COMMIT
+  GIT_REPO
+}
+
+"""An enumeration."""
+enum ModelOrderBy {
+  CREATED_AT
+  EXECUTION_CONTEXT
+  GIT_BRANCH
+  GIT_COMMIT
+  GIT_IS_DIRTY
+  GIT_REPO
+  ID
+  IS_CURRENT
+  IS_VALIDATION
+  ORGANIZATION_ID
+  UPLOADER_ID
+}
+
+input ModelOrderByInput {
+  orderBy: ModelOrderBy!
+  desc: Boolean
+}
+
 """Filters supported for metric search."""
 type MetricFilter {
   filterName: String
@@ -2223,7 +2261,7 @@ type Mutation {
   orgMetricsApproveTeamViewershipRequest(metricId: Int!, teamId: Int!): OrgMetric
   orgMetricsRemoveTeamViewers(metricId: Int!, teamIds: [Int], ownerType: GOwnerType): OrgMetric
   orgMetricsAddDescription(metricId: ID!, description: String!): OrgMetric
-  orgMetricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString): OrgMetric
+  orgMetricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString, isPrivate: Boolean): OrgMetric
   savedQueryCreate(title: String!, serializedQuery: GenericScalar!, metricIds: [ID], ownerTeamId: ID, isPrivate: Boolean): SavedQuery
   savedQueryUpdate(id: ID!, title: String, createdBy: Int, ownerTeamId: Int, serializedQuery: GenericScalar, metricIds: [ID], isPrivate: Boolean): SavedQuery
   createSavedQuery(title: String!, queryId: Int!, isPrivate: Boolean, chartType: GChartType): SavedQuery

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -19,6 +19,7 @@ type Query {
   materializations(modelKey: ModelKeyInput): [Materialization!]
   metrics(modelKey: ModelKeyInput): [Metric!]
   metricByName(modelKey: ModelKeyInput, name: String!): Metric
+  metricsByName(modelKey: ModelKeyInput, names: [String]!): [Metric]
   measures(modelKey: ModelKeyInput): [Measure!]
   measureByName(modelKey: ModelKeyInput, name: String!): Measure
   dimensionNamesForMetrics(modelKey: ModelKeyInput, metricNames: [String], excludeProperties: [DimensionProperty]): [String]
@@ -98,6 +99,8 @@ type MqlQuery {
   logsByLine(fromLine: Int, maxLines: Int): String
   chartValueMin: Float
   chartValueMax: Float
+  columnMinChartValues: GenericScalar
+  columnMaxChartValues: GenericScalar
   latestResultValues: [QueryResultValue]
   whereConstraint: String
   requestedGranularity: TimeGranularity
@@ -374,6 +377,7 @@ type Metric {
   maxGranularity(modelKey: ModelKeyInput): TimeGranularity
   newDataIsAvailable(afterDatetime: DateTime!, modelKey: ModelKeyInput): Boolean
   canLimitDimensionValues(modelKey: ModelKeyInput): Boolean
+  valueFormat: String
 }
 
 """
@@ -545,6 +549,9 @@ type Mutation {
 
   """Invalidate cache for a given metric."""
   invalidateCacheForMetric(metricName: String!, modelKey: ModelKeyInput): InvalidateCacheForMetric
+
+  """Invalidate cache for a given metric."""
+  invalidateCacheForMetrics(metricNames: [String]!, modelKey: ModelKeyInput): InvalidateCacheForMetrics
 
   """Invalidate all cache."""
   invalidateAllCaches(modelKey: ModelKeyInput): InvalidateAllCaches
@@ -822,6 +829,11 @@ input PctChangeOverRangeInput {
 
 """Invalidate cache for a given metric."""
 type InvalidateCacheForMetric {
+  success: String
+}
+
+"""Invalidate cache for a given metric."""
+type InvalidateCacheForMetrics {
   success: String
 }
 


### PR DESCRIPTION
# Changes
Added UserId field to FetchMQLQueryLogs. Needed for updates to MQL Query Logs page. 

# Security Implications

None

<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
