### PR TITLE
Enable auth via api key

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -85,6 +85,8 @@ const useCreateTimeSeriesMqlQuery = ({
       trimIncompletePeriods: formState.trimIncompletePeriods,
       where: clearEmptyConstraints(formState.where),
     }).then(({ data, error }) => {
+      console.log('data', data);
+      console.log('error', error);
       if (data?.createMqlQuery?.query?.status === MqlQueryStatus.Successful) {
         dispatch({
           type: 'postQueryCachedResultsSuccess',

--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -85,8 +85,6 @@ const useCreateTimeSeriesMqlQuery = ({
       trimIncompletePeriods: formState.trimIncompletePeriods,
       where: clearEmptyConstraints(formState.where),
     }).then(({ data, error }) => {
-      console.log('data', data);
-      console.log('error', error);
       if (data?.createMqlQuery?.query?.status === MqlQueryStatus.Successful) {
         dispatch({
           type: 'postQueryCachedResultsSuccess',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/utils/buildAuthExchange.ts
+++ b/utils/buildAuthExchange.ts
@@ -1,5 +1,5 @@
-import { makeOperation, Operation } from "urql";
-import { authExchange } from "@urql/exchange-auth";
+import { authExchange } from '@urql/exchange-auth';
+import { makeOperation, Operation } from 'urql';
 
 type AuthState = {
   token: string;
@@ -7,9 +7,11 @@ type AuthState = {
 
 function buildGetAuth(token?: string) {
   const getAuth = async ({ authState }: { authState: AuthState }) => {
-
     if (!authState) {
       if (token) {
+        if (token.includes('X-Api-Key')) {
+          return { token };
+        }
         return { token: `Bearer ${token}` };
       }
       return null;
@@ -19,37 +21,42 @@ function buildGetAuth(token?: string) {
   return getAuth;
 }
 
-const addAuthToOperation = (clientVersion: string) => ({
-  authState,
-  operation,
-}: {
-  authState: AuthState;
-  operation: Operation;
-}) => {
-  if (!authState || !authState.token) {
-    return operation;
-  }
+const addAuthToOperation =
+  (clientVersion: string) =>
+  ({
+    authState,
+    operation,
+  }: {
+    authState: AuthState;
+    operation: Operation;
+  }) => {
+    if (!authState || !authState.token) {
+      return operation;
+    }
 
-  const fetchOptions =
-    typeof operation.context.fetchOptions === "function"
-      ? operation.context.fetchOptions()
-      : operation.context.fetchOptions || {};
+    const fetchOptions =
+      typeof operation.context.fetchOptions === 'function'
+        ? operation.context.fetchOptions()
+        : operation.context.fetchOptions || {};
 
-  return makeOperation(operation.kind, operation, {
-    ...operation.context,
-    fetchOptions: {
-      ...fetchOptions,
-      headers: {
-        ...fetchOptions.headers,
-        Authorization: authState.token,
-        'X-Transform-Client': 'frontend',
-        "X-Transform-Client-Version": clientVersion
+    return makeOperation(operation.kind, operation, {
+      ...operation.context,
+      fetchOptions: {
+        ...fetchOptions,
+        headers: {
+          ...fetchOptions.headers,
+          Authorization: authState.token,
+          'X-Transform-Client': 'frontend',
+          'X-Transform-Client-Version': clientVersion,
+        },
       },
-    },
-  });
-}
+    });
+  };
 
-export default function buildAuthExchange(clientVersion: string, token?: string) {
+export default function buildAuthExchange(
+  clientVersion: string,
+  token?: string
+) {
   return authExchange({
     getAuth: buildGetAuth(token),
     addAuthToOperation: addAuthToOperation(clientVersion),


### PR DESCRIPTION
# Changes
Add a prop for `serviceUserApiKey` to allow api auth via api key.

# Security Implications
None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
