### PR TITLE
Ignore Invalid Dimensions

### DIFF
--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -279,6 +279,7 @@ export type Organization = {
   historyOfCurrentModels?: Maybe<Array<Maybe<CurrentModelHistory>>>;
   annotationsForMetrics?: Maybe<Array<Maybe<Annotation>>>;
   totalAnnotationsForMetrics?: Maybe<Scalars['Int']>;
+  user?: Maybe<User>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -475,6 +476,7 @@ export type OrganizationTotalMetricsArgs = {
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  tags?: Maybe<Array<Maybe<Scalars['Int']>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
   modelId?: Maybe<Scalars['Int']>;
   userIsSubscribed?: Maybe<Scalars['Boolean']>;
@@ -509,6 +511,7 @@ export type OrganizationOrgMetricArgs = {
 
 export type OrganizationMetricArgs = {
   name: Scalars['String'];
+  modelId?: Maybe<Scalars['Int']>;
 };
 
 
@@ -643,6 +646,11 @@ export type OrganizationTotalAnnotationsForMetricsArgs = {
   startDate?: Maybe<Scalars['Date']>;
   endDate?: Maybe<Scalars['Date']>;
   priorities?: Maybe<Array<Maybe<Priority>>>;
+};
+
+
+export type OrganizationUserArgs = {
+  id: Scalars['Int'];
 };
 
 /** An enumeration. */
@@ -1028,7 +1036,8 @@ export enum ChartType {
   BarChartStacked = 'BAR_CHART_STACKED',
   BarChartShareOf = 'BAR_CHART_SHARE_OF',
   BigNumber = 'BIG_NUMBER',
-  Table = 'TABLE'
+  Table = 'TABLE',
+  DualAxisLineChart = 'DUAL_AXIS_LINE_CHART'
 }
 
 export type OrgMetric = {
@@ -1409,6 +1418,7 @@ export type ProtectedMetricFields = {
   increaseIsGoodWithLock?: Maybe<LockableParameter>;
   tierWithLock?: Maybe<LockableParameter>;
   isPrivateWithLock?: Maybe<LockableParameter>;
+  unitWithLock?: Maybe<LockableParameter>;
   latestApproval?: Maybe<MetricApproval>;
   questions?: Maybe<Array<Maybe<Question>>>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
@@ -1577,11 +1587,13 @@ export type MetricMetadata = {
   tier?: Maybe<Scalars['Int']>;
   valueFormat?: Maybe<Scalars['String']>;
   increaseIsGood?: Maybe<Scalars['Boolean']>;
+  unit?: Maybe<Scalars['String']>;
   descriptionLock: Scalars['Boolean'];
   displayNameLock: Scalars['Boolean'];
   tierLock: Scalars['Boolean'];
   valueFormatLock: Scalars['Boolean'];
   increaseIsGoodLock: Scalars['Boolean'];
+  unitLock: Scalars['Boolean'];
   extraFields?: Maybe<Scalars['JSONString']>;
   isNew: Scalars['Boolean'];
   createdAt?: Maybe<Scalars['DateTime']>;
@@ -1824,6 +1836,7 @@ export type DataSourceVersionOrderByInput = {
 export enum SavedQueryStrColumns {
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
   OrgMetricName = 'OrgMetric__NAME',
   Title = 'TITLE'
@@ -1852,6 +1865,8 @@ export enum SavedQueryOrderBy {
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
+  MetricMetadataUnitLock = 'MetricMetadata__UNIT_LOCK',
   MetricMetadataUpdatedAt = 'MetricMetadata__UPDATED_AT',
   MetricMetadataUpdatedBy = 'MetricMetadata__UPDATED_BY',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
@@ -2052,7 +2067,7 @@ export type BoardTeamOwnersArgs = {
 
 
 export type BoardFilteredViewsArgs = {
-  ownedBy?: Maybe<Scalars['Int']>;
+  mineOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
   orderBy?: Maybe<BoardFilteredViewOrderBy>;
@@ -2067,7 +2082,7 @@ export type BoardTotalFilteredViewsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
   excludeNotViewed?: Maybe<Scalars['Boolean']>;
-  ownedBy?: Maybe<Scalars['Int']>;
+  mineOnly?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -2272,6 +2287,7 @@ export enum OrgMetricStrColumns {
   DisplayName = 'DISPLAY_NAME',
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
   Name = 'NAME',
   OrgTagName = 'OrgTag__NAME'
@@ -2298,6 +2314,8 @@ export enum OrgMetricOrderBy {
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
+  MetricMetadataUnitLock = 'MetricMetadata__UNIT_LOCK',
   MetricMetadataUpdatedAt = 'MetricMetadata__UPDATED_AT',
   MetricMetadataUpdatedBy = 'MetricMetadata__UPDATED_BY',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
@@ -2736,6 +2754,7 @@ export enum MetricVersionStrColumns {
   MetricTypeStr = 'METRIC_TYPE_STR',
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
   OrgMetricName = 'OrgMetric__NAME'
 }
@@ -4187,6 +4206,7 @@ export type MutationOrgMetricsUpdateMetadataArgs = {
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
   isPrivate?: Maybe<Scalars['Boolean']>;
+  unit?: Maybe<Scalars['String']>;
   tags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -5036,7 +5056,8 @@ export enum GChartType {
   BarChartStacked = 'BAR_CHART_STACKED',
   BarChartShareOf = 'BAR_CHART_SHARE_OF',
   BigNumber = 'BIG_NUMBER',
-  Table = 'TABLE'
+  Table = 'TABLE',
+  DualAxisLineChart = 'DUAL_AXIS_LINE_CHART'
 }
 
 /** An enumeration. */

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -70,6 +70,8 @@ export type Query = {
   oneHourSuccessRate?: Maybe<Scalars['Float']>;
   oneDaySuccessRate?: Maybe<Scalars['Float']>;
   oneWeekSuccessRate?: Maybe<Scalars['Float']>;
+  metricsForDimensions?: Maybe<Array<Maybe<Scalars['String']>>>;
+  canLimitDimensionValues?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -328,6 +330,28 @@ export type QueryQueryParamsFromDbIdArgs = {
   dbId: Scalars['Int'];
 };
 
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryMetricsForDimensionsArgs = {
+  dimensionNames: Array<Maybe<Scalars['String']>>;
+  modelKey?: Maybe<ModelKeyInput>;
+};
+
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryCanLimitDimensionValuesArgs = {
+  numMetrics: Scalars['Int'];
+  numDimensions: Scalars['Int'];
+};
+
 /**
  * The MQL Query class is used to access the output of an MQL Query.
  *
@@ -379,6 +403,7 @@ export type MqlQuery = {
   groupBy?: Maybe<Array<Maybe<Scalars['String']>>>;
   maxDimensionValues?: Maybe<Scalars['Int']>;
   constraint?: Maybe<Constraint>;
+  order?: Maybe<Array<Maybe<Scalars['String']>>>;
   timeComparison?: Maybe<PercentChange>;
   trimIncompletePeriods?: Maybe<Scalars['Boolean']>;
   timeConstraint?: Maybe<TimeConstraint>;
@@ -404,6 +429,9 @@ export type MqlQueryResultTabularArgs = {
   cursor?: Maybe<Scalars['Int']>;
   orient?: Maybe<PandasJsonOrient>;
   paginate?: Maybe<Scalars['Boolean']>;
+  gzip?: Maybe<Scalars['Boolean']>;
+  encodingType?: Maybe<Scalars['String']>;
+  paginateSize?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -581,7 +609,8 @@ export enum ChartType {
   BarChartStacked = 'BAR_CHART_STACKED',
   BarChartShareOf = 'BAR_CHART_SHARE_OF',
   BigNumber = 'BIG_NUMBER',
-  Table = 'TABLE'
+  Table = 'TABLE',
+  DualAxisLineChart = 'DUAL_AXIS_LINE_CHART'
 }
 
 /** GQL class for QueryJob. */
@@ -681,6 +710,7 @@ export type MetricDimensionValuesArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   searchStr?: Maybe<Scalars['String']>;
+  ignoreInvalidDimensions?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -691,6 +721,7 @@ export type MetricTotalDimensionValuesArgs = {
   endTime?: Maybe<Scalars['String']>;
   allowDynamicCache?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
+  ignoreInvalidDimensions?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -861,7 +892,10 @@ export type Mutation = {
   createMqlQuery?: Maybe<CreateMqlQueryPayload>;
   /** Initiate an MQL Query based on just the DB id. We'll build out the parameters from the DB record. */
   createMqlQueryFromDbId?: Maybe<CreateMqlQueryFromDbIdPayload>;
-  /** @deprecated Moving to async implementation (CreateMqlMaterializationNew) */
+  /**
+   * Deprecated in favor of CreateMaterializationNew!
+   * @deprecated Moving to async implementation (CreateMqlMaterializationNew)
+   */
   materialize?: Maybe<Materialize>;
   /** Drop the MQL dynamic cache. Please avoid doing this unless there's a cache corruption issue. */
   dropCache?: Maybe<DropCache>;
@@ -1137,6 +1171,7 @@ export type CreateMqlQueryFromDbIdInput = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
+/** Deprecated in favor of CreateMaterializationNew! */
 export type Materialize = {
   __typename?: 'Materialize';
   schema?: Maybe<Scalars['String']>;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "codegen:mql:queries": "graphql-codegen --config codegen/mql/queries.yml",
     "codegen:core:mutations": "graphql-codegen --config codegen/core/mutations.yml",
     "codegen:core:queries": "graphql-codegen --config codegen/core/queries.yml",
-    "codegen": "yarn run codegen:mql:mutations && yarn run codegen:mql:queries && yarn run codegen:core:mutations && yarn run codegen:core:queries",
+    "codegen": "yarn schema && yarn run codegen:mql:mutations && yarn run codegen:mql:queries && yarn run codegen:core:mutations && yarn run codegen:core:queries",
     "dev": "next dev",
     "prepare": "tsc",
     "tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.39.2",
+  "version": "1.40.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -279,6 +279,7 @@ export type Organization = {
   historyOfCurrentModels?: Maybe<Array<Maybe<CurrentModelHistory>>>;
   annotationsForMetrics?: Maybe<Array<Maybe<Annotation>>>;
   totalAnnotationsForMetrics?: Maybe<Scalars['Int']>;
+  user?: Maybe<User>;
   activeFeatures?: Maybe<Array<Maybe<Feature>>>;
 };
 
@@ -475,6 +476,7 @@ export type OrganizationTotalMetricsArgs = {
   searchColumns?: Maybe<Array<Maybe<MetricVersionStrColumns>>>;
   names?: Maybe<Array<Maybe<Scalars['String']>>>;
   tiers?: Maybe<Array<Maybe<MetricTier>>>;
+  tags?: Maybe<Array<Maybe<Scalars['Int']>>>;
   types?: Maybe<Array<Maybe<MetricType>>>;
   modelId?: Maybe<Scalars['Int']>;
   userIsSubscribed?: Maybe<Scalars['Boolean']>;
@@ -509,6 +511,7 @@ export type OrganizationOrgMetricArgs = {
 
 export type OrganizationMetricArgs = {
   name: Scalars['String'];
+  modelId?: Maybe<Scalars['Int']>;
 };
 
 
@@ -643,6 +646,11 @@ export type OrganizationTotalAnnotationsForMetricsArgs = {
   startDate?: Maybe<Scalars['Date']>;
   endDate?: Maybe<Scalars['Date']>;
   priorities?: Maybe<Array<Maybe<Priority>>>;
+};
+
+
+export type OrganizationUserArgs = {
+  id: Scalars['Int'];
 };
 
 /** An enumeration. */
@@ -1028,7 +1036,8 @@ export enum ChartType {
   BarChartStacked = 'BAR_CHART_STACKED',
   BarChartShareOf = 'BAR_CHART_SHARE_OF',
   BigNumber = 'BIG_NUMBER',
-  Table = 'TABLE'
+  Table = 'TABLE',
+  DualAxisLineChart = 'DUAL_AXIS_LINE_CHART'
 }
 
 export type OrgMetric = {
@@ -1409,6 +1418,7 @@ export type ProtectedMetricFields = {
   increaseIsGoodWithLock?: Maybe<LockableParameter>;
   tierWithLock?: Maybe<LockableParameter>;
   isPrivateWithLock?: Maybe<LockableParameter>;
+  unitWithLock?: Maybe<LockableParameter>;
   latestApproval?: Maybe<MetricApproval>;
   questions?: Maybe<Array<Maybe<Question>>>;
   annotations?: Maybe<Array<Maybe<Annotation>>>;
@@ -1577,11 +1587,13 @@ export type MetricMetadata = {
   tier?: Maybe<Scalars['Int']>;
   valueFormat?: Maybe<Scalars['String']>;
   increaseIsGood?: Maybe<Scalars['Boolean']>;
+  unit?: Maybe<Scalars['String']>;
   descriptionLock: Scalars['Boolean'];
   displayNameLock: Scalars['Boolean'];
   tierLock: Scalars['Boolean'];
   valueFormatLock: Scalars['Boolean'];
   increaseIsGoodLock: Scalars['Boolean'];
+  unitLock: Scalars['Boolean'];
   extraFields?: Maybe<Scalars['JSONString']>;
   isNew: Scalars['Boolean'];
   createdAt?: Maybe<Scalars['DateTime']>;
@@ -1824,6 +1836,7 @@ export type DataSourceVersionOrderByInput = {
 export enum SavedQueryStrColumns {
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
   OrgMetricName = 'OrgMetric__NAME',
   Title = 'TITLE'
@@ -1852,6 +1865,8 @@ export enum SavedQueryOrderBy {
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
+  MetricMetadataUnitLock = 'MetricMetadata__UNIT_LOCK',
   MetricMetadataUpdatedAt = 'MetricMetadata__UPDATED_AT',
   MetricMetadataUpdatedBy = 'MetricMetadata__UPDATED_BY',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
@@ -2052,7 +2067,7 @@ export type BoardTeamOwnersArgs = {
 
 
 export type BoardFilteredViewsArgs = {
-  ownedBy?: Maybe<Scalars['Int']>;
+  mineOnly?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
   orderBy?: Maybe<BoardFilteredViewOrderBy>;
@@ -2067,7 +2082,7 @@ export type BoardTotalFilteredViewsArgs = {
   searchStr?: Maybe<Scalars['String']>;
   searchColumns?: Maybe<Array<Maybe<BoardFilteredViewStrColumns>>>;
   excludeNotViewed?: Maybe<Scalars['Boolean']>;
-  ownedBy?: Maybe<Scalars['Int']>;
+  mineOnly?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -2272,6 +2287,7 @@ export enum OrgMetricStrColumns {
   DisplayName = 'DISPLAY_NAME',
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
   Name = 'NAME',
   OrgTagName = 'OrgTag__NAME'
@@ -2298,6 +2314,8 @@ export enum OrgMetricOrderBy {
   MetricMetadataMetricId = 'MetricMetadata__METRIC_ID',
   MetricMetadataTier = 'MetricMetadata__TIER',
   MetricMetadataTierLock = 'MetricMetadata__TIER_LOCK',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
+  MetricMetadataUnitLock = 'MetricMetadata__UNIT_LOCK',
   MetricMetadataUpdatedAt = 'MetricMetadata__UPDATED_AT',
   MetricMetadataUpdatedBy = 'MetricMetadata__UPDATED_BY',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
@@ -2736,6 +2754,7 @@ export enum MetricVersionStrColumns {
   MetricTypeStr = 'METRIC_TYPE_STR',
   MetricMetadataDescription = 'MetricMetadata__DESCRIPTION',
   MetricMetadataDisplayName = 'MetricMetadata__DISPLAY_NAME',
+  MetricMetadataUnit = 'MetricMetadata__UNIT',
   MetricMetadataValueFormat = 'MetricMetadata__VALUE_FORMAT',
   OrgMetricName = 'OrgMetric__NAME'
 }
@@ -4187,6 +4206,7 @@ export type MutationOrgMetricsUpdateMetadataArgs = {
   defaultDaysLimit?: Maybe<Scalars['Int']>;
   extraFields?: Maybe<Scalars['JSONString']>;
   isPrivate?: Maybe<Scalars['Boolean']>;
+  unit?: Maybe<Scalars['String']>;
   tags?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
@@ -5036,7 +5056,8 @@ export enum GChartType {
   BarChartStacked = 'BAR_CHART_STACKED',
   BarChartShareOf = 'BAR_CHART_SHARE_OF',
   BigNumber = 'BIG_NUMBER',
-  Table = 'TABLE'
+  Table = 'TABLE',
+  DualAxisLineChart = 'DUAL_AXIS_LINE_CHART'
 }
 
 /** An enumeration. */

--- a/queries/mql/FetchDimensionValues.ts
+++ b/queries/mql/FetchDimensionValues.ts
@@ -4,7 +4,7 @@ const query = gql`
   query FetchDimensionValues(
     $metricName: String!
     $dimensionName: String!
-    $ignoreInvalidDimensions: boolean
+    $ignoreInvalidDimensions: Boolean
     $searchStr: String
     $pageNumber: Int
     $pageSize: Int

--- a/queries/mql/FetchDimensionValues.ts
+++ b/queries/mql/FetchDimensionValues.ts
@@ -1,9 +1,10 @@
-import { gql } from "urql";
+import { gql } from 'urql';
 
 const query = gql`
   query FetchDimensionValues(
     $metricName: String!
     $dimensionName: String!
+    $ignoreInvalidDimensions: boolean
     $searchStr: String
     $pageNumber: Int
     $pageSize: Int
@@ -11,12 +12,14 @@ const query = gql`
     metricByName(name: $metricName) {
       dimensionValues(
         dimensionName: $dimensionName
+        ignoreInvalidDimensions: $ignoreInvalidDimensions
         searchStr: $searchStr
         pageNumber: $pageNumber
         pageSize: $pageSize
       )
       totalDimensionValues(
         dimensionName: $dimensionName
+        ignoreInvalidDimensions: $ignoreInvalidDimensions
       )
     }
   }

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -70,6 +70,8 @@ export type Query = {
   oneHourSuccessRate?: Maybe<Scalars['Float']>;
   oneDaySuccessRate?: Maybe<Scalars['Float']>;
   oneWeekSuccessRate?: Maybe<Scalars['Float']>;
+  metricsForDimensions?: Maybe<Array<Maybe<Scalars['String']>>>;
+  canLimitDimensionValues?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -328,6 +330,28 @@ export type QueryQueryParamsFromDbIdArgs = {
   dbId: Scalars['Int'];
 };
 
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryMetricsForDimensionsArgs = {
+  dimensionNames: Array<Maybe<Scalars['String']>>;
+  modelKey?: Maybe<ModelKeyInput>;
+};
+
+
+/**
+ * Base Query object exposed by GraphQL for the MQL Server
+ *
+ * Each field defined below is accessible by the API, by calling the equivalent resolver.
+ */
+export type QueryCanLimitDimensionValuesArgs = {
+  numMetrics: Scalars['Int'];
+  numDimensions: Scalars['Int'];
+};
+
 /**
  * The MQL Query class is used to access the output of an MQL Query.
  *
@@ -379,6 +403,7 @@ export type MqlQuery = {
   groupBy?: Maybe<Array<Maybe<Scalars['String']>>>;
   maxDimensionValues?: Maybe<Scalars['Int']>;
   constraint?: Maybe<Constraint>;
+  order?: Maybe<Array<Maybe<Scalars['String']>>>;
   timeComparison?: Maybe<PercentChange>;
   trimIncompletePeriods?: Maybe<Scalars['Boolean']>;
   timeConstraint?: Maybe<TimeConstraint>;
@@ -404,6 +429,9 @@ export type MqlQueryResultTabularArgs = {
   cursor?: Maybe<Scalars['Int']>;
   orient?: Maybe<PandasJsonOrient>;
   paginate?: Maybe<Scalars['Boolean']>;
+  gzip?: Maybe<Scalars['Boolean']>;
+  encodingType?: Maybe<Scalars['String']>;
+  paginateSize?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -581,7 +609,8 @@ export enum ChartType {
   BarChartStacked = 'BAR_CHART_STACKED',
   BarChartShareOf = 'BAR_CHART_SHARE_OF',
   BigNumber = 'BIG_NUMBER',
-  Table = 'TABLE'
+  Table = 'TABLE',
+  DualAxisLineChart = 'DUAL_AXIS_LINE_CHART'
 }
 
 /** GQL class for QueryJob. */
@@ -681,6 +710,7 @@ export type MetricDimensionValuesArgs = {
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;
   searchStr?: Maybe<Scalars['String']>;
+  ignoreInvalidDimensions?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -691,6 +721,7 @@ export type MetricTotalDimensionValuesArgs = {
   endTime?: Maybe<Scalars['String']>;
   allowDynamicCache?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
+  ignoreInvalidDimensions?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -861,7 +892,10 @@ export type Mutation = {
   createMqlQuery?: Maybe<CreateMqlQueryPayload>;
   /** Initiate an MQL Query based on just the DB id. We'll build out the parameters from the DB record. */
   createMqlQueryFromDbId?: Maybe<CreateMqlQueryFromDbIdPayload>;
-  /** @deprecated Moving to async implementation (CreateMqlMaterializationNew) */
+  /**
+   * Deprecated in favor of CreateMaterializationNew!
+   * @deprecated Moving to async implementation (CreateMqlMaterializationNew)
+   */
   materialize?: Maybe<Materialize>;
   /** Drop the MQL dynamic cache. Please avoid doing this unless there's a cache corruption issue. */
   dropCache?: Maybe<DropCache>;
@@ -1137,6 +1171,7 @@ export type CreateMqlQueryFromDbIdInput = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
+/** Deprecated in favor of CreateMaterializationNew! */
 export type Materialize = {
   __typename?: 'Materialize';
   schema?: Maybe<Scalars['String']>;
@@ -1284,6 +1319,7 @@ export type FetchDimensionNamesMultihopQuery = (
 export type FetchDimensionValuesQueryVariables = Exact<{
   metricName: Scalars['String'];
   dimensionName: Scalars['String'];
+  ignoreInvalidDimensions?: Maybe<Scalars['Boolean']>;
   searchStr?: Maybe<Scalars['String']>;
   pageNumber?: Maybe<Scalars['Int']>;
   pageSize?: Maybe<Scalars['Int']>;

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -91,7 +91,7 @@ type Organization {
   totalAnnotations: Int
   metrics(names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime, searchStr: String, searchColumns: [OrgMetricStrColumns], orderBy: OrgMetricOrderBy, desc: Boolean, orderBys: [OrgMetricOrderByInput], pageNumber: Int, pageSize: Int): [OrgMetric]
   totalOrgMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
-  totalMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
+  totalMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
   supportedMetricFilters: [MetricFilter]
   latestMqlHeartbeat: MqlHeartbeat
   totalUsers(activeOnly: Boolean, searchStr: String, searchColumns: [UserStrColumns]): Int
@@ -100,7 +100,7 @@ type Organization {
   mqlServer(id: ID!): OrgMqlServer
   totalMqlServers: Int
   orgMetric(name: String!): OrgMetric
-  metric(name: String!): OrgMetric
+  metric(name: String!, modelId: Int): OrgMetric
   team(slug: String!): Team
   savedQuery(id: ID!): SavedQuery
   totalMetricCollections: Int
@@ -138,6 +138,7 @@ type Organization {
   historyOfCurrentModels(pageNumber: Int, pageSize: Int): [CurrentModelHistory]
   annotationsForMetrics(metrics: [String]!, dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority], searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
   totalAnnotationsForMetrics(metrics: [String]!, dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority]): Int
+  user(id: Int!): User
   activeFeatures: [Feature]
 }
 
@@ -341,6 +342,7 @@ enum ChartType {
   BAR_CHART_SHARE_OF
   BIG_NUMBER
   TABLE
+  DUAL_AXIS_LINE_CHART
 }
 
 type OrgMetric {
@@ -621,6 +623,7 @@ type ProtectedMetricFields {
   increaseIsGoodWithLock: LockableParameter
   tierWithLock: LockableParameter
   isPrivateWithLock: LockableParameter
+  unitWithLock: LockableParameter
   latestApproval: MetricApproval
   questions(searchStr: String, searchColumns: [QuestionStrColumns], orderBy: QuestionOrderBy, desc: Boolean, orderBys: [QuestionOrderByInput], pageNumber: Int, pageSize: Int): [Question]
   annotations(dimensions: [GMetricAnnotationDimensionInput], startDate: Date, endDate: Date, priorities: [Priority], searchStr: String, searchColumns: [AnnotationStrColumns], orderBy: AnnotationOrderBy, desc: Boolean, orderBys: [AnnotationOrderByInput], pageNumber: Int, pageSize: Int): [Annotation]
@@ -697,11 +700,13 @@ type MetricMetadata {
   tier: Int
   valueFormat: String
   increaseIsGood: Boolean
+  unit: String
   descriptionLock: Boolean!
   displayNameLock: Boolean!
   tierLock: Boolean!
   valueFormatLock: Boolean!
   increaseIsGoodLock: Boolean!
+  unitLock: Boolean!
   extraFields: JSONString
   isNew: Boolean!
   createdAt: DateTime
@@ -933,6 +938,7 @@ input DataSourceVersionOrderByInput {
 enum SavedQueryStrColumns {
   MetricMetadata__DESCRIPTION
   MetricMetadata__DISPLAY_NAME
+  MetricMetadata__UNIT
   MetricMetadata__VALUE_FORMAT
   OrgMetric__NAME
   TITLE
@@ -961,6 +967,8 @@ enum SavedQueryOrderBy {
   MetricMetadata__METRIC_ID
   MetricMetadata__TIER
   MetricMetadata__TIER_LOCK
+  MetricMetadata__UNIT
+  MetricMetadata__UNIT_LOCK
   MetricMetadata__UPDATED_AT
   MetricMetadata__UPDATED_BY
   MetricMetadata__VALUE_FORMAT
@@ -1128,8 +1136,8 @@ type Board {
   totalFavorites: Int
   isFavoritedByUser: Boolean
   lastWeekViews: Int
-  filteredViews(ownedBy: Int, searchStr: String, searchColumns: [BoardFilteredViewStrColumns], orderBy: BoardFilteredViewOrderBy, desc: Boolean, orderBys: [BoardFilteredViewOrderByInput], pageNumber: Int, pageSize: Int): [BoardFilteredView]
-  totalFilteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], excludeNotViewed: Boolean, ownedBy: Int): Int
+  filteredViews(mineOnly: Boolean, searchStr: String, searchColumns: [BoardFilteredViewStrColumns], orderBy: BoardFilteredViewOrderBy, desc: Boolean, orderBys: [BoardFilteredViewOrderByInput], pageNumber: Int, pageSize: Int): [BoardFilteredView]
+  totalFilteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], excludeNotViewed: Boolean, mineOnly: Boolean): Int
   defaultFilter: BoardDefaultFilter
   filteredViewById(filteredViewId: Int!): BoardFilteredView
 }
@@ -1327,6 +1335,7 @@ enum OrgMetricStrColumns {
   DISPLAY_NAME
   MetricMetadata__DESCRIPTION
   MetricMetadata__DISPLAY_NAME
+  MetricMetadata__UNIT
   MetricMetadata__VALUE_FORMAT
   NAME
   OrgTag__NAME
@@ -1353,6 +1362,8 @@ enum OrgMetricOrderBy {
   MetricMetadata__METRIC_ID
   MetricMetadata__TIER
   MetricMetadata__TIER_LOCK
+  MetricMetadata__UNIT
+  MetricMetadata__UNIT_LOCK
   MetricMetadata__UPDATED_AT
   MetricMetadata__UPDATED_BY
   MetricMetadata__VALUE_FORMAT
@@ -1748,6 +1759,7 @@ enum MetricVersionStrColumns {
   METRIC_TYPE_STR
   MetricMetadata__DESCRIPTION
   MetricMetadata__DISPLAY_NAME
+  MetricMetadata__UNIT
   MetricMetadata__VALUE_FORMAT
   OrgMetric__NAME
 }
@@ -2116,7 +2128,7 @@ type Mutation {
   orgMetricsApproveTeamViewershipRequest(metricId: Int!, teamId: Int!): OrgMetric
   orgMetricsRemoveTeamViewers(metricId: Int!, teamIds: [Int], ownerType: GOwnerType): OrgMetric
   orgMetricsAddDescription(metricId: ID!, description: String!): OrgMetric
-  orgMetricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString, isPrivate: Boolean, tags: [String]): OrgMetric
+  orgMetricsUpdateMetadata(metricId: ID!, description: String, tier: Int, displayName: String, valueFormat: String, increaseIsGood: Boolean, defaultTrim: Boolean, defaultGranularity: TimeGranularity, defaultDaysLimit: Int, extraFields: JSONString, isPrivate: Boolean, unit: String, tags: [String]): OrgMetric
   savedQueryCreate(title: String!, serializedQuery: GenericScalar!, metricIds: [ID], ownerTeamId: ID, isPrivate: Boolean): SavedQuery
   savedQueryUpdate(id: ID!, title: String, createdBy: Int, ownerTeamId: Int, serializedQuery: GenericScalar, metricIds: [ID], isPrivate: Boolean): SavedQuery
   createSavedQuery(title: String!, queryId: Int!, isPrivate: Boolean, chartType: GChartType): SavedQuery
@@ -2344,6 +2356,7 @@ enum GChartType {
   BAR_CHART_SHARE_OF
   BIG_NUMBER
   TABLE
+  DUAL_AXIS_LINE_CHART
 }
 
 """An enumeration."""

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -41,6 +41,13 @@ type Query {
   oneHourSuccessRate: Float
   oneDaySuccessRate: Float
   oneWeekSuccessRate: Float
+  metricsForDimensions(dimensionNames: [String]!, modelKey: ModelKeyInput): [String]
+  canLimitDimensionValues(
+    numMetrics: Int!
+
+    """Number of dimensions used in query, not including metric_time."""
+    numDimensions: Int!
+  ): Boolean
 }
 
 """
@@ -71,7 +78,7 @@ type MqlQuery {
   """
   The Tabular Results are Base 64-encoded JSON of a subset of rows from the query results Data Frame.
   """
-  resultTabular(cursor: Int, orient: PandasJsonOrient, paginate: Boolean): MqlQueryTabularResult
+  resultTabular(cursor: Int, orient: PandasJsonOrient, paginate: Boolean, gzip: Boolean = false, encodingType: String = "base64", paginateSize: Boolean): MqlQueryTabularResult
   totalResultRows: Int
 
   """
@@ -107,6 +114,7 @@ type MqlQuery {
   groupBy: [String]
   maxDimensionValues: Int
   constraint: Constraint
+  order: [String]
   timeComparison: PercentChange
   trimIncompletePeriods: Boolean
   timeConstraint: TimeConstraint
@@ -299,6 +307,7 @@ enum ChartType {
   BAR_CHART_SHARE_OF
   BIG_NUMBER
   TABLE
+  DUAL_AXIS_LINE_CHART
 }
 
 """GQL class for QueryJob."""
@@ -378,8 +387,8 @@ type Metric {
   constraint: String
   dimensions: [String!]
   dimensionObjects(modelKey: ModelKeyInput): [Dimension!]
-  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int, searchStr: String): [String]
-  totalDimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, searchStr: String): Int
+  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int, searchStr: String, ignoreInvalidDimensions: Boolean): [String]
+  totalDimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, searchStr: String, ignoreInvalidDimensions: Boolean): Int
   maxGranularity(modelKey: ModelKeyInput): TimeGranularity
   newDataIsAvailable(afterDatetime: DateTime!, modelKey: ModelKeyInput): Boolean
   canLimitDimensionValues(modelKey: ModelKeyInput): Boolean
@@ -526,6 +535,8 @@ type Mutation {
   Initiate an MQL Query based on just the DB id. We'll build out the parameters from the DB record.
   """
   createMqlQueryFromDbId(input: CreateMqlQueryFromDbIdInput!): CreateMqlQueryFromDbIdPayload
+
+  """Deprecated in favor of CreateMaterializationNew!"""
   materialize(asTable: String, cacheMode: CacheMode, groupBy: [String!], metrics: [String!], modelKey: ModelKeyInput, where: String): Materialize @deprecated(reason: "Moving to async implementation (CreateMqlMaterializationNew)")
 
   """
@@ -764,6 +775,7 @@ input CreateMqlQueryFromDbIdInput {
   clientMutationId: String
 }
 
+"""Deprecated in favor of CreateMaterializationNew!"""
 type Materialize {
   schema: String
   table: String

--- a/scripts/schemaCore.js
+++ b/scripts/schemaCore.js
@@ -1,29 +1,29 @@
-const path = require("path");
-const fs = require("fs");
-const fetch = require("node-fetch");
+const path = require('path');
+const fs = require('fs');
+const fetch = require('node-fetch');
 const {
   getIntrospectionQuery,
   printSchema,
   buildClientSchema,
-} = require("graphql");
+} = require('graphql');
 
-process.env.NODE_ENV = "development";
+process.env.NODE_ENV = 'development';
 // Ensure environment variables are read.
-require("./loadEnvLocal");
+require('./loadEnvLocal');
 
 if (!process.env.API_TOKEN) {
-  throw new Error("No production token available in process.env.API_TOKEN");
+  throw new Error('No production token available in process.env.API_TOKEN');
 }
 
 async function main() {
   let response;
   let data;
   try {
-    response = await fetch("https://api.transformdata.io/graphql", {
-      method: "POST",
+    response = await fetch('https://api.transformdata.io/graphql', {
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.API_TOKEN}`,
+        'Content-Type': 'application/json',
+        Authorization: `X-Api-Key ${process.env.API_TOKEN}`,
       },
       body: JSON.stringify({ query: getIntrospectionQuery() }),
     });
@@ -44,20 +44,20 @@ async function main() {
 
   const schema = buildClientSchema(data.data);
 
-  const outputFile = path.join(__dirname, "../schemas/core/core.graphql");
+  const outputFile = path.join(__dirname, '../schemas/core/core.graphql');
 
   try {
     await fs.promises.writeFile(outputFile, printSchema(schema));
   } catch (err) {
     return Promise.reject(err);
   }
-  return Promise.resolve("We did it!");
+  return Promise.resolve('We did it!');
 }
 
 main()
   .then((success) => {
-    if (success) console.log("Success!", success);
+    if (success) console.log('Success!', success);
   })
   .catch((failure) => {
-    if (failure) console.log("Failure!", failure);
+    if (failure) console.log('Failure!', failure);
   });

--- a/scripts/schemaMql.js
+++ b/scripts/schemaMql.js
@@ -1,32 +1,35 @@
-const path = require("path");
-const fs = require("fs");
-const fetch = require("node-fetch");
+const path = require('path');
+const fs = require('fs');
+const fetch = require('node-fetch');
 const {
   getIntrospectionQuery,
   printSchema,
   buildClientSchema,
-} = require("graphql");
+} = require('graphql');
 
-process.env.NODE_ENV = "development";
+process.env.NODE_ENV = 'development';
 // Ensure environment variables are read.
-require("./loadEnvLocal");
+require('./loadEnvLocal');
 
 if (!process.env.API_TOKEN) {
-  throw new Error("No production token available in process.env.API_TOKEN");
+  throw new Error('No production token available in process.env.API_TOKEN');
 }
 
 async function main() {
   let response;
   let data;
   try {
-    response = await fetch("https://mql-transform-staging.transform.sh/graphql", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.API_TOKEN}`,
-      },
-      body: JSON.stringify({ query: getIntrospectionQuery() }),
-    });
+    response = await fetch(
+      'https://mql-transform-staging.transform.sh/graphql',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `X-Api-Key ${process.env.API_TOKEN}`,
+        },
+        body: JSON.stringify({ query: getIntrospectionQuery() }),
+      }
+    );
   } catch (err) {
     return Promise.reject(err);
   }
@@ -43,20 +46,20 @@ async function main() {
 
   const schema = buildClientSchema(data.data);
 
-  const outputFile = path.join(__dirname, "../schemas/mql/mql.graphql");
+  const outputFile = path.join(__dirname, '../schemas/mql/mql.graphql');
 
   try {
     await fs.promises.writeFile(outputFile, printSchema(schema));
   } catch (err) {
     return Promise.reject(err);
   }
-  return Promise.resolve("We did it!");
+  return Promise.resolve('We did it!');
 }
 
 main()
   .then((success) => {
-    if (success) console.log("Success!", success);
+    if (success) console.log('Success!', success);
   })
   .catch((failure) => {
-    if (failure) console.log("Failure!", failure);
+    if (failure) console.log('Failure!', failure);
   });


### PR DESCRIPTION
# Changes
Add `ignoreInvalidDimensions` param to `FetchDimensionValues` query so we can ask for dimension values on a metric when the metric doesn't have the corresponding dimension.

# Security Implications
None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
