### PR TITLE
[MQL Refetch] Explicitly ignore cache

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -22,6 +22,7 @@ interface CommonMqlQueryParams {
   skip?: boolean;
   retries?: number;
   doRefetchMqlQuery?: boolean;
+  ignoreCache?: boolean;
 }
 
 interface SingleMetricMqlQueryParams extends CommonMqlQueryParams {
@@ -60,6 +61,7 @@ export default function useTimeSeriesMqlQuery({
   skip,
   retries = 5,
   doRefetchMqlQuery,
+  ignoreCache,
 }: UseMqlQueryParams) {
   const { mqlServerUrl } = useContext(MqlContext);
   const dataAccr = (data: CreateMqlQueryMutation) =>
@@ -77,9 +79,9 @@ export default function useTimeSeriesMqlQuery({
       formState: queryInput,
       dispatch,
       retries,
-      doRefetchMqlQuery,
+      ignoreCache,
     }),
-    [metricName, queryInput, dispatch, retries, doRefetchMqlQuery]
+    [metricName, queryInput, dispatch, retries, ignoreCache]
   );
 
   const useCreateTimeSeriesMqlQueryArgsMultiple = useMemo(
@@ -88,9 +90,9 @@ export default function useTimeSeriesMqlQuery({
       formState: queryInput,
       dispatch,
       retries,
-      doRefetchMqlQuery,
+      ignoreCache,
     }),
-    [metricNames, queryInput, dispatch, retries, doRefetchMqlQuery]
+    [metricNames, queryInput, dispatch, retries, ignoreCache]
   );
 
   const { createTimeSeriesMqlQuery } = useCreateTimeSeriesMqlQuery(

--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -27,7 +27,7 @@ interface CommonUseCreateMqlQueryArgs {
   dispatch: Dispatch<
     UseMqlQueryAction<CreateMqlQueryMutation, FetchMqlTimeSeriesQuery>
   >;
-  doRefetchMqlQuery?: boolean;
+  ignoreCache?: boolean;
 }
 
 export interface SingleMetricUserCreateMqlQueryArgs
@@ -55,7 +55,7 @@ const useCreateTimeSeriesMqlQuery = ({
   formState = {},
   dispatch,
   retries,
-  doRefetchMqlQuery,
+  ignoreCache,
 }: UseCreateMqlQueryArgs): UseCreateMqlQuery => {
   const { useMutation, handleCombinedError } = useContext(MqlContext);
 
@@ -73,7 +73,7 @@ const useCreateTimeSeriesMqlQuery = ({
     createMqlQueryMutation({
       addTimeSeries: true,
       attemptNum: stateRetries,
-      cacheMode: doRefetchMqlQuery ? CacheMode.Ignore : undefined,
+      cacheMode: ignoreCache ? CacheMode.Ignore : undefined,
       daysLimit: formState.daysLimit,
       endTime: formState.latestXDays ? null : formState.endTime,
       groupBy: formState.groupBy || [],

--- a/mutations/mql/MqlMutationTypes.ts
+++ b/mutations/mql/MqlMutationTypes.ts
@@ -696,6 +696,7 @@ export type Metric = {
   newDataIsAvailable?: Maybe<Scalars['Boolean']>;
   canLimitDimensionValues?: Maybe<Scalars['Boolean']>;
   valueFormat?: Maybe<Scalars['String']>;
+  queryingRequiresTimeDim?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -750,6 +751,7 @@ export type MetricTypeParams = {
   denominator?: Maybe<Scalars['String']>;
   expr?: Maybe<Scalars['String']>;
   window?: Maybe<Scalars['String']>;
+  grainToDate?: Maybe<TimeGranularity>;
 };
 
 export type Dimension = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/mql/MqlQueryTypes.ts
+++ b/queries/mql/MqlQueryTypes.ts
@@ -696,6 +696,7 @@ export type Metric = {
   newDataIsAvailable?: Maybe<Scalars['Boolean']>;
   canLimitDimensionValues?: Maybe<Scalars['Boolean']>;
   valueFormat?: Maybe<Scalars['String']>;
+  queryingRequiresTimeDim?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -750,6 +751,7 @@ export type MetricTypeParams = {
   denominator?: Maybe<Scalars['String']>;
   expr?: Maybe<Scalars['String']>;
   window?: Maybe<Scalars['String']>;
+  grainToDate?: Maybe<TimeGranularity>;
 };
 
 export type Dimension = {

--- a/schemas/mql/mql.graphql
+++ b/schemas/mql/mql.graphql
@@ -399,6 +399,7 @@ type Metric {
   newDataIsAvailable(afterDatetime: DateTime!, modelKey: ModelKeyInput): Boolean
   canLimitDimensionValues(modelKey: ModelKeyInput): Boolean
   valueFormat: String
+  queryingRequiresTimeDim: Boolean
 }
 
 """
@@ -409,6 +410,7 @@ type MetricTypeParams {
   denominator: String
   expr: String
   window: String
+  grainToDate: TimeGranularity
 }
 
 type Dimension {


### PR DESCRIPTION
# Changes
* Using `doRefetchMqlQuery` to tell Create MQL Query to ignore the cache was proving unreliable. This adds a new parameter to explicitly tell it to ignore the cache.

# Security Implications
* "None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
