### PR TITLE
[Refetch MQL Query] Fix logic and accidental double-create

### DIFF
--- a/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
+++ b/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
@@ -1,10 +1,7 @@
-import { useEffect, useReducer, useContext } from "react";
+import { useEffect, useReducer, useContext, useMemo } from "react";
 // import { CombinedError } from "urql";
 import MqlContext from "../../context/MqlContext/MqlContext";
-import {
-  CreateMqlQueryFromDbIdMutation,
-  CreateMqlQueryFromDbIdMutationVariables,
-} from "../../mutations/mql/MqlMutationTypes";
+import { CreateMqlQueryFromDbIdMutation } from "../../mutations/mql/MqlMutationTypes";
 import {
   FetchMqlTimeSeriesQuery,
 } from "../../queries/mql/MqlQueryTypes";
@@ -30,7 +27,7 @@ export type UseMqlQueryFromDbIdParams = {
   // queryInput?: Omit<CreateMqlQueryFromDbIdMutationVariables, 'attemptNum'>;
   skip?: boolean;
   retries?: number;
-  doRefetchMqlQuery?: boolean;
+  refetchMqlQueryAttempt?: boolean;
 };
 
 export type UseMqlQueryFromDbIdQuery = UseMqlQueryState<FetchMqlTimeSeriesQuery>
@@ -43,13 +40,17 @@ export default function useMqlQueryFromDbId({
   mqlQueryId,
   skip,
   retries = 5,
-  doRefetchMqlQuery,
+  refetchMqlQueryAttempt,
 }: UseMqlQueryFromDbIdParams) {
   const {
     mqlServerUrl,
   } = useContext(MqlContext);
   const dataAccr = (data: CreateMqlQueryFromDbIdMutation) => data?.createMqlQueryFromDbId?.query;
 
+  const doRefetchMqlQuery = useMemo(
+    () => Boolean(refetchMqlQueryAttempt),
+    [refetchMqlQueryAttempt]
+  );
   const reducer = mqlQueryReducer<CreateMqlQueryFromDbIdMutation, FetchMqlTimeSeriesQuery>(dataAccr);
   const [state, dispatch] = useReducer(reducer, initialState);
   const {createMqlQueryFromDbId} = useCreateMqlQueryFromDbId({mqlQueryId, dispatch, retries})

--- a/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
+++ b/hooks/useMqlQueryFromDbId/useMqlQueryFromDbId.ts
@@ -27,7 +27,7 @@ export type UseMqlQueryFromDbIdParams = {
   // queryInput?: Omit<CreateMqlQueryFromDbIdMutationVariables, 'attemptNum'>;
   skip?: boolean;
   retries?: number;
-  refetchMqlQueryAttempt?: boolean;
+  refetchMqlQueryAttempt?: number;
 };
 
 export type UseMqlQueryFromDbIdQuery = UseMqlQueryState<FetchMqlTimeSeriesQuery>

--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -21,8 +21,7 @@ interface CommonMqlQueryParams {
   queryInput?: Omit<CreateMqlQueryMutationVariables, 'attemptNum'>;
   skip?: boolean;
   retries?: number;
-  doRefetchMqlQuery?: boolean;
-  ignoreCache?: boolean;
+  refetchMqlQueryAttempt?: number;
 }
 
 interface SingleMetricMqlQueryParams extends CommonMqlQueryParams {
@@ -60,12 +59,16 @@ export default function useTimeSeriesMqlQuery({
   metricNames,
   skip,
   retries = 5,
-  doRefetchMqlQuery,
-  ignoreCache,
+  refetchMqlQueryAttempt,
 }: UseMqlQueryParams) {
   const { mqlServerUrl } = useContext(MqlContext);
   const dataAccr = (data: CreateMqlQueryMutation) =>
     data?.createMqlQuery?.query;
+
+  const doRefetchMqlQuery = useMemo(
+    () => Boolean(refetchMqlQueryAttempt),
+    [refetchMqlQueryAttempt]
+  );
 
   const reducer = mqlQueryReducer<
     CreateMqlQueryMutation,
@@ -79,9 +82,9 @@ export default function useTimeSeriesMqlQuery({
       formState: queryInput,
       dispatch,
       retries,
-      ignoreCache,
+      ignoreCache: doRefetchMqlQuery,
     }),
-    [metricName, queryInput, dispatch, retries, ignoreCache]
+    [metricName, queryInput, dispatch, retries, doRefetchMqlQuery]
   );
 
   const useCreateTimeSeriesMqlQueryArgsMultiple = useMemo(
@@ -90,9 +93,9 @@ export default function useTimeSeriesMqlQuery({
       formState: queryInput,
       dispatch,
       retries,
-      ignoreCache,
+      ignoreCache: doRefetchMqlQuery,
     }),
-    [metricNames, queryInput, dispatch, retries, ignoreCache]
+    [metricNames, queryInput, dispatch, retries, doRefetchMqlQuery]
   );
 
   const { createTimeSeriesMqlQuery } = useCreateTimeSeriesMqlQuery(

--- a/hooks/utils/useFetchMqlQuery.ts
+++ b/hooks/utils/useFetchMqlQuery.ts
@@ -43,7 +43,7 @@ const useFetchMqlQuery = <CreateQueryDataType, FetchDataType extends {mqlQuery?:
   >({
     query: fetchDataQuery, //FetchMqlQueryTimeSeries,
     variables: {
-      queryId: doRefetchMqlQuery ? "" : state.queryId || "",
+      queryId: state.queryId || "",
       attemptNum: retries
     },
     pause: skip,

--- a/mutations/core/CoreApiMutationTypes.ts
+++ b/mutations/core/CoreApiMutationTypes.ts
@@ -264,6 +264,7 @@ export type Organization = {
   samlConnectionId?: Maybe<Scalars['String']>;
   samlSignatureCert?: Maybe<Scalars['String']>;
   integrationConfigurationTableau?: Maybe<IntegrationConfigurationTableau>;
+  integrationConfigurationDbtCloud?: Maybe<IntegrationConfigurationDbtCloud>;
   dbUtcTimezoneOffsetHours?: Maybe<Scalars['Int']>;
   dbArrearsHours?: Maybe<Scalars['Int']>;
   allIntegrations?: Maybe<Array<Maybe<Integration>>>;
@@ -2813,6 +2814,19 @@ export type IntegrationConfigurationTableau = {
   organization?: Maybe<Organization>;
 };
 
+export type IntegrationConfigurationDbtCloud = {
+  __typename?: 'IntegrationConfigurationDbtCloud';
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  accountId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']>;
+  jobId?: Maybe<Scalars['String']>;
+  isFullyConfigured?: Maybe<Scalars['String']>;
+  organization?: Maybe<Organization>;
+};
+
 export type Integration = {
   __typename?: 'Integration';
   id: Scalars['ID'];
@@ -3020,7 +3034,8 @@ export type AlertRuleDefinitionParameter = {
 
 /** Supported parameter types for an alert rule config */
 export enum ParameterType {
-  Number = 'NUMBER',
+  Float = 'FLOAT',
+  Int = 'INT',
   String = 'STRING',
   Bool = 'BOOL',
   Enum = 'ENUM'
@@ -3038,6 +3053,7 @@ export type Mutation = {
   createOrganizationTest?: Maybe<Organization>;
   setOrgMqlServerConfigSecret?: Maybe<SetOrgMqlServerConfigSecretId>;
   setIntegrationConfigurationTableau?: Maybe<SetIntegrationConfigurationTableau>;
+  setIntegrationConfigurationDbtCloud?: Maybe<SetIntegrationConfigurationDbtCloud>;
   removeIntegrationConfigurationTableau?: Maybe<RemoveIntegrationConfigurationTableau>;
   sendMqlHeartbeat?: Maybe<SendMqlHeartbeat>;
   createAnnotationTest?: Maybe<CreateAnnotation>;
@@ -3242,6 +3258,17 @@ export type MutationSetOrgMqlServerConfigSecretArgs = {
  */
 export type MutationSetIntegrationConfigurationTableauArgs = {
   configuration?: Maybe<GIntegrationConfigurationTableauInput>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationSetIntegrationConfigurationDbtCloudArgs = {
+  configuration?: Maybe<GIntegrationConfigurationDbtCloudInput>;
 };
 
 
@@ -4955,6 +4982,21 @@ export type GIntegrationConfigurationTableauInput = {
   site?: Maybe<Scalars['String']>;
   useServerVersion: Scalars['Boolean'];
   serverAddress: Scalars['String'];
+};
+
+export type SetIntegrationConfigurationDbtCloud = {
+  __typename?: 'SetIntegrationConfigurationDbtCloud';
+  accountId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']>;
+  jobId?: Maybe<Scalars['String']>;
+  isFullyConfigured?: Maybe<Scalars['Boolean']>;
+};
+
+export type GIntegrationConfigurationDbtCloudInput = {
+  secretAccessToken?: Maybe<Scalars['String']>;
+  accountId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']>;
+  jobId?: Maybe<Scalars['String']>;
 };
 
 export type RemoveIntegrationConfigurationTableau = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.42.2",
+  "version": "1.43.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/core/CoreApiQueryTypes.ts
+++ b/queries/core/CoreApiQueryTypes.ts
@@ -264,6 +264,7 @@ export type Organization = {
   samlConnectionId?: Maybe<Scalars['String']>;
   samlSignatureCert?: Maybe<Scalars['String']>;
   integrationConfigurationTableau?: Maybe<IntegrationConfigurationTableau>;
+  integrationConfigurationDbtCloud?: Maybe<IntegrationConfigurationDbtCloud>;
   dbUtcTimezoneOffsetHours?: Maybe<Scalars['Int']>;
   dbArrearsHours?: Maybe<Scalars['Int']>;
   allIntegrations?: Maybe<Array<Maybe<Integration>>>;
@@ -2813,6 +2814,19 @@ export type IntegrationConfigurationTableau = {
   organization?: Maybe<Organization>;
 };
 
+export type IntegrationConfigurationDbtCloud = {
+  __typename?: 'IntegrationConfigurationDbtCloud';
+  id: Scalars['ID'];
+  createdAt: Scalars['DateTime'];
+  updatedAt: Scalars['DateTime'];
+  deletedAt?: Maybe<Scalars['DateTime']>;
+  accountId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']>;
+  jobId?: Maybe<Scalars['String']>;
+  isFullyConfigured?: Maybe<Scalars['String']>;
+  organization?: Maybe<Organization>;
+};
+
 export type Integration = {
   __typename?: 'Integration';
   id: Scalars['ID'];
@@ -3020,7 +3034,8 @@ export type AlertRuleDefinitionParameter = {
 
 /** Supported parameter types for an alert rule config */
 export enum ParameterType {
-  Number = 'NUMBER',
+  Float = 'FLOAT',
+  Int = 'INT',
   String = 'STRING',
   Bool = 'BOOL',
   Enum = 'ENUM'
@@ -3038,6 +3053,7 @@ export type Mutation = {
   createOrganizationTest?: Maybe<Organization>;
   setOrgMqlServerConfigSecret?: Maybe<SetOrgMqlServerConfigSecretId>;
   setIntegrationConfigurationTableau?: Maybe<SetIntegrationConfigurationTableau>;
+  setIntegrationConfigurationDbtCloud?: Maybe<SetIntegrationConfigurationDbtCloud>;
   removeIntegrationConfigurationTableau?: Maybe<RemoveIntegrationConfigurationTableau>;
   sendMqlHeartbeat?: Maybe<SendMqlHeartbeat>;
   createAnnotationTest?: Maybe<CreateAnnotation>;
@@ -3242,6 +3258,17 @@ export type MutationSetOrgMqlServerConfigSecretArgs = {
  */
 export type MutationSetIntegrationConfigurationTableauArgs = {
   configuration?: Maybe<GIntegrationConfigurationTableauInput>;
+};
+
+
+/**
+ * Base mutation object exposed by GraphQL.
+ *
+ * Mutation names will be converted from snake_case to camelCase automatically
+ * (e.g., log_mql_log will show up as logMqlLog in the GQL schema).
+ */
+export type MutationSetIntegrationConfigurationDbtCloudArgs = {
+  configuration?: Maybe<GIntegrationConfigurationDbtCloudInput>;
 };
 
 
@@ -4955,6 +4982,21 @@ export type GIntegrationConfigurationTableauInput = {
   site?: Maybe<Scalars['String']>;
   useServerVersion: Scalars['Boolean'];
   serverAddress: Scalars['String'];
+};
+
+export type SetIntegrationConfigurationDbtCloud = {
+  __typename?: 'SetIntegrationConfigurationDbtCloud';
+  accountId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']>;
+  jobId?: Maybe<Scalars['String']>;
+  isFullyConfigured?: Maybe<Scalars['Boolean']>;
+};
+
+export type GIntegrationConfigurationDbtCloudInput = {
+  secretAccessToken?: Maybe<Scalars['String']>;
+  accountId?: Maybe<Scalars['String']>;
+  projectId?: Maybe<Scalars['String']>;
+  jobId?: Maybe<Scalars['String']>;
 };
 
 export type RemoveIntegrationConfigurationTableau = {

--- a/schemas/core/core.graphql
+++ b/schemas/core/core.graphql
@@ -123,6 +123,7 @@ type Organization {
   samlConnectionId: String
   samlSignatureCert: String
   integrationConfigurationTableau: IntegrationConfigurationTableau
+  integrationConfigurationDbtCloud: IntegrationConfigurationDbtCloud
   dbUtcTimezoneOffsetHours: Int
   dbArrearsHours: Int
   allIntegrations(searchStr: String, searchColumns: [IntegrationStrColumns], orderBy: IntegrationOrderBy, desc: Boolean, orderBys: [IntegrationOrderByInput], pageNumber: Int, pageSize: Int): [Integration]
@@ -1787,6 +1788,18 @@ type IntegrationConfigurationTableau {
   organization: Organization
 }
 
+type IntegrationConfigurationDbtCloud {
+  id: ID!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  deletedAt: DateTime
+  accountId: String
+  projectId: String
+  jobId: String
+  isFullyConfigured: String
+  organization: Organization
+}
+
 type Integration {
   id: ID!
   organizationId: Int!
@@ -1992,7 +2005,8 @@ type AlertRuleDefinitionParameter {
 
 """Supported parameter types for an alert rule config"""
 enum ParameterType {
-  NUMBER
+  FLOAT
+  INT
   STRING
   BOOL
   ENUM
@@ -2009,6 +2023,7 @@ type Mutation {
   createOrganizationTest(name: String!, primaryConfigRepo: String, primaryConfigBranch: String, mqlServerUrl: String, sourceControlUrl: String, mqlServerLogs: String, isHosted: Boolean, dwEngine: String, mqlServerName: String, requireMfa: Boolean, allowMfaRememberBrowser: Boolean, allowedEmailDomains: [String], orgType: GOrgType): Organization
   setOrgMqlServerConfigSecret(clientConfigSecretId: String, mqlServerId: Int): SetOrgMqlServerConfigSecretId
   setIntegrationConfigurationTableau(configuration: GIntegrationConfigurationTableauInput): SetIntegrationConfigurationTableau
+  setIntegrationConfigurationDbtCloud(configuration: GIntegrationConfigurationDbtCloudInput): SetIntegrationConfigurationDbtCloud
   removeIntegrationConfigurationTableau: RemoveIntegrationConfigurationTableau
   sendMqlHeartbeat(mqlServerId: Int, sha: String!): SendMqlHeartbeat
   createAnnotationTest(dateEndedAt: Date!, dateStartedAt: Date!, expectedImpact: String!, metricInputs: [GMetricAnnotationInput]!, priority: Priority!, text: String!, title: String!): CreateAnnotation
@@ -2204,6 +2219,20 @@ input GIntegrationConfigurationTableauInput {
   site: String
   useServerVersion: Boolean!
   serverAddress: String!
+}
+
+type SetIntegrationConfigurationDbtCloud {
+  accountId: String
+  projectId: String
+  jobId: String
+  isFullyConfigured: Boolean
+}
+
+input GIntegrationConfigurationDbtCloudInput {
+  secretAccessToken: String
+  accountId: String
+  projectId: String
+  jobId: String
 }
 
 type RemoveIntegrationConfigurationTableau {


### PR DESCRIPTION
# Changes
* We were causing a double-createMqlQuery because of how we were triggering refetches -- by setting a boolean to true & then resetting it to false on success, so that we could flip it again for the next refetch.
* Now we are using a number, `refetchMqlQueryAttempt` to trigger refetches & converting it to a boolean within this package to determine whether it's safe to create the query from the cache.
* Because it's a number, we can safely keep incrementing it with each refetch call within our application & never need to reset the value until the component is re-rendered. This means we no longer have a double-create mutation.

# Security Implications
* "None"


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
