### PR TITLE
[MQL Refetch] Ensure proper cacheMode is actually passed

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -79,7 +79,7 @@ export default function useTimeSeriesMqlQuery({
       retries,
       doRefetchMqlQuery,
     }),
-    [metricName, queryInput, dispatch, retries]
+    [metricName, queryInput, dispatch, retries, doRefetchMqlQuery]
   );
 
   const useCreateTimeSeriesMqlQueryArgsMultiple = useMemo(
@@ -90,7 +90,7 @@ export default function useTimeSeriesMqlQuery({
       retries,
       doRefetchMqlQuery,
     }),
-    [metricNames, queryInput, dispatch, retries]
+    [metricNames, queryInput, dispatch, retries, doRefetchMqlQuery]
   );
 
   const { createTimeSeriesMqlQuery } = useCreateTimeSeriesMqlQuery(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
* I forgot to include `doRefetchMqlQuery` in a couple `useMemo` arrays, so it wasn't "sticking" for the new create MQL Query mutation. 🤦‍♂️ 

# Security Implications
* "None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
