### PR TITLE
[MQL Query Cache] Bypass cache on refetch time series MQL Query

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -77,6 +77,7 @@ export default function useTimeSeriesMqlQuery({
       formState: queryInput,
       dispatch,
       retries,
+      doRefetchMqlQuery,
     }),
     [metricName, queryInput, dispatch, retries]
   );
@@ -87,6 +88,7 @@ export default function useTimeSeriesMqlQuery({
       formState: queryInput,
       dispatch,
       retries,
+      doRefetchMqlQuery,
     }),
     [metricNames, queryInput, dispatch, retries]
   );

--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -6,6 +6,7 @@ import {
   CreateMqlQueryMutationVariables,
 } from '../../../mutations/mql/MqlMutationTypes';
 import {
+  CacheMode,
   FetchMqlTimeSeriesQuery,
   MqlQueryStatus,
 } from '../../../queries/mql/MqlQueryTypes';
@@ -26,6 +27,7 @@ interface CommonUseCreateMqlQueryArgs {
   dispatch: Dispatch<
     UseMqlQueryAction<CreateMqlQueryMutation, FetchMqlTimeSeriesQuery>
   >;
+  doRefetchMqlQuery?: boolean;
 }
 
 export interface SingleMetricUserCreateMqlQueryArgs
@@ -53,6 +55,7 @@ const useCreateTimeSeriesMqlQuery = ({
   formState = {},
   dispatch,
   retries,
+  doRefetchMqlQuery,
 }: UseCreateMqlQueryArgs): UseCreateMqlQuery => {
   const { useMutation, handleCombinedError } = useContext(MqlContext);
 
@@ -70,6 +73,7 @@ const useCreateTimeSeriesMqlQuery = ({
     createMqlQueryMutation({
       addTimeSeries: true,
       attemptNum: stateRetries,
+      cacheMode: doRefetchMqlQuery ? CacheMode.Ignore : undefined,
       daysLimit: formState.daysLimit,
       endTime: formState.latestXDays ? null : formState.endTime,
       groupBy: formState.groupBy || [],

--- a/mutations/mql/CreateMqlQuery.ts
+++ b/mutations/mql/CreateMqlQuery.ts
@@ -4,6 +4,7 @@ const mutation = gql`
   mutation CreateMqlQuery(
     $addTimeSeries: Boolean
     $attemptNum: Int!
+    $cacheMode: CacheMode
     $daysLimit: Int
     $endTime: String
     $groupBy: [String!]
@@ -24,6 +25,7 @@ const mutation = gql`
       input: {
         addTimeSeries: $addTimeSeries
         attemptNum: $attemptNum
+        cacheMode: $cacheMode
         daysLimit: $daysLimit
         endTime: $endTime
         groupBy: $groupBy

--- a/mutations/mql/InvalidateCacheForMetricsMutation.ts
+++ b/mutations/mql/InvalidateCacheForMetricsMutation.ts
@@ -1,0 +1,15 @@
+import { gql } from "urql";
+
+const mutation = gql`
+  mutation InvalidateCacheForMetricsMutation(
+    $metricNames: [String]!
+  ) {
+    invalidateCacheForMetrics(
+      metricNames: $metricNames
+    ) {
+      success
+    }
+  }
+`
+
+export default mutation;

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -431,7 +431,7 @@ export type MqlQueryResultTabularArgs = {
   paginate?: Maybe<Scalars['Boolean']>;
   gzip?: Maybe<Scalars['Boolean']>;
   encodingType?: Maybe<Scalars['String']>;
-  paginateSize?: Maybe<Scalars['Boolean']>;
+  paginateSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -463,7 +463,8 @@ export enum MqlQueryStatus {
   Successful = 'SUCCESSFUL',
   Failed = 'FAILED',
   UnhandledException = 'UNHANDLED_EXCEPTION',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
+  Killed = 'KILLED'
 }
 
 /** This is the canonical shape for chart-ready data. */
@@ -494,6 +495,8 @@ export type MqlQueryTabularResult = {
   nextCursor?: Maybe<Scalars['String']>;
   /** Columns that have a value format associated with them. Used for displaying table view in the UI. */
   valueFormattedColumns?: Maybe<Array<Maybe<ValueFormattedColumn>>>;
+  /** Number of rows in the whole result set, useful when paginating through results */
+  totalRowCount?: Maybe<Scalars['Int']>;
 };
 
 /** Value formats to be applied to columns, like percent or dollar. */
@@ -569,9 +572,9 @@ export type SingleConstraint = {
   __typename?: 'SingleConstraint';
   constraintType?: Maybe<AtomicConstraintType>;
   dimensionName?: Maybe<Scalars['String']>;
-  values?: Maybe<Array<Maybe<Scalars['String']>>>;
-  start?: Maybe<Scalars['String']>;
-  stop?: Maybe<Scalars['String']>;
+  values?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
+  start?: Maybe<Scalars['GenericScalar']>;
+  stop?: Maybe<Scalars['GenericScalar']>;
 };
 
 /** Current possible values for constraints */
@@ -658,7 +661,7 @@ export enum QueryType {
 /** GQL class for DimensionValuesQueryResult. */
 export type DimensionValuesQueryResult = {
   __typename?: 'DimensionValuesQueryResult';
-  values?: Maybe<Array<Maybe<Scalars['String']>>>;
+  values?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
   totalValues?: Maybe<Scalars['Int']>;
 };
 
@@ -687,7 +690,7 @@ export type Metric = {
   constraint?: Maybe<Scalars['String']>;
   dimensions?: Maybe<Array<Scalars['String']>>;
   dimensionObjects?: Maybe<Array<Dimension>>;
-  dimensionValues?: Maybe<Array<Maybe<Scalars['String']>>>;
+  dimensionValues?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
   totalDimensionValues?: Maybe<Scalars['Int']>;
   maxGranularity?: Maybe<TimeGranularity>;
   newDataIsAvailable?: Maybe<Scalars['Boolean']>;
@@ -758,7 +761,7 @@ export type Dimension = {
   type?: Maybe<DimensionTypeForDescription>;
   isPrimaryTime?: Maybe<Scalars['Boolean']>;
   timeGranularity?: Maybe<TimeGranularity>;
-  values?: Maybe<Array<Scalars['String']>>;
+  values?: Maybe<Array<Scalars['GenericScalar']>>;
   cardinality?: Maybe<Scalars['Int']>;
 };
 
@@ -1119,19 +1122,19 @@ export type CreateMqlQueryInput = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
-/** Container class for inputs to allow for and/or wrappers on the `where` clause */
+/** GQL container class for inputs to allow for and/or wrappers on the `where` clause */
 export type ConstraintInput = {
   And?: Maybe<Array<SingleConstraintInput>>;
   constraint?: Maybe<SingleConstraintInput>;
 };
 
-/** Actual `where` clauses to be applied */
+/** Input structure for GQL query constraints. */
 export type SingleConstraintInput = {
   constraintType?: Maybe<AtomicConstraintType>;
   dimensionName?: Maybe<Scalars['String']>;
-  values?: Maybe<Array<Maybe<Scalars['String']>>>;
-  start?: Maybe<Scalars['String']>;
-  stop?: Maybe<Scalars['String']>;
+  values?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
+  start?: Maybe<Scalars['GenericScalar']>;
+  stop?: Maybe<Scalars['GenericScalar']>;
 };
 
 
@@ -1320,6 +1323,7 @@ export type CreateLatestMetricChangeMutation = (
 export type CreateMqlQueryMutationVariables = Exact<{
   addTimeSeries?: Maybe<Scalars['Boolean']>;
   attemptNum: Scalars['Int'];
+  cacheMode?: Maybe<CacheMode>;
   daysLimit?: Maybe<Scalars['Int']>;
   endTime?: Maybe<Scalars['String']>;
   groupBy?: Maybe<Array<Scalars['String']> | Scalars['String']>;
@@ -1443,5 +1447,18 @@ export type InvalidateCacheForMetricMutationMutation = (
   & { invalidateCacheForMetric?: Maybe<(
     { __typename?: 'InvalidateCacheForMetric' }
     & Pick<InvalidateCacheForMetric, 'success'>
+  )> }
+);
+
+export type InvalidateCacheForMetricsMutationMutationVariables = Exact<{
+  metricNames: Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>;
+}>;
+
+
+export type InvalidateCacheForMetricsMutationMutation = (
+  { __typename?: 'Mutation' }
+  & { invalidateCacheForMetrics?: Maybe<(
+    { __typename?: 'InvalidateCacheForMetrics' }
+    & Pick<InvalidateCacheForMetrics, 'success'>
   )> }
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -431,7 +431,7 @@ export type MqlQueryResultTabularArgs = {
   paginate?: Maybe<Scalars['Boolean']>;
   gzip?: Maybe<Scalars['Boolean']>;
   encodingType?: Maybe<Scalars['String']>;
-  paginateSize?: Maybe<Scalars['Boolean']>;
+  paginateSize?: Maybe<Scalars['Int']>;
 };
 
 
@@ -463,7 +463,8 @@ export enum MqlQueryStatus {
   Successful = 'SUCCESSFUL',
   Failed = 'FAILED',
   UnhandledException = 'UNHANDLED_EXCEPTION',
-  Unknown = 'UNKNOWN'
+  Unknown = 'UNKNOWN',
+  Killed = 'KILLED'
 }
 
 /** This is the canonical shape for chart-ready data. */
@@ -494,6 +495,8 @@ export type MqlQueryTabularResult = {
   nextCursor?: Maybe<Scalars['String']>;
   /** Columns that have a value format associated with them. Used for displaying table view in the UI. */
   valueFormattedColumns?: Maybe<Array<Maybe<ValueFormattedColumn>>>;
+  /** Number of rows in the whole result set, useful when paginating through results */
+  totalRowCount?: Maybe<Scalars['Int']>;
 };
 
 /** Value formats to be applied to columns, like percent or dollar. */
@@ -569,9 +572,9 @@ export type SingleConstraint = {
   __typename?: 'SingleConstraint';
   constraintType?: Maybe<AtomicConstraintType>;
   dimensionName?: Maybe<Scalars['String']>;
-  values?: Maybe<Array<Maybe<Scalars['String']>>>;
-  start?: Maybe<Scalars['String']>;
-  stop?: Maybe<Scalars['String']>;
+  values?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
+  start?: Maybe<Scalars['GenericScalar']>;
+  stop?: Maybe<Scalars['GenericScalar']>;
 };
 
 /** Current possible values for constraints */
@@ -658,7 +661,7 @@ export enum QueryType {
 /** GQL class for DimensionValuesQueryResult. */
 export type DimensionValuesQueryResult = {
   __typename?: 'DimensionValuesQueryResult';
-  values?: Maybe<Array<Maybe<Scalars['String']>>>;
+  values?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
   totalValues?: Maybe<Scalars['Int']>;
 };
 
@@ -687,7 +690,7 @@ export type Metric = {
   constraint?: Maybe<Scalars['String']>;
   dimensions?: Maybe<Array<Scalars['String']>>;
   dimensionObjects?: Maybe<Array<Dimension>>;
-  dimensionValues?: Maybe<Array<Maybe<Scalars['String']>>>;
+  dimensionValues?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
   totalDimensionValues?: Maybe<Scalars['Int']>;
   maxGranularity?: Maybe<TimeGranularity>;
   newDataIsAvailable?: Maybe<Scalars['Boolean']>;
@@ -758,7 +761,7 @@ export type Dimension = {
   type?: Maybe<DimensionTypeForDescription>;
   isPrimaryTime?: Maybe<Scalars['Boolean']>;
   timeGranularity?: Maybe<TimeGranularity>;
-  values?: Maybe<Array<Scalars['String']>>;
+  values?: Maybe<Array<Scalars['GenericScalar']>>;
   cardinality?: Maybe<Scalars['Int']>;
 };
 
@@ -1119,19 +1122,19 @@ export type CreateMqlQueryInput = {
   clientMutationId?: Maybe<Scalars['String']>;
 };
 
-/** Container class for inputs to allow for and/or wrappers on the `where` clause */
+/** GQL container class for inputs to allow for and/or wrappers on the `where` clause */
 export type ConstraintInput = {
   And?: Maybe<Array<SingleConstraintInput>>;
   constraint?: Maybe<SingleConstraintInput>;
 };
 
-/** Actual `where` clauses to be applied */
+/** Input structure for GQL query constraints. */
 export type SingleConstraintInput = {
   constraintType?: Maybe<AtomicConstraintType>;
   dimensionName?: Maybe<Scalars['String']>;
-  values?: Maybe<Array<Maybe<Scalars['String']>>>;
-  start?: Maybe<Scalars['String']>;
-  stop?: Maybe<Scalars['String']>;
+  values?: Maybe<Array<Maybe<Scalars['GenericScalar']>>>;
+  start?: Maybe<Scalars['GenericScalar']>;
+  stop?: Maybe<Scalars['GenericScalar']>;
 };
 
 

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -90,8 +90,8 @@ type Organization {
   totalQuestions: Int
   totalAnnotations: Int
   metrics(names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime, searchStr: String, searchColumns: [OrgMetricStrColumns], orderBy: OrgMetricOrderBy, desc: Boolean, orderBys: [OrgMetricOrderByInput], pageNumber: Int, pageSize: Int): [OrgMetric]
-  totalOrgMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
-  totalMetrics(searchStr: String, searchColumns: [MetricVersionStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
+  totalOrgMetrics(searchStr: String, searchColumns: [OrgMetricStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
+  totalMetrics(searchStr: String, searchColumns: [OrgMetricStrColumns], names: [String], tiers: [MetricTier], tags: [Int], types: [MetricType], modelId: Int, userIsSubscribed: Boolean, ownedByTeamIds: [Int], ownedByUserIds: [Int], createdAtOrBefore: DateTime, createdAtOrAfter: DateTime): Int
   supportedMetricFilters: [MetricFilter]
   latestMqlHeartbeat: MqlHeartbeat
   totalUsers(activeOnly: Boolean, searchStr: String, searchColumns: [UserStrColumns]): Int
@@ -194,6 +194,8 @@ type User {
   boardsV2(searchStr: String, searchColumns: [BoardStrColumns], orderBy: BoardOrderBy, desc: Boolean, orderBys: [BoardOrderByInput], pageNumber: Int, pageSize: Int): [Board]
   favoriteBoards(searchStr: String, searchColumns: [BoardStrColumns], orderBy: BoardOrderBy, desc: Boolean, orderBys: [BoardOrderByInput], pageNumber: Int, pageSize: Int): [Board]
   totalFavoriteBoards(searchStr: String, searchColumns: [BoardStrColumns], excludeNotViewed: Boolean): Int
+  favoriteFilteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], orderBy: BoardFilteredViewOrderBy, desc: Boolean, orderBys: [BoardFilteredViewOrderByInput], pageNumber: Int, pageSize: Int): [BoardFilteredView]
+  totalFavoriteFilteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], excludeNotViewed: Boolean): Int
   totalBoardsV2(searchStr: String, searchColumns: [BoardStrColumns], excludeNotViewed: Boolean): Int
   boardsWithSubscribedMetricsV2(searchStr: String, searchColumns: [BoardStrColumns], orderBy: BoardOrderBy, desc: Boolean, orderBys: [BoardOrderByInput], pageNumber: Int, pageSize: Int): [Board]
   totalBoardsWithSubscribedMetricsV2(searchStr: String, searchColumns: [BoardStrColumns], excludeNotViewed: Boolean): Int
@@ -1134,7 +1136,7 @@ type Board {
   totalViews: Int
   myViews: Int
   totalFavorites: Int
-  isFavoritedByUser: Boolean
+  isFavoritedByUser(userId: Int): Boolean
   lastWeekViews: Int
   filteredViews(mineOnly: Boolean, searchStr: String, searchColumns: [BoardFilteredViewStrColumns], orderBy: BoardFilteredViewOrderBy, desc: Boolean, orderBys: [BoardFilteredViewOrderByInput], pageNumber: Int, pageSize: Int): [BoardFilteredView]
   totalFilteredViews(searchStr: String, searchColumns: [BoardFilteredViewStrColumns], excludeNotViewed: Boolean, mineOnly: Boolean): Int
@@ -1209,10 +1211,11 @@ type BoardFilteredView {
   creator: User
   where: Constraint
   userCanEditContent: Boolean
+  userCanDeactivate: Boolean
   userHasAccess: Boolean
-  userCanDelete: Boolean
   totalViews: Int
   myViews: Int
+  isFavoritedByUser(userId: Int): Boolean
 }
 
 """Represents a where constraint used in a query."""
@@ -1225,9 +1228,9 @@ type Constraint {
 type SingleConstraint {
   constraintType: AtomicConstraintType
   dimensionName: String
-  values: [String]
-  start: String
-  stop: String
+  values: [GenericScalar]
+  start: GenericScalar
+  stop: GenericScalar
 }
 
 """Current possible values for constraints"""
@@ -1253,6 +1256,7 @@ enum BoardFilteredViewOrderBy {
   CREATED_BY
   DESCRIPTION
   END_TIME
+  FAVORITES
   ID
   IS_PRIVATE
   LATEST_X_DAYS
@@ -1409,6 +1413,7 @@ enum MqlQueryStatus {
   FAILED
   UNHANDLED_EXCEPTION
   UNKNOWN
+  KILLED
 }
 
 """
@@ -1749,19 +1754,6 @@ enum ModelOrderBy {
 input ModelOrderByInput {
   orderBy: ModelOrderBy!
   desc: Boolean
-}
-
-"""An enumeration."""
-enum MetricVersionStrColumns {
-  DESCRIPTION
-  DISPLAY_NAME
-  HASH
-  METRIC_TYPE_STR
-  MetricMetadata__DESCRIPTION
-  MetricMetadata__DISPLAY_NAME
-  MetricMetadata__UNIT
-  MetricMetadata__VALUE_FORMAT
-  OrgMetric__NAME
 }
 
 """Filters supported for metric search."""
@@ -2182,6 +2174,8 @@ type Mutation {
   boardsFilteredViewDelete(filteredViewId: Int!): BoardFilteredView
   boardsFilteredViewChangeVisability(filteredViewId: Int!, isPrivate: Boolean!): BoardFilteredView
   boardsFilteredViewLogView(filteredViewId: Int!): BoardFilteredViewView
+  boardsFilteredViewFavorite(filteredViewId: ID!): BoardFilteredView
+  boardsFilteredViewUnfavorite(filteredViewId: ID!): BoardFilteredView
   testSlackMessage(message: String!, fromUsername: String, fromImgUrl: String): String
   sendSlackMessages(message: String!, channelNames: [String]!, fromUsername: String, fromImgUrl: String): String
 }
@@ -2416,20 +2410,20 @@ input MetricQueryInput {
 }
 
 """
-Container class for inputs to allow for and/or wrappers on the `where` clause
+GQL container class for inputs to allow for and/or wrappers on the `where` clause
 """
 input ConstraintInput {
   And: [SingleConstraintInput!]
   constraint: SingleConstraintInput
 }
 
-"""Actual `where` clauses to be applied"""
+"""Input structure for GQL query constraints."""
 input SingleConstraintInput {
   constraintType: AtomicConstraintType
   dimensionName: String
-  values: [String]
-  start: String
-  stop: String
+  values: [GenericScalar]
+  start: GenericScalar
+  stop: GenericScalar
 }
 
 enum PercentChange {

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -78,7 +78,7 @@ type MqlQuery {
   """
   The Tabular Results are Base 64-encoded JSON of a subset of rows from the query results Data Frame.
   """
-  resultTabular(cursor: Int, orient: PandasJsonOrient, paginate: Boolean, gzip: Boolean = false, encodingType: String = "base64", paginateSize: Boolean): MqlQueryTabularResult
+  resultTabular(cursor: Int, orient: PandasJsonOrient, paginate: Boolean, gzip: Boolean = false, encodingType: String = "base64", paginateSize: Int): MqlQueryTabularResult
   totalResultRows: Int
 
   """
@@ -144,6 +144,7 @@ enum MqlQueryStatus {
   FAILED
   UNHANDLED_EXCEPTION
   UNKNOWN
+  KILLED
 }
 
 """This is the canonical shape for chart-ready data."""
@@ -192,6 +193,11 @@ type MqlQueryTabularResult {
   Columns that have a value format associated with them. Used for displaying table view in the UI.
   """
   valueFormattedColumns: [ValueFormattedColumn]
+
+  """
+  Number of rows in the whole result set, useful when paginating through results
+  """
+  totalRowCount: Int
 }
 
 """Value formats to be applied to columns, like percent or dollar."""
@@ -267,9 +273,9 @@ type Constraint {
 type SingleConstraint {
   constraintType: AtomicConstraintType
   dimensionName: String
-  values: [String]
-  start: String
-  stop: String
+  values: [GenericScalar]
+  start: GenericScalar
+  stop: GenericScalar
 }
 
 """Current possible values for constraints"""
@@ -360,7 +366,7 @@ enum QueryType {
 
 """GQL class for DimensionValuesQueryResult."""
 type DimensionValuesQueryResult {
-  values: [String]
+  values: [GenericScalar]
   totalValues: Int
 }
 
@@ -387,7 +393,7 @@ type Metric {
   constraint: String
   dimensions: [String!]
   dimensionObjects(modelKey: ModelKeyInput): [Dimension!]
-  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int, searchStr: String, ignoreInvalidDimensions: Boolean): [String]
+  dimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, pageNumber: Int, pageSize: Int, searchStr: String, ignoreInvalidDimensions: Boolean): [GenericScalar]
   totalDimensionValues(modelKey: ModelKeyInput, dimensionName: String!, startTime: String, endTime: String, allowDynamicCache: Boolean, searchStr: String, ignoreInvalidDimensions: Boolean): Int
   maxGranularity(modelKey: ModelKeyInput): TimeGranularity
   newDataIsAvailable(afterDatetime: DateTime!, modelKey: ModelKeyInput): Boolean
@@ -413,7 +419,7 @@ type Dimension {
   type: DimensionTypeForDescription
   isPrimaryTime: Boolean
   timeGranularity: TimeGranularity
-  values: [String!]
+  values: [GenericScalar!]
   cardinality: Int
 }
 
@@ -710,20 +716,20 @@ input CreateMqlQueryInput {
 }
 
 """
-Container class for inputs to allow for and/or wrappers on the `where` clause
+GQL container class for inputs to allow for and/or wrappers on the `where` clause
 """
 input ConstraintInput {
   And: [SingleConstraintInput!]
   constraint: SingleConstraintInput
 }
 
-"""Actual `where` clauses to be applied"""
+"""Input structure for GQL query constraints."""
 input SingleConstraintInput {
   constraintType: AtomicConstraintType
   dimensionName: String
-  values: [String]
-  start: String
-  stop: String
+  values: [GenericScalar]
+  start: GenericScalar
+  stop: GenericScalar
 }
 
 """


### PR DESCRIPTION
# Changes
* Explicitly bypasses the cache when `doRefetchMqlQuery === true`  when creating a time series MQL Query
* Introduces a "bulk" version of the metric cache-invalidation mutation

# Security Implications
* "None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
