### PR TITLE
Added params for getting union of all dimensions, not just intersect

### DIFF
--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -157,6 +157,7 @@ export type QueryDwHealthCheckArgs = {
   snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
   redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
   bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
+  databricksConnectionDetails?: Maybe<DatabricksConnectionInput>;
 };
 
 
@@ -212,6 +213,7 @@ export type Organization = {
   mqlServers?: Maybe<Array<Maybe<OrgMqlServer>>>;
   models?: Maybe<Array<Maybe<Model>>>;
   orgMetrics?: Maybe<Array<Maybe<OrgMetric>>>;
+  orgTags?: Maybe<Array<Maybe<OrgTag>>>;
   mqlHeartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   teams?: Maybe<Array<Maybe<Team>>>;
   prefs?: Maybe<Array<Maybe<OrgPref>>>;
@@ -317,6 +319,7 @@ export type OrganizationModelsArgs = {
 export type OrganizationOrgMetricsArgs = {
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  tags?: Maybe<Array<Maybe<Scalars['Int']>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
   modelId?: Maybe<Scalars['Int']>;
   userIsSubscribed?: Maybe<Scalars['Boolean']>;
@@ -359,6 +362,7 @@ export type OrganizationPrefsArgs = {
 
 export type OrganizationSavedQueriesArgs = {
   onlyPublicAndMine?: Maybe<Scalars['Boolean']>;
+  metrics?: Maybe<Array<Maybe<Scalars['String']>>>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
   orderBy?: Maybe<SavedQueryOrderBy>;
@@ -470,6 +474,7 @@ export type OrganizationTotalOrgMetricsArgs = {
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  tags?: Maybe<Array<Maybe<Scalars['Int']>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
   modelId?: Maybe<Scalars['Int']>;
   userIsSubscribed?: Maybe<Scalars['Boolean']>;
@@ -542,6 +547,7 @@ export type OrganizationTotalSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
   onlyPublicAndMine?: Maybe<Scalars['Boolean']>;
+  metrics?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -1252,9 +1258,9 @@ export type OrgMetric = {
   name: Scalars['String'];
   userOwners?: Maybe<Array<Maybe<MetricUserOwner>>>;
   userOwnersWithDeactivated?: Maybe<Array<Maybe<MetricUserOwner>>>;
-  userViewers?: Maybe<Array<Maybe<MetricUserOwner>>>;
+  userViewers?: Maybe<Array<Maybe<MetricUserViewer>>>;
   teamOwners?: Maybe<Array<Maybe<MetricTeamOwner>>>;
-  teamViewers?: Maybe<Array<Maybe<MetricTeamOwner>>>;
+  teamViewers?: Maybe<Array<Maybe<MetricTeamViewer>>>;
   versions?: Maybe<Array<Maybe<Metric>>>;
   metricAnnotations?: Maybe<Array<Maybe<MetricAnnotation>>>;
   metricMetadata?: Maybe<MetricMetadata>;
@@ -1370,6 +1376,11 @@ export type OrgMetricPendingViewerRequestsTeamsArgs = {
   pageSize?: Maybe<Scalars['Int']>;
 };
 
+
+export type OrgMetricUserHasAccessArgs = {
+  userId?: Maybe<Scalars['Int']>;
+};
+
 export type MetricUserOwner = {
   __typename?: 'MetricUserOwner';
   id: Scalars['ID'];
@@ -1397,8 +1408,37 @@ export enum GovernanceType {
   Viewer = 'VIEWER'
 }
 
+export type MetricUserViewer = {
+  __typename?: 'MetricUserViewer';
+  id: Scalars['ID'];
+  organizationId: Scalars['Int'];
+  orgMetricId: Scalars['Int'];
+  userId: Scalars['Int'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  createdBy: Scalars['Int'];
+  isLocked: Scalars['Boolean'];
+  ownerType: OwnerType;
+  governanceType: GovernanceType;
+  user?: Maybe<User>;
+  organization?: Maybe<Organization>;
+};
+
 export type MetricTeamOwner = {
   __typename?: 'MetricTeamOwner';
+  id: Scalars['ID'];
+  organizationId: Scalars['Int'];
+  teamId: Scalars['Int'];
+  orgMetricId: Scalars['Int'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  createdBy: Scalars['Int'];
+  ownerType: OwnerType;
+  governanceType: GovernanceType;
+  team?: Maybe<Team>;
+  organization?: Maybe<Organization>;
+};
+
+export type MetricTeamViewer = {
+  __typename?: 'MetricTeamViewer';
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
   teamId: Scalars['Int'];
@@ -1586,6 +1626,13 @@ export type MetricBoardsArgs = {
   orderBys?: Maybe<Array<Maybe<BoardOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type MetricTotalBoardsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardStrColumns>>>;
+  excludeNotViewed?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1818,6 +1865,28 @@ export type MetricMetadata = {
   orgMetric?: Maybe<OrgMetric>;
   createdByUser?: Maybe<User>;
   updatedByUser?: Maybe<User>;
+  tags?: Maybe<Array<Maybe<MetricMetadataTag>>>;
+};
+
+export type MetricMetadataTag = {
+  __typename?: 'MetricMetadataTag';
+  id: Scalars['ID'];
+  metricId?: Maybe<Scalars['Int']>;
+  orgMetricTagId?: Maybe<Scalars['Int']>;
+  createdAt: Scalars['DateTime'];
+  locked: Scalars['Boolean'];
+  metricMetadata?: Maybe<MetricMetadata>;
+  orgTag?: Maybe<OrgTag>;
+};
+
+export type OrgTag = {
+  __typename?: 'OrgTag';
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  organizationId: Scalars['Int'];
+  name: Scalars['String'];
+  organization?: Maybe<Organization>;
+  metricMetadataTags?: Maybe<Array<Maybe<MetricMetadataTag>>>;
 };
 
 export type LockableParameter = {
@@ -2037,7 +2106,8 @@ export enum OrgMetricStrColumns {
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
-  Name = 'NAME'
+  Name = 'NAME',
+  OrgTagName = 'OrgTag__NAME'
 }
 
 /** An enumeration. */
@@ -2067,6 +2137,10 @@ export enum OrgMetricOrderBy {
   MetricMetadataValueFormatLock = 'MetricMetadata__VALUE_FORMAT_LOCK',
   Name = 'NAME',
   OrganizationId = 'ORGANIZATION_ID',
+  OrgTagCreatedAt = 'OrgTag__CREATED_AT',
+  OrgTagId = 'OrgTag__ID',
+  OrgTagName = 'OrgTag__NAME',
+  OrgTagOrganizationId = 'OrgTag__ORGANIZATION_ID',
   Views = 'VIEWS'
 }
 
@@ -2194,6 +2268,10 @@ export type Board = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   deletedAt?: Maybe<Scalars['DateTime']>;
   isPrivate?: Maybe<Scalars['Boolean']>;
+  constraint?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  latestXDays?: Maybe<Scalars['Int']>;
   owner?: Maybe<User>;
   userOwners?: Maybe<Array<Maybe<User>>>;
   teamOwners?: Maybe<Array<Maybe<Team>>>;
@@ -2206,6 +2284,9 @@ export type Board = {
   totalFavorites?: Maybe<Scalars['Int']>;
   isFavoritedByUser?: Maybe<Scalars['Boolean']>;
   lastWeekViews?: Maybe<Scalars['Int']>;
+  filteredViews?: Maybe<Array<Maybe<BoardFilteredView>>>;
+  totalFilteredViews?: Maybe<Scalars['Int']>;
+  defaultFilter?: Maybe<BoardDefaultFilter>;
 };
 
 
@@ -2228,6 +2309,24 @@ export type BoardTeamOwnersArgs = {
   orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type BoardFilteredViewsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
+  orderBy?: Maybe<BoardFilteredViewOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<BoardFilteredViewOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type BoardTotalFilteredViewsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
+  excludeNotViewed?: Maybe<Scalars['Boolean']>;
 };
 
 /** An enumeration. */
@@ -2336,6 +2435,113 @@ export type MarkdownConfig = {
   __typename?: 'MarkdownConfig';
   type?: Maybe<Scalars['String']>;
   content?: Maybe<Scalars['String']>;
+};
+
+export type BoardFilteredView = {
+  __typename?: 'BoardFilteredView';
+  id: Scalars['ID'];
+  boardId?: Maybe<Scalars['Int']>;
+  organizationId?: Maybe<Scalars['Int']>;
+  createdBy?: Maybe<Scalars['Int']>;
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
+  constraint?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+  board?: Maybe<Board>;
+  creator?: Maybe<User>;
+  where?: Maybe<Constraint>;
+  userCanEditContent?: Maybe<Scalars['Boolean']>;
+  userHasAccess?: Maybe<Scalars['Boolean']>;
+  userCanDelete?: Maybe<Scalars['Boolean']>;
+  totalViews?: Maybe<Scalars['Int']>;
+  myViews?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * For time dimensions, the smallest possible difference between two time values.
+ *
+ *     Needed for calculating adjacency when merging 2 different time ranges.
+ */
+export enum TimeGranularity {
+  Day = 'DAY',
+  Week = 'WEEK',
+  Month = 'MONTH',
+  Quarter = 'QUARTER',
+  Year = 'YEAR'
+}
+
+/** Represents a where constraint used in a query. */
+export type Constraint = {
+  __typename?: 'Constraint';
+  constraint?: Maybe<SingleConstraint>;
+  And?: Maybe<Array<SingleConstraint>>;
+};
+
+/** Actual `where` clauses to be applied */
+export type SingleConstraint = {
+  __typename?: 'SingleConstraint';
+  constraintType?: Maybe<AtomicConstraintType>;
+  dimensionName?: Maybe<Scalars['String']>;
+  values?: Maybe<Array<Maybe<Scalars['String']>>>;
+  start?: Maybe<Scalars['String']>;
+  stop?: Maybe<Scalars['String']>;
+};
+
+/** Current possible values for constraints */
+export enum AtomicConstraintType {
+  Set = 'SET',
+  Range = 'RANGE'
+}
+
+/** An enumeration. */
+export enum BoardFilteredViewStrColumns {
+  Constraint = 'CONSTRAINT',
+  Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
+  StartTime = 'START_TIME',
+  Title = 'TITLE'
+}
+
+/** An enumeration. */
+export enum BoardFilteredViewOrderBy {
+  BoardId = 'BOARD_ID',
+  Constraint = 'CONSTRAINT',
+  CreatedAt = 'CREATED_AT',
+  CreatedBy = 'CREATED_BY',
+  Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
+  Id = 'ID',
+  IsPrivate = 'IS_PRIVATE',
+  LatestXDays = 'LATEST_X_DAYS',
+  MyViews = 'MY_VIEWS',
+  OrganizationId = 'ORGANIZATION_ID',
+  RecentlyViewed = 'RECENTLY_VIEWED',
+  StartTime = 'START_TIME',
+  TimeGranularity = 'TIME_GRANULARITY',
+  Title = 'TITLE',
+  UpdatedAt = 'UPDATED_AT',
+  Views = 'VIEWS'
+}
+
+export type BoardFilteredViewOrderByInput = {
+  orderBy: BoardFilteredViewOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+/** Object type for default filter */
+export type BoardDefaultFilter = {
+  __typename?: 'BoardDefaultFilter';
+  where?: Maybe<Constraint>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
 };
 
 /** An enumeration. */
@@ -2459,19 +2665,6 @@ export enum AlertRuleType {
   MetricAccessRequestResponded = 'METRIC_ACCESS_REQUEST_RESPONDED'
 }
 
-/**
- * For time dimensions, the smallest possible difference between two time values.
- *
- *     Needed for calculating adjacency when merging 2 different time ranges.
- */
-export enum TimeGranularity {
-  Day = 'DAY',
-  Week = 'WEEK',
-  Month = 'MONTH',
-  Quarter = 'QUARTER',
-  Year = 'YEAR'
-}
-
 export type Alert = {
   __typename?: 'Alert';
   id: Scalars['ID'];
@@ -2487,6 +2680,7 @@ export type Alert = {
   questionReply?: Maybe<QuestionReply>;
   annotation?: Maybe<Annotation>;
   alertRule?: Maybe<AlertRule>;
+  requestingUser?: Maybe<User>;
 };
 
 /** An enumeration. */
@@ -2515,21 +2709,29 @@ export type AlertOrderByInput = {
 
 /** An enumeration. */
 export enum BoardStrColumns {
+  Constraint = 'CONSTRAINT',
   Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
+  StartTime = 'START_TIME',
   Title = 'TITLE'
 }
 
 /** An enumeration. */
 export enum BoardOrderBy {
+  Constraint = 'CONSTRAINT',
   CreatedAt = 'CREATED_AT',
   CreatedBy = 'CREATED_BY',
   DeletedAt = 'DELETED_AT',
   Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
   Id = 'ID',
   IsPrivate = 'IS_PRIVATE',
+  LatestXDays = 'LATEST_X_DAYS',
   MyViews = 'MY_VIEWS',
   OrganizationId = 'ORGANIZATION_ID',
   RecentlyViewed = 'RECENTLY_VIEWED',
+  StartTime = 'START_TIME',
+  TimeGranularity = 'TIME_GRANULARITY',
   Title = 'TITLE',
   UpdatedAt = 'UPDATED_AT',
   Views = 'VIEWS'
@@ -2548,9 +2750,9 @@ export type ProtectedMetricFields = {
   name: Scalars['String'];
   userOwners?: Maybe<Array<Maybe<MetricUserOwner>>>;
   userOwnersWithDeactivated?: Maybe<Array<Maybe<MetricUserOwner>>>;
-  userViewers?: Maybe<Array<Maybe<MetricUserOwner>>>;
+  userViewers?: Maybe<Array<Maybe<MetricUserViewer>>>;
   teamOwners?: Maybe<Array<Maybe<MetricTeamOwner>>>;
-  teamViewers?: Maybe<Array<Maybe<MetricTeamOwner>>>;
+  teamViewers?: Maybe<Array<Maybe<MetricTeamViewer>>>;
   versions?: Maybe<Array<Maybe<Metric>>>;
   metricAnnotations?: Maybe<Array<Maybe<MetricAnnotation>>>;
   metricMetadata?: Maybe<MetricMetadata>;
@@ -2679,6 +2881,13 @@ export type ProtectedMetricFieldsBoardsArgs = {
   orderBys?: Maybe<Array<Maybe<BoardOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type ProtectedMetricFieldsTotalBoardsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardStrColumns>>>;
+  excludeNotViewed?: Maybe<Scalars['Boolean']>;
 };
 
 /** Enum of governance owner/viewer request types for user_governance_request_status used for private metrics */
@@ -2923,7 +3132,8 @@ export enum DwEngine {
   Postgresql = 'POSTGRESQL',
   Mysql = 'MYSQL',
   Snowflake = 'SNOWFLAKE',
-  Bigquery = 'BIGQUERY'
+  Bigquery = 'BIGQUERY',
+  Databricks = 'DATABRICKS'
 }
 
 /** Enums to represent the status of the mql server deployment */
@@ -2959,6 +3169,7 @@ export type DataWarehouseConfig = {
   query?: Maybe<Scalars['String']>;
   dialect?: Maybe<Scalars['String']>;
   isPasswordSet?: Maybe<Scalars['Boolean']>;
+  httpPath?: Maybe<Scalars['String']>;
 };
 
 /** An enumeration. */
@@ -3311,6 +3522,14 @@ export type BigQueryConnectionInput = {
   schema: Scalars['String'];
 };
 
+/** GQL Input object for Databricks connection details. */
+export type DatabricksConnectionInput = {
+  host: Scalars['String'];
+  httpPath: Scalars['String'];
+  password: Scalars['String'];
+  schema: Scalars['String'];
+};
+
 export type AlertRuleDefinition = {
   __typename?: 'AlertRuleDefinition';
   /** The name used internally to identify the alert rule */
@@ -3509,6 +3728,12 @@ export type Mutation = {
   boardsRemoveTeamOwners?: Maybe<Board>;
   boardsFavorite?: Maybe<Board>;
   boardsUnfavorite?: Maybe<Board>;
+  boardsUpdateDefaultFilters?: Maybe<Board>;
+  boardsFilteredViewCreate?: Maybe<BoardFilteredView>;
+  boardsFilteredViewUpdate?: Maybe<BoardFilteredView>;
+  boardsFilteredViewDelete?: Maybe<BoardFilteredView>;
+  boardsFilteredViewChangeVisability?: Maybe<BoardFilteredView>;
+  boardsFilteredViewLogView?: Maybe<BoardFilteredViewView>;
   testSlackMessage?: Maybe<Scalars['String']>;
   sendSlackMessages?: Maybe<Scalars['String']>;
 };
@@ -3784,6 +4009,7 @@ export type MutationRevokeMqlServerConfigArgs = {
  */
 export type MutationSetMqlServerEnvConfigArgs = {
   bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
+  databricksConnectionDetails?: Maybe<DatabricksConnectionInput>;
   deployServer?: Maybe<Scalars['Boolean']>;
   redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
   snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
@@ -4478,6 +4704,7 @@ export type MutationMetricsUpdateMetadataArgs = {
   defaultGranularity?: Maybe<TimeGranularity>;
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
+  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -4757,6 +4984,7 @@ export type MutationOrgMetricsUpdateMetadataArgs = {
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
   isPrivate?: Maybe<Scalars['Boolean']>;
+  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -5350,6 +5578,94 @@ export type MutationBoardsUnfavoriteArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
+export type MutationBoardsUpdateDefaultFiltersArgs = {
+  boardId: Scalars['Int'];
+  where?: Maybe<ConstraintInput>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewCreateArgs = {
+  boardId: Scalars['Int'];
+  title: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
+  where?: Maybe<ConstraintInput>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewUpdateArgs = {
+  filteredViewId: Scalars['Int'];
+  title: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
+  where?: Maybe<ConstraintInput>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewDeleteArgs = {
+  filteredViewId: Scalars['Int'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewChangeVisabilityArgs = {
+  filteredViewId: Scalars['Int'];
+  isPrivate: Scalars['Boolean'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewLogViewArgs = {
+  filteredViewId: Scalars['Int'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
 export type MutationTestSlackMessageArgs = {
   message: Scalars['String'];
   fromUsername?: Maybe<Scalars['String']>;
@@ -5609,11 +5925,13 @@ export type MetricQueryInput = {
   maxDimensionValues?: Maybe<Scalars['Int']>;
 };
 
+/** Container class for inputs to allow for and/or wrappers on the `where` clause */
 export type ConstraintInput = {
   And?: Maybe<Array<SingleConstraintInput>>;
   constraint?: Maybe<SingleConstraintInput>;
 };
 
+/** Actual `where` clauses to be applied */
 export type SingleConstraintInput = {
   constraintType?: Maybe<AtomicConstraintType>;
   dimensionName?: Maybe<Scalars['String']>;
@@ -5621,11 +5939,6 @@ export type SingleConstraintInput = {
   start?: Maybe<Scalars['String']>;
   stop?: Maybe<Scalars['String']>;
 };
-
-export enum AtomicConstraintType {
-  Set = 'SET',
-  Range = 'RANGE'
-}
 
 export enum PercentChange {
   Dod = 'DOD',
@@ -5694,7 +6007,14 @@ export type BoardView = {
   userId: Scalars['ID'];
   boardId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
-  organization?: Maybe<Organization>;
+};
+
+export type BoardFilteredViewView = {
+  __typename?: 'BoardFilteredViewView';
+  organizationId: Scalars['Int'];
+  userId: Scalars['ID'];
+  filteredViewId: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
 };
 
 export type SetMqlServerMutationVariables = Exact<{

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -185,6 +185,7 @@ export type QueryMeasureByNameArgs = {
 export type QueryDimensionNamesForMetricsArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
   excludeProperties?: Maybe<Array<Maybe<DimensionProperty>>>;
 };
 
@@ -197,6 +198,7 @@ export type QueryDimensionNamesForMetricsArgs = {
 export type QueryDimensionsForMetricsArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
   excludeProperties?: Maybe<Array<Maybe<DimensionProperty>>>;
 };
 
@@ -209,6 +211,7 @@ export type QueryDimensionsForMetricsArgs = {
 export type QueryDimensionNamesForMetricsMultihopArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -220,6 +223,7 @@ export type QueryDimensionNamesForMetricsMultihopArgs = {
 export type QueryDimensionsForMetricsMultihopArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -157,6 +157,7 @@ export type QueryDwHealthCheckArgs = {
   snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
   redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
   bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
+  databricksConnectionDetails?: Maybe<DatabricksConnectionInput>;
 };
 
 
@@ -212,6 +213,7 @@ export type Organization = {
   mqlServers?: Maybe<Array<Maybe<OrgMqlServer>>>;
   models?: Maybe<Array<Maybe<Model>>>;
   orgMetrics?: Maybe<Array<Maybe<OrgMetric>>>;
+  orgTags?: Maybe<Array<Maybe<OrgTag>>>;
   mqlHeartbeats?: Maybe<Array<Maybe<MqlHeartbeat>>>;
   teams?: Maybe<Array<Maybe<Team>>>;
   prefs?: Maybe<Array<Maybe<OrgPref>>>;
@@ -317,6 +319,7 @@ export type OrganizationModelsArgs = {
 export type OrganizationOrgMetricsArgs = {
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  tags?: Maybe<Array<Maybe<Scalars['Int']>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
   modelId?: Maybe<Scalars['Int']>;
   userIsSubscribed?: Maybe<Scalars['Boolean']>;
@@ -359,6 +362,7 @@ export type OrganizationPrefsArgs = {
 
 export type OrganizationSavedQueriesArgs = {
   onlyPublicAndMine?: Maybe<Scalars['Boolean']>;
+  metrics?: Maybe<Array<Maybe<Scalars['String']>>>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
   orderBy?: Maybe<SavedQueryOrderBy>;
@@ -470,6 +474,7 @@ export type OrganizationTotalOrgMetricsArgs = {
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  tags?: Maybe<Array<Maybe<Scalars['Int']>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
   modelId?: Maybe<Scalars['Int']>;
   userIsSubscribed?: Maybe<Scalars['Boolean']>;
@@ -542,6 +547,7 @@ export type OrganizationTotalSavedQueriesArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<SavedQueryStrColumns>>>;
   onlyPublicAndMine?: Maybe<Scalars['Boolean']>;
+  metrics?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -1252,9 +1258,9 @@ export type OrgMetric = {
   name: Scalars['String'];
   userOwners?: Maybe<Array<Maybe<MetricUserOwner>>>;
   userOwnersWithDeactivated?: Maybe<Array<Maybe<MetricUserOwner>>>;
-  userViewers?: Maybe<Array<Maybe<MetricUserOwner>>>;
+  userViewers?: Maybe<Array<Maybe<MetricUserViewer>>>;
   teamOwners?: Maybe<Array<Maybe<MetricTeamOwner>>>;
-  teamViewers?: Maybe<Array<Maybe<MetricTeamOwner>>>;
+  teamViewers?: Maybe<Array<Maybe<MetricTeamViewer>>>;
   versions?: Maybe<Array<Maybe<Metric>>>;
   metricAnnotations?: Maybe<Array<Maybe<MetricAnnotation>>>;
   metricMetadata?: Maybe<MetricMetadata>;
@@ -1370,6 +1376,11 @@ export type OrgMetricPendingViewerRequestsTeamsArgs = {
   pageSize?: Maybe<Scalars['Int']>;
 };
 
+
+export type OrgMetricUserHasAccessArgs = {
+  userId?: Maybe<Scalars['Int']>;
+};
+
 export type MetricUserOwner = {
   __typename?: 'MetricUserOwner';
   id: Scalars['ID'];
@@ -1397,8 +1408,37 @@ export enum GovernanceType {
   Viewer = 'VIEWER'
 }
 
+export type MetricUserViewer = {
+  __typename?: 'MetricUserViewer';
+  id: Scalars['ID'];
+  organizationId: Scalars['Int'];
+  orgMetricId: Scalars['Int'];
+  userId: Scalars['Int'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  createdBy: Scalars['Int'];
+  isLocked: Scalars['Boolean'];
+  ownerType: OwnerType;
+  governanceType: GovernanceType;
+  user?: Maybe<User>;
+  organization?: Maybe<Organization>;
+};
+
 export type MetricTeamOwner = {
   __typename?: 'MetricTeamOwner';
+  id: Scalars['ID'];
+  organizationId: Scalars['Int'];
+  teamId: Scalars['Int'];
+  orgMetricId: Scalars['Int'];
+  createdAt?: Maybe<Scalars['DateTime']>;
+  createdBy: Scalars['Int'];
+  ownerType: OwnerType;
+  governanceType: GovernanceType;
+  team?: Maybe<Team>;
+  organization?: Maybe<Organization>;
+};
+
+export type MetricTeamViewer = {
+  __typename?: 'MetricTeamViewer';
   id: Scalars['ID'];
   organizationId: Scalars['Int'];
   teamId: Scalars['Int'];
@@ -1586,6 +1626,13 @@ export type MetricBoardsArgs = {
   orderBys?: Maybe<Array<Maybe<BoardOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type MetricTotalBoardsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardStrColumns>>>;
+  excludeNotViewed?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1818,6 +1865,28 @@ export type MetricMetadata = {
   orgMetric?: Maybe<OrgMetric>;
   createdByUser?: Maybe<User>;
   updatedByUser?: Maybe<User>;
+  tags?: Maybe<Array<Maybe<MetricMetadataTag>>>;
+};
+
+export type MetricMetadataTag = {
+  __typename?: 'MetricMetadataTag';
+  id: Scalars['ID'];
+  metricId?: Maybe<Scalars['Int']>;
+  orgMetricTagId?: Maybe<Scalars['Int']>;
+  createdAt: Scalars['DateTime'];
+  locked: Scalars['Boolean'];
+  metricMetadata?: Maybe<MetricMetadata>;
+  orgTag?: Maybe<OrgTag>;
+};
+
+export type OrgTag = {
+  __typename?: 'OrgTag';
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  organizationId: Scalars['Int'];
+  name: Scalars['String'];
+  organization?: Maybe<Organization>;
+  metricMetadataTags?: Maybe<Array<Maybe<MetricMetadataTag>>>;
 };
 
 export type LockableParameter = {
@@ -2037,7 +2106,8 @@ export enum OrgMetricStrColumns {
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
-  Name = 'NAME'
+  Name = 'NAME',
+  OrgTagName = 'OrgTag__NAME'
 }
 
 /** An enumeration. */
@@ -2067,6 +2137,10 @@ export enum OrgMetricOrderBy {
   MetricMetadataValueFormatLock = 'MetricMetadata__VALUE_FORMAT_LOCK',
   Name = 'NAME',
   OrganizationId = 'ORGANIZATION_ID',
+  OrgTagCreatedAt = 'OrgTag__CREATED_AT',
+  OrgTagId = 'OrgTag__ID',
+  OrgTagName = 'OrgTag__NAME',
+  OrgTagOrganizationId = 'OrgTag__ORGANIZATION_ID',
   Views = 'VIEWS'
 }
 
@@ -2194,6 +2268,10 @@ export type Board = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   deletedAt?: Maybe<Scalars['DateTime']>;
   isPrivate?: Maybe<Scalars['Boolean']>;
+  constraint?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  latestXDays?: Maybe<Scalars['Int']>;
   owner?: Maybe<User>;
   userOwners?: Maybe<Array<Maybe<User>>>;
   teamOwners?: Maybe<Array<Maybe<Team>>>;
@@ -2206,6 +2284,9 @@ export type Board = {
   totalFavorites?: Maybe<Scalars['Int']>;
   isFavoritedByUser?: Maybe<Scalars['Boolean']>;
   lastWeekViews?: Maybe<Scalars['Int']>;
+  filteredViews?: Maybe<Array<Maybe<BoardFilteredView>>>;
+  totalFilteredViews?: Maybe<Scalars['Int']>;
+  defaultFilter?: Maybe<BoardDefaultFilter>;
 };
 
 
@@ -2228,6 +2309,24 @@ export type BoardTeamOwnersArgs = {
   orderBys?: Maybe<Array<Maybe<TeamOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type BoardFilteredViewsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
+  orderBy?: Maybe<BoardFilteredViewOrderBy>;
+  desc?: Maybe<Scalars['Boolean']>;
+  orderBys?: Maybe<Array<Maybe<BoardFilteredViewOrderByInput>>>;
+  pageNumber?: Maybe<Scalars['Int']>;
+  pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type BoardTotalFilteredViewsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
+  excludeNotViewed?: Maybe<Scalars['Boolean']>;
 };
 
 /** An enumeration. */
@@ -2336,6 +2435,113 @@ export type MarkdownConfig = {
   __typename?: 'MarkdownConfig';
   type?: Maybe<Scalars['String']>;
   content?: Maybe<Scalars['String']>;
+};
+
+export type BoardFilteredView = {
+  __typename?: 'BoardFilteredView';
+  id: Scalars['ID'];
+  boardId?: Maybe<Scalars['Int']>;
+  organizationId?: Maybe<Scalars['Int']>;
+  createdBy?: Maybe<Scalars['Int']>;
+  title?: Maybe<Scalars['String']>;
+  description?: Maybe<Scalars['String']>;
+  createdAt?: Maybe<Scalars['DateTime']>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
+  constraint?: Maybe<Scalars['String']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+  board?: Maybe<Board>;
+  creator?: Maybe<User>;
+  where?: Maybe<Constraint>;
+  userCanEditContent?: Maybe<Scalars['Boolean']>;
+  userHasAccess?: Maybe<Scalars['Boolean']>;
+  userCanDelete?: Maybe<Scalars['Boolean']>;
+  totalViews?: Maybe<Scalars['Int']>;
+  myViews?: Maybe<Scalars['Int']>;
+};
+
+/**
+ * For time dimensions, the smallest possible difference between two time values.
+ *
+ *     Needed for calculating adjacency when merging 2 different time ranges.
+ */
+export enum TimeGranularity {
+  Day = 'DAY',
+  Week = 'WEEK',
+  Month = 'MONTH',
+  Quarter = 'QUARTER',
+  Year = 'YEAR'
+}
+
+/** Represents a where constraint used in a query. */
+export type Constraint = {
+  __typename?: 'Constraint';
+  constraint?: Maybe<SingleConstraint>;
+  And?: Maybe<Array<SingleConstraint>>;
+};
+
+/** Actual `where` clauses to be applied */
+export type SingleConstraint = {
+  __typename?: 'SingleConstraint';
+  constraintType?: Maybe<AtomicConstraintType>;
+  dimensionName?: Maybe<Scalars['String']>;
+  values?: Maybe<Array<Maybe<Scalars['String']>>>;
+  start?: Maybe<Scalars['String']>;
+  stop?: Maybe<Scalars['String']>;
+};
+
+/** Current possible values for constraints */
+export enum AtomicConstraintType {
+  Set = 'SET',
+  Range = 'RANGE'
+}
+
+/** An enumeration. */
+export enum BoardFilteredViewStrColumns {
+  Constraint = 'CONSTRAINT',
+  Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
+  StartTime = 'START_TIME',
+  Title = 'TITLE'
+}
+
+/** An enumeration. */
+export enum BoardFilteredViewOrderBy {
+  BoardId = 'BOARD_ID',
+  Constraint = 'CONSTRAINT',
+  CreatedAt = 'CREATED_AT',
+  CreatedBy = 'CREATED_BY',
+  Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
+  Id = 'ID',
+  IsPrivate = 'IS_PRIVATE',
+  LatestXDays = 'LATEST_X_DAYS',
+  MyViews = 'MY_VIEWS',
+  OrganizationId = 'ORGANIZATION_ID',
+  RecentlyViewed = 'RECENTLY_VIEWED',
+  StartTime = 'START_TIME',
+  TimeGranularity = 'TIME_GRANULARITY',
+  Title = 'TITLE',
+  UpdatedAt = 'UPDATED_AT',
+  Views = 'VIEWS'
+}
+
+export type BoardFilteredViewOrderByInput = {
+  orderBy: BoardFilteredViewOrderBy;
+  desc?: Maybe<Scalars['Boolean']>;
+};
+
+/** Object type for default filter */
+export type BoardDefaultFilter = {
+  __typename?: 'BoardDefaultFilter';
+  where?: Maybe<Constraint>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
 };
 
 /** An enumeration. */
@@ -2459,19 +2665,6 @@ export enum AlertRuleType {
   MetricAccessRequestResponded = 'METRIC_ACCESS_REQUEST_RESPONDED'
 }
 
-/**
- * For time dimensions, the smallest possible difference between two time values.
- *
- *     Needed for calculating adjacency when merging 2 different time ranges.
- */
-export enum TimeGranularity {
-  Day = 'DAY',
-  Week = 'WEEK',
-  Month = 'MONTH',
-  Quarter = 'QUARTER',
-  Year = 'YEAR'
-}
-
 export type Alert = {
   __typename?: 'Alert';
   id: Scalars['ID'];
@@ -2487,6 +2680,7 @@ export type Alert = {
   questionReply?: Maybe<QuestionReply>;
   annotation?: Maybe<Annotation>;
   alertRule?: Maybe<AlertRule>;
+  requestingUser?: Maybe<User>;
 };
 
 /** An enumeration. */
@@ -2515,21 +2709,29 @@ export type AlertOrderByInput = {
 
 /** An enumeration. */
 export enum BoardStrColumns {
+  Constraint = 'CONSTRAINT',
   Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
+  StartTime = 'START_TIME',
   Title = 'TITLE'
 }
 
 /** An enumeration. */
 export enum BoardOrderBy {
+  Constraint = 'CONSTRAINT',
   CreatedAt = 'CREATED_AT',
   CreatedBy = 'CREATED_BY',
   DeletedAt = 'DELETED_AT',
   Description = 'DESCRIPTION',
+  EndTime = 'END_TIME',
   Id = 'ID',
   IsPrivate = 'IS_PRIVATE',
+  LatestXDays = 'LATEST_X_DAYS',
   MyViews = 'MY_VIEWS',
   OrganizationId = 'ORGANIZATION_ID',
   RecentlyViewed = 'RECENTLY_VIEWED',
+  StartTime = 'START_TIME',
+  TimeGranularity = 'TIME_GRANULARITY',
   Title = 'TITLE',
   UpdatedAt = 'UPDATED_AT',
   Views = 'VIEWS'
@@ -2548,9 +2750,9 @@ export type ProtectedMetricFields = {
   name: Scalars['String'];
   userOwners?: Maybe<Array<Maybe<MetricUserOwner>>>;
   userOwnersWithDeactivated?: Maybe<Array<Maybe<MetricUserOwner>>>;
-  userViewers?: Maybe<Array<Maybe<MetricUserOwner>>>;
+  userViewers?: Maybe<Array<Maybe<MetricUserViewer>>>;
   teamOwners?: Maybe<Array<Maybe<MetricTeamOwner>>>;
-  teamViewers?: Maybe<Array<Maybe<MetricTeamOwner>>>;
+  teamViewers?: Maybe<Array<Maybe<MetricTeamViewer>>>;
   versions?: Maybe<Array<Maybe<Metric>>>;
   metricAnnotations?: Maybe<Array<Maybe<MetricAnnotation>>>;
   metricMetadata?: Maybe<MetricMetadata>;
@@ -2679,6 +2881,13 @@ export type ProtectedMetricFieldsBoardsArgs = {
   orderBys?: Maybe<Array<Maybe<BoardOrderByInput>>>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
+};
+
+
+export type ProtectedMetricFieldsTotalBoardsArgs = {
+  searchStr?: Maybe<Scalars['String']>;
+  searchColumns?: Maybe<Array<Maybe<BoardStrColumns>>>;
+  excludeNotViewed?: Maybe<Scalars['Boolean']>;
 };
 
 /** Enum of governance owner/viewer request types for user_governance_request_status used for private metrics */
@@ -2923,7 +3132,8 @@ export enum DwEngine {
   Postgresql = 'POSTGRESQL',
   Mysql = 'MYSQL',
   Snowflake = 'SNOWFLAKE',
-  Bigquery = 'BIGQUERY'
+  Bigquery = 'BIGQUERY',
+  Databricks = 'DATABRICKS'
 }
 
 /** Enums to represent the status of the mql server deployment */
@@ -2959,6 +3169,7 @@ export type DataWarehouseConfig = {
   query?: Maybe<Scalars['String']>;
   dialect?: Maybe<Scalars['String']>;
   isPasswordSet?: Maybe<Scalars['Boolean']>;
+  httpPath?: Maybe<Scalars['String']>;
 };
 
 /** An enumeration. */
@@ -3311,6 +3522,14 @@ export type BigQueryConnectionInput = {
   schema: Scalars['String'];
 };
 
+/** GQL Input object for Databricks connection details. */
+export type DatabricksConnectionInput = {
+  host: Scalars['String'];
+  httpPath: Scalars['String'];
+  password: Scalars['String'];
+  schema: Scalars['String'];
+};
+
 export type AlertRuleDefinition = {
   __typename?: 'AlertRuleDefinition';
   /** The name used internally to identify the alert rule */
@@ -3509,6 +3728,12 @@ export type Mutation = {
   boardsRemoveTeamOwners?: Maybe<Board>;
   boardsFavorite?: Maybe<Board>;
   boardsUnfavorite?: Maybe<Board>;
+  boardsUpdateDefaultFilters?: Maybe<Board>;
+  boardsFilteredViewCreate?: Maybe<BoardFilteredView>;
+  boardsFilteredViewUpdate?: Maybe<BoardFilteredView>;
+  boardsFilteredViewDelete?: Maybe<BoardFilteredView>;
+  boardsFilteredViewChangeVisability?: Maybe<BoardFilteredView>;
+  boardsFilteredViewLogView?: Maybe<BoardFilteredViewView>;
   testSlackMessage?: Maybe<Scalars['String']>;
   sendSlackMessages?: Maybe<Scalars['String']>;
 };
@@ -3784,6 +4009,7 @@ export type MutationRevokeMqlServerConfigArgs = {
  */
 export type MutationSetMqlServerEnvConfigArgs = {
   bigQueryConnectionDetails?: Maybe<BigQueryConnectionInput>;
+  databricksConnectionDetails?: Maybe<DatabricksConnectionInput>;
   deployServer?: Maybe<Scalars['Boolean']>;
   redshiftConnectionDetails?: Maybe<RedshiftConnectionInput>;
   snowflakeConnectionDetails?: Maybe<SnowflakeConnectionInput>;
@@ -4478,6 +4704,7 @@ export type MutationMetricsUpdateMetadataArgs = {
   defaultGranularity?: Maybe<TimeGranularity>;
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
+  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -4757,6 +4984,7 @@ export type MutationOrgMetricsUpdateMetadataArgs = {
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
   isPrivate?: Maybe<Scalars['Boolean']>;
+  tags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 
@@ -5350,6 +5578,94 @@ export type MutationBoardsUnfavoriteArgs = {
  * Mutation names will be converted from snake_case to camelCase automatically
  * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
  */
+export type MutationBoardsUpdateDefaultFiltersArgs = {
+  boardId: Scalars['Int'];
+  where?: Maybe<ConstraintInput>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewCreateArgs = {
+  boardId: Scalars['Int'];
+  title: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
+  where?: Maybe<ConstraintInput>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewUpdateArgs = {
+  filteredViewId: Scalars['Int'];
+  title: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
+  isPrivate?: Maybe<Scalars['Boolean']>;
+  where?: Maybe<ConstraintInput>;
+  startTime?: Maybe<Scalars['String']>;
+  endTime?: Maybe<Scalars['String']>;
+  timeGranularity?: Maybe<TimeGranularity>;
+  latestXDays?: Maybe<Scalars['Int']>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewDeleteArgs = {
+  filteredViewId: Scalars['Int'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewChangeVisabilityArgs = {
+  filteredViewId: Scalars['Int'];
+  isPrivate: Scalars['Boolean'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationBoardsFilteredViewLogViewArgs = {
+  filteredViewId: Scalars['Int'];
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
 export type MutationTestSlackMessageArgs = {
   message: Scalars['String'];
   fromUsername?: Maybe<Scalars['String']>;
@@ -5609,11 +5925,13 @@ export type MetricQueryInput = {
   maxDimensionValues?: Maybe<Scalars['Int']>;
 };
 
+/** Container class for inputs to allow for and/or wrappers on the `where` clause */
 export type ConstraintInput = {
   And?: Maybe<Array<SingleConstraintInput>>;
   constraint?: Maybe<SingleConstraintInput>;
 };
 
+/** Actual `where` clauses to be applied */
 export type SingleConstraintInput = {
   constraintType?: Maybe<AtomicConstraintType>;
   dimensionName?: Maybe<Scalars['String']>;
@@ -5621,11 +5939,6 @@ export type SingleConstraintInput = {
   start?: Maybe<Scalars['String']>;
   stop?: Maybe<Scalars['String']>;
 };
-
-export enum AtomicConstraintType {
-  Set = 'SET',
-  Range = 'RANGE'
-}
 
 export enum PercentChange {
   Dod = 'DOD',
@@ -5694,7 +6007,14 @@ export type BoardView = {
   userId: Scalars['ID'];
   boardId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
-  organization?: Maybe<Organization>;
+};
+
+export type BoardFilteredViewView = {
+  __typename?: 'BoardFilteredViewView';
+  organizationId: Scalars['Int'];
+  userId: Scalars['ID'];
+  filteredViewId: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
 };
 
 export type MqlServerUrlQueryVariables = Exact<{ [key: string]: never; }>;

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -185,6 +185,7 @@ export type QueryMeasureByNameArgs = {
 export type QueryDimensionNamesForMetricsArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
   excludeProperties?: Maybe<Array<Maybe<DimensionProperty>>>;
 };
 
@@ -197,6 +198,7 @@ export type QueryDimensionNamesForMetricsArgs = {
 export type QueryDimensionsForMetricsArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
   excludeProperties?: Maybe<Array<Maybe<DimensionProperty>>>;
 };
 
@@ -209,6 +211,7 @@ export type QueryDimensionsForMetricsArgs = {
 export type QueryDimensionNamesForMetricsMultihopArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -220,6 +223,7 @@ export type QueryDimensionNamesForMetricsMultihopArgs = {
 export type QueryDimensionsForMetricsMultihopArgs = {
   modelKey?: Maybe<ModelKeyInput>;
   metricNames?: Maybe<Array<Maybe<Scalars['String']>>>;
+  includeAll?: Maybe<Scalars['Boolean']>;
 };
 
 

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -20,7 +20,7 @@ type Query {
   boom(raise_: Boolean): Boolean
   transformConfig: TransformConfig
   emailCanSignUp(email: String!): Boolean
-  dwHealthCheck(snowflakeConnectionDetails: SnowflakeConnectionInput, redshiftConnectionDetails: RedshiftConnectionInput, bigQueryConnectionDetails: BigQueryConnectionInput): [MqlServerHealthItem]
+  dwHealthCheck(snowflakeConnectionDetails: SnowflakeConnectionInput, redshiftConnectionDetails: RedshiftConnectionInput, bigQueryConnectionDetails: BigQueryConnectionInput, databricksConnectionDetails: DatabricksConnectionInput): [MqlServerHealthItem]
   flagIsEnabled(flag: String!): Boolean
   supportedAlertRules: [AlertRuleDefinition]
   celeryHealthCheck: Int
@@ -71,11 +71,12 @@ type Organization {
   users(activeOnly: Boolean, searchStr: String, searchColumns: [UserStrColumns], orderBy: UserOrderBy, desc: Boolean, orderBys: [UserOrderByInput], pageNumber: Int, pageSize: Int): [User]
   mqlServers(searchStr: String, searchColumns: [OrgMqlServerStrColumns], orderBy: OrgMqlServerOrderBy, desc: Boolean, orderBys: [OrgMqlServerOrderByInput], pageNumber: Int, pageSize: Int): [OrgMqlServer]
   models(id: ID): [Model]
-  orgMetrics(names: [String], tiers: [MetricTier], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime, searchStr: String, searchColumns: [OrgMetricStrColumns], orderBy: OrgMetricOrderBy, desc: Boolean, orderBys: [OrgMetricOrderByInput], pageNumber: Int, pageSize: Int): [OrgMetric]
+  orgMetrics(names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime, searchStr: String, searchColumns: [OrgMetricStrColumns], orderBy: OrgMetricOrderBy, desc: Boolean, orderBys: [OrgMetricOrderByInput], pageNumber: Int, pageSize: Int): [OrgMetric]
+  orgTags: [OrgTag]
   mqlHeartbeats: [MqlHeartbeat]
   teams(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
   prefs(prefKey: String, searchStr: String, searchColumns: [OrgPrefStrColumns], orderBy: OrgPrefOrderBy, desc: Boolean, orderBys: [OrgPrefOrderByInput], pageNumber: Int, pageSize: Int): [OrgPref]
-  savedQueries(onlyPublicAndMine: Boolean, searchStr: String, searchColumns: [SavedQueryStrColumns], orderBy: SavedQueryOrderBy, desc: Boolean, orderBys: [SavedQueryOrderByInput], pageNumber: Int, pageSize: Int): [SavedQuery]
+  savedQueries(onlyPublicAndMine: Boolean, metrics: [String], searchStr: String, searchColumns: [SavedQueryStrColumns], orderBy: SavedQueryOrderBy, desc: Boolean, orderBys: [SavedQueryOrderByInput], pageNumber: Int, pageSize: Int): [SavedQuery]
   dashboards: [Dashboard]
   metricCollections(searchStr: String, searchColumns: [MetricCollectionStrColumns], orderBy: MetricCollectionOrderBy, desc: Boolean, orderBys: [MetricCollectionOrderByInput], pageNumber: Int, pageSize: Int): [MetricCollection]
   metricViews: [MetricView]
@@ -91,7 +92,7 @@ type Organization {
   totalQuestions: Int
   totalAnnotations: Int
   metrics(names: [String], tiers: [MetricTier], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime, searchStr: String, searchColumns: [MetricVersionStrColumns], orderBy: MetricVersionOrderBy, desc: Boolean, orderBys: [MetricVersionOrderByInput], pageNumber: Int, pageSize: Int): [Metric]
-  totalOrgMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
+  totalOrgMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
   totalMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
   supportedMetricFilters: [MetricFilter]
   latestMqlHeartbeat: MqlHeartbeat
@@ -106,7 +107,7 @@ type Organization {
   savedQuery(id: ID!): SavedQuery
   metricCollection(slug: String!): MetricCollection
   totalMetricCollections: Int
-  totalSavedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], onlyPublicAndMine: Boolean): Int
+  totalSavedQueries(searchStr: String, searchColumns: [SavedQueryStrColumns], onlyPublicAndMine: Boolean, metrics: [String]): Int
   totalActiveFeatures: Int
   requireMfa: Boolean
   allowMfaRememberBrowser: Boolean
@@ -414,9 +415,9 @@ type OrgMetric {
   name: String!
   userOwners: [MetricUserOwner]
   userOwnersWithDeactivated: [MetricUserOwner]
-  userViewers: [MetricUserOwner]
+  userViewers: [MetricUserViewer]
   teamOwners: [MetricTeamOwner]
-  teamViewers: [MetricTeamOwner]
+  teamViewers: [MetricTeamViewer]
   versions: [Metric]
   metricAnnotations: [MetricAnnotation]
   metricMetadata: MetricMetadata
@@ -439,7 +440,7 @@ type OrgMetric {
   pendingViewerRequestsTeams(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
   protectedFields: ProtectedMetricFields
   tier: Int
-  userHasAccess: Boolean
+  userHasAccess(userId: Int): Boolean
 
   """status of request for metric ownership"""
   userGovernanceRequestStatus: GovernanceRequestStatus
@@ -473,7 +474,34 @@ enum GovernanceType {
   VIEWER
 }
 
+type MetricUserViewer {
+  id: ID!
+  organizationId: Int!
+  orgMetricId: Int!
+  userId: Int!
+  createdAt: DateTime
+  createdBy: Int!
+  isLocked: Boolean!
+  ownerType: OwnerType!
+  governanceType: GovernanceType!
+  user: User
+  organization: Organization
+}
+
 type MetricTeamOwner {
+  id: ID!
+  organizationId: Int!
+  teamId: Int!
+  orgMetricId: Int!
+  createdAt: DateTime
+  createdBy: Int!
+  ownerType: OwnerType!
+  governanceType: GovernanceType!
+  team: Team
+  organization: Organization
+}
+
+type MetricTeamViewer {
   id: ID!
   organizationId: Int!
   teamId: Int!
@@ -556,7 +584,7 @@ type Metric {
   totalValueChangeAlerts: Int
   isCurrent: Boolean
   boards(searchStr: String, searchColumns: [BoardStrColumns], orderBy: BoardOrderBy, desc: Boolean, orderBys: [BoardOrderByInput], pageNumber: Int, pageSize: Int): [Board]
-  totalBoards: Int
+  totalBoards(searchStr: String, searchColumns: [BoardStrColumns], excludeNotViewed: Boolean): Int
 }
 
 """
@@ -776,6 +804,26 @@ type MetricMetadata {
   orgMetric: OrgMetric
   createdByUser: User
   updatedByUser: User
+  tags: [MetricMetadataTag]
+}
+
+type MetricMetadataTag {
+  id: ID!
+  metricId: Int
+  orgMetricTagId: Int
+  createdAt: DateTime!
+  locked: Boolean!
+  metricMetadata: MetricMetadata
+  orgTag: OrgTag
+}
+
+type OrgTag {
+  id: ID!
+  createdAt: DateTime!
+  organizationId: Int!
+  name: String!
+  organization: Organization
+  metricMetadataTags: [MetricMetadataTag]
 }
 
 type LockableParameter {
@@ -974,6 +1022,7 @@ enum OrgMetricStrColumns {
   MetricMetadata__DISPLAY_NAME
   MetricMetadata__VALUE_FORMAT
   NAME
+  OrgTag__NAME
 }
 
 """An enumeration."""
@@ -1003,6 +1052,10 @@ enum OrgMetricOrderBy {
   MetricMetadata__VALUE_FORMAT_LOCK
   NAME
   ORGANIZATION_ID
+  OrgTag__CREATED_AT
+  OrgTag__ID
+  OrgTag__NAME
+  OrgTag__ORGANIZATION_ID
   VIEWS
 }
 
@@ -1129,6 +1182,10 @@ type Board {
   updatedAt: DateTime
   deletedAt: DateTime
   isPrivate: Boolean
+  constraint: String
+  startTime: String
+  endTime: String
+  latestXDays: Int
   owner: User
   userOwners(searchStr: String, searchColumns: [UserStrColumns], orderBy: UserOrderBy, desc: Boolean, orderBys: [UserOrderByInput], pageNumber: Int, pageSize: Int): [User]
   teamOwners(searchStr: String, searchColumns: [TeamStrColumns], orderBy: TeamOrderBy, desc: Boolean, orderBys: [TeamOrderByInput], pageNumber: Int, pageSize: Int): [Team]
@@ -1141,6 +1198,9 @@ type Board {
   totalFavorites: Int
   isFavoritedByUser: Boolean
   lastWeekViews: Int
+  filteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], orderBy: BoardFilteredViewOrderBy, desc: Boolean, orderBys: [BoardFilteredViewOrderByInput], pageNumber: Int, pageSize: Int): [BoardFilteredView]
+  totalFilteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], excludeNotViewed: Boolean): Int
+  defaultFilter: BoardDefaultFilter
 }
 
 """An enumeration."""
@@ -1247,6 +1307,110 @@ type GroupItemConfig {
 type MarkdownConfig {
   type: String
   content: String
+}
+
+type BoardFilteredView {
+  id: ID!
+  boardId: Int
+  organizationId: Int
+  createdBy: Int
+  title: String
+  description: String
+  createdAt: DateTime
+  updatedAt: DateTime
+  isPrivate: Boolean
+  constraint: String
+  startTime: String
+  endTime: String
+  timeGranularity: TimeGranularity
+  latestXDays: Int
+  board: Board
+  creator: User
+  where: Constraint
+  userCanEditContent: Boolean
+  userHasAccess: Boolean
+  userCanDelete: Boolean
+  totalViews: Int
+  myViews: Int
+}
+
+"""
+For time dimensions, the smallest possible difference between two time values.
+
+    Needed for calculating adjacency when merging 2 different time ranges.
+    
+"""
+enum TimeGranularity {
+  DAY
+  WEEK
+  MONTH
+  QUARTER
+  YEAR
+}
+
+"""Represents a where constraint used in a query."""
+type Constraint {
+  constraint: SingleConstraint
+  And: [SingleConstraint!]
+}
+
+"""Actual `where` clauses to be applied"""
+type SingleConstraint {
+  constraintType: AtomicConstraintType
+  dimensionName: String
+  values: [String]
+  start: String
+  stop: String
+}
+
+"""Current possible values for constraints"""
+enum AtomicConstraintType {
+  SET
+  RANGE
+}
+
+"""An enumeration."""
+enum BoardFilteredViewStrColumns {
+  CONSTRAINT
+  DESCRIPTION
+  END_TIME
+  START_TIME
+  TITLE
+}
+
+"""An enumeration."""
+enum BoardFilteredViewOrderBy {
+  BOARD_ID
+  CONSTRAINT
+  CREATED_AT
+  CREATED_BY
+  DESCRIPTION
+  END_TIME
+  ID
+  IS_PRIVATE
+  LATEST_X_DAYS
+  MY_VIEWS
+  ORGANIZATION_ID
+  RECENTLY_VIEWED
+  START_TIME
+  TIME_GRANULARITY
+  TITLE
+  UPDATED_AT
+  VIEWS
+}
+
+input BoardFilteredViewOrderByInput {
+  orderBy: BoardFilteredViewOrderBy!
+  desc: Boolean
+}
+
+"""Object type for default filter"""
+type BoardDefaultFilter {
+  where: Constraint
+  timeGranularity: TimeGranularity
+  latestXDays: Int
+  startTime: String
+  endTime: String
 }
 
 """An enumeration."""
@@ -1368,20 +1532,6 @@ enum AlertRuleType {
   METRIC_ACCESS_REQUEST_RESPONDED
 }
 
-"""
-For time dimensions, the smallest possible difference between two time values.
-
-    Needed for calculating adjacency when merging 2 different time ranges.
-    
-"""
-enum TimeGranularity {
-  DAY
-  WEEK
-  MONTH
-  QUARTER
-  YEAR
-}
-
 type Alert {
   id: ID!
   alertRuleId: Int!
@@ -1396,6 +1546,7 @@ type Alert {
   questionReply: QuestionReply
   annotation: Annotation
   alertRule: AlertRule
+  requestingUser: User
 }
 
 """An enumeration."""
@@ -1424,21 +1575,29 @@ input AlertOrderByInput {
 
 """An enumeration."""
 enum BoardStrColumns {
+  CONSTRAINT
   DESCRIPTION
+  END_TIME
+  START_TIME
   TITLE
 }
 
 """An enumeration."""
 enum BoardOrderBy {
+  CONSTRAINT
   CREATED_AT
   CREATED_BY
   DELETED_AT
   DESCRIPTION
+  END_TIME
   ID
   IS_PRIVATE
+  LATEST_X_DAYS
   MY_VIEWS
   ORGANIZATION_ID
   RECENTLY_VIEWED
+  START_TIME
+  TIME_GRANULARITY
   TITLE
   UPDATED_AT
   VIEWS
@@ -1456,9 +1615,9 @@ type ProtectedMetricFields {
   name: String!
   userOwners: [MetricUserOwner]
   userOwnersWithDeactivated: [MetricUserOwner]
-  userViewers: [MetricUserOwner]
+  userViewers: [MetricUserViewer]
   teamOwners: [MetricTeamOwner]
-  teamViewers: [MetricTeamOwner]
+  teamViewers: [MetricTeamViewer]
   versions: [Metric]
   metricAnnotations: [MetricAnnotation]
   metricMetadata: MetricMetadata
@@ -1505,7 +1664,7 @@ type ProtectedMetricFields {
   valueChangeAlerts(orderBy: AlertOrderBy, desc: Boolean, orderBys: [AlertOrderByInput], pageNumber: Int, pageSize: Int): [Alert]
   totalValueChangeAlerts: Int
   boards(searchStr: String, searchColumns: [BoardStrColumns], orderBy: BoardOrderBy, desc: Boolean, orderBys: [BoardOrderByInput], pageNumber: Int, pageSize: Int): [Board]
-  totalBoards: Int
+  totalBoards(searchStr: String, searchColumns: [BoardStrColumns], excludeNotViewed: Boolean): Int
 }
 
 """
@@ -1725,6 +1884,7 @@ enum DWEngine {
   MYSQL
   SNOWFLAKE
   BIGQUERY
+  DATABRICKS
 }
 
 """Enums to represent the status of the mql server deployment"""
@@ -1758,6 +1918,7 @@ type DataWarehouseConfig {
   query: String
   dialect: String
   isPasswordSet: Boolean
+  httpPath: String
 }
 
 """An enumeration."""
@@ -2088,6 +2249,14 @@ input BigQueryConnectionInput {
   schema: String!
 }
 
+"""GQL Input object for Databricks connection details."""
+input DatabricksConnectionInput {
+  host: String!
+  httpPath: String!
+  password: String!
+  schema: String!
+}
+
 type AlertRuleDefinition {
   """The name used internally to identify the alert rule"""
   ruleType: String!
@@ -2186,7 +2355,7 @@ type Mutation {
   """
   Stores environment variables required to spin up the MQL server into AWS Secrets Manager.
   """
-  setMqlServerEnvConfig(bigQueryConnectionDetails: BigQueryConnectionInput, deployServer: Boolean, redshiftConnectionDetails: RedshiftConnectionInput, snowflakeConnectionDetails: SnowflakeConnectionInput): SetMqlServerEnvConfig
+  setMqlServerEnvConfig(bigQueryConnectionDetails: BigQueryConnectionInput, databricksConnectionDetails: DatabricksConnectionInput, deployServer: Boolean, redshiftConnectionDetails: RedshiftConnectionInput, snowflakeConnectionDetails: SnowflakeConnectionInput): SetMqlServerEnvConfig
   featuresCreate(name: String!): Feature
   featuresUpdate(id: ID!, name: String, retireFeature: Boolean): Feature
   featuresAddOrgs(featureId: ID!, organizationIds: [ID]!): Feature
@@ -2239,7 +2408,7 @@ type Mutation {
   metricsAddTeamViewers(metricId: ID!, teamIds: [ID], ownerType: GOwnerType): Metric
   metricsRemoveTeamViewers(metricId: ID!, teamIds: [ID], ownerType: GOwnerType): Metric
   metricsAddDescription(metricId: ID!, description: String!): Metric
-  metricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString): Metric
+  metricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString, tags: [String]): Metric
   orgMetricsAddUserOwners(metricId: Int!, userIds: [Int], ownerType: GOwnerType): OrgMetric
   orgMetricsRequestUserOwnership(metricId: Int!): OrgMetric
   orgMetricsDeclineUserOwnershipRequest(metricId: ID!, userId: Int!): OrgMetric
@@ -2261,7 +2430,7 @@ type Mutation {
   orgMetricsApproveTeamViewershipRequest(metricId: Int!, teamId: Int!): OrgMetric
   orgMetricsRemoveTeamViewers(metricId: Int!, teamIds: [Int], ownerType: GOwnerType): OrgMetric
   orgMetricsAddDescription(metricId: ID!, description: String!): OrgMetric
-  orgMetricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString, isPrivate: Boolean): OrgMetric
+  orgMetricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString, isPrivate: Boolean, tags: [String]): OrgMetric
   savedQueryCreate(title: String!, serializedQuery: GenericScalar!, metricIds: [ID], ownerTeamId: ID, isPrivate: Boolean): SavedQuery
   savedQueryUpdate(id: ID!, title: String, createdBy: Int, ownerTeamId: Int, serializedQuery: GenericScalar, metricIds: [ID], isPrivate: Boolean): SavedQuery
   createSavedQuery(title: String!, queryId: Int!, isPrivate: Boolean, chartType: GChartType): SavedQuery
@@ -2311,6 +2480,12 @@ type Mutation {
   boardsRemoveTeamOwners(boardId: ID!, teamIds: [ID]): Board
   boardsFavorite(boardId: ID!): Board
   boardsUnfavorite(boardId: ID!): Board
+  boardsUpdateDefaultFilters(boardId: Int!, where: ConstraintInput, startTime: String, endTime: String, timeGranularity: TimeGranularity, latestXDays: Int): Board
+  boardsFilteredViewCreate(boardId: Int!, title: String!, description: String, isPrivate: Boolean, where: ConstraintInput, startTime: String, endTime: String, timeGranularity: TimeGranularity, latestXDays: Int): BoardFilteredView
+  boardsFilteredViewUpdate(filteredViewId: Int!, title: String!, description: String, isPrivate: Boolean, where: ConstraintInput, startTime: String, endTime: String, timeGranularity: TimeGranularity, latestXDays: Int): BoardFilteredView
+  boardsFilteredViewDelete(filteredViewId: Int!): BoardFilteredView
+  boardsFilteredViewChangeVisability(filteredViewId: Int!, isPrivate: Boolean!): BoardFilteredView
+  boardsFilteredViewLogView(filteredViewId: Int!): BoardFilteredViewView
   testSlackMessage(message: String!, fromUsername: String, fromImgUrl: String): String
   sendSlackMessages(message: String!, channelNames: [String]!, fromUsername: String, fromImgUrl: String): String
 }
@@ -2553,22 +2728,21 @@ input MetricQueryInput {
   maxDimensionValues: Int
 }
 
+"""
+Container class for inputs to allow for and/or wrappers on the `where` clause
+"""
 input ConstraintInput {
   And: [SingleConstraintInput!]
   constraint: SingleConstraintInput
 }
 
+"""Actual `where` clauses to be applied"""
 input SingleConstraintInput {
   constraintType: AtomicConstraintType
   dimensionName: String
   values: [String]
   start: String
   stop: String
-}
-
-enum AtomicConstraintType {
-  SET
-  RANGE
 }
 
 enum PercentChange {
@@ -2637,5 +2811,11 @@ type BoardView {
   userId: ID!
   boardId: ID!
   createdAt: DateTime!
-  organization: Organization
+}
+
+type BoardFilteredViewView {
+  organizationId: Int!
+  userId: ID!
+  filteredViewId: ID!
+  createdAt: DateTime!
 }

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -22,10 +22,10 @@ type Query {
   metricsByName(modelKey: ModelKeyInput, names: [String]!): [Metric]
   measures(modelKey: ModelKeyInput): [Measure!]
   measureByName(modelKey: ModelKeyInput, name: String!): Measure
-  dimensionNamesForMetrics(modelKey: ModelKeyInput, metricNames: [String], excludeProperties: [DimensionProperty]): [String]
-  dimensionsForMetrics(modelKey: ModelKeyInput, metricNames: [String], excludeProperties: [DimensionProperty]): Dimensions
-  dimensionNamesForMetricsMultihop(modelKey: ModelKeyInput, metricNames: [String]): [String] @deprecated(reason: "Use `dimensionNamesForMetrics`.")
-  dimensionsForMetricsMultihop(modelKey: ModelKeyInput, metricNames: [String]): Dimensions @deprecated(reason: "Use `dimensionsForMetrics`.")
+  dimensionNamesForMetrics(modelKey: ModelKeyInput, metricNames: [String], includeAll: Boolean = false, excludeProperties: [DimensionProperty]): [String]
+  dimensionsForMetrics(modelKey: ModelKeyInput, metricNames: [String], includeAll: Boolean = false, excludeProperties: [DimensionProperty]): Dimensions
+  dimensionNamesForMetricsMultihop(modelKey: ModelKeyInput, metricNames: [String], includeAll: Boolean = false): [String] @deprecated(reason: "Use `dimensionNamesForMetrics`.")
+  dimensionsForMetricsMultihop(modelKey: ModelKeyInput, metricNames: [String], includeAll: Boolean = false): Dimensions @deprecated(reason: "Use `dimensionsForMetrics`.")
   dimensions(modelKey: ModelKeyInput): [Dimension!]
   primaryTimeDimension(modelKey: ModelKeyInput): Dimension
   maxGranularityForMetrics(metricNames: [String]!, modelKey: ModelKeyInput): TimeGranularity


### PR DESCRIPTION
# Changes
Added the "includeAll" param on the dimension resolvers to select the union of all dimensions for a list of metrics, not just the intersection.

# Security Implications
"None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
