### PR TITLE
pass null for pctChange and timeComparison if empty string

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/useTimeSeriesMqlQuery.ts
@@ -72,18 +72,29 @@ export default function useTimeSeriesMqlQuery({
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const useCreateTimeSeriesMqlQueryArgs = useMemo(
-    (): SingleMetricUserCreateMqlQueryArgs | MultipleMetricsUserCreateMqlQueryArgs => ({
-      ...(metricName ? {
-        metricName: metricName as string,
-      } : {
-        metricNames: metricNames as string[],
-      }),
+    ():
+      | SingleMetricUserCreateMqlQueryArgs
+      | MultipleMetricsUserCreateMqlQueryArgs => ({
+      ...(metricName
+        ? {
+            metricName: metricName as string,
+          }
+        : {
+            metricNames: metricNames as string[],
+          }),
       formState: queryInput,
       dispatch,
       retries,
       refetchMqlQueryAttempt,
     }),
-    [metricName, metricNames, queryInput, dispatch, retries, refetchMqlQueryAttempt]
+    [
+      metricName,
+      metricNames,
+      queryInput,
+      dispatch,
+      retries,
+      refetchMqlQueryAttempt,
+    ]
   );
 
   const { createTimeSeriesMqlQuery } = useCreateTimeSeriesMqlQuery(
@@ -94,7 +105,10 @@ export default function useTimeSeriesMqlQuery({
     if ((!metricName && !metricNames) || !mqlServerUrl || skip) {
       return;
     }
-    dispatch({ type: 'postQueryStart', doRefetchMqlQuery: Boolean(refetchMqlQueryAttempt) });
+    dispatch({
+      type: 'postQueryStart',
+      doRefetchMqlQuery: Boolean(refetchMqlQueryAttempt),
+    });
     createTimeSeriesMqlQuery({ stateRetries: state.retries });
   }, [
     queryInput,

--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -83,9 +83,9 @@ const useCreateTimeSeriesMqlQuery = ({
       maxDimensionValues: formState.maxDimensionValues,
       metrics: metrics as string[],
       order: formState.order,
-      pctChange: formState.pctChange,
+      pctChange: formState.pctChange || null,
       startTime: formState.latestXDays ? null : formState.startTime,
-      timeGranularity: formState.timeGranularity,
+      timeGranularity: formState.timeGranularity || null,
       trimIncompletePeriods: formState.trimIncompletePeriods,
       where: clearEmptyConstraints(formState.where),
     }).then(({ data, error }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.43.1",
+  "version": "1.43.2",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Changes
Pass `null` instead of `""` for `pctChange` and `timeComparison`

# Security Implications
None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
