### PR TITLE
No Time Dimension

### DIFF
--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -72,7 +72,7 @@ const useCreateTimeSeriesMqlQuery = ({
   const createTimeSeriesMqlQuery = ({ stateRetries }: DoCreateMqlQueryArgs) => {
     createMqlQueryMutation({
       addTimeSeries:
-        formState?.addTimeSeries === undefined ? true : formState.addTimeSeries,
+        formState?.addTimeSeries !== false,
       attemptNum: stateRetries,
       cacheMode: refetchMqlQueryAttempt ? CacheMode.Ignore : undefined,
       daysLimit: formState.daysLimit,

--- a/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
+++ b/hooks/useTimeSeriesMqlQuery/utils/useCreateTimeSeriesMqlQuery.ts
@@ -71,7 +71,8 @@ const useCreateTimeSeriesMqlQuery = ({
 
   const createTimeSeriesMqlQuery = ({ stateRetries }: DoCreateMqlQueryArgs) => {
     createMqlQueryMutation({
-      addTimeSeries: true,
+      addTimeSeries:
+        formState?.addTimeSeries === undefined ? true : formState.addTimeSeries,
       attemptNum: stateRetries,
       cacheMode: doRefetchMqlQuery ? CacheMode.Ignore : undefined,
       daysLimit: formState.daysLimit,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transform-data/transform-react",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "React components and hooks for querying Transform's MQL Server",
   "repository": {
     "type": "git",

--- a/queries/mql/FetchMetricFilterRules.ts
+++ b/queries/mql/FetchMetricFilterRules.ts
@@ -1,10 +1,11 @@
-import { gql } from "urql";
+import { gql } from 'urql';
 
 const query = gql`
   query FetchMetricFilterRules($metricName: String!) {
     metricByName(name: $metricName) {
       canLimitDimensionValues
       maxGranularity
+      queryingRequiresTimeDim
     }
   }
 `;


### PR DESCRIPTION
# Changes
Add `queryingRequiresTimeDim` to `FetchMetricFilterRules` so we can know if a metric can have it's time dimension removed.

Allow `addTimeSeries` to be passed into `createMqlQuery`

# Security Implications
None


<!--
PR checklist – confirm the PR contains the following:

* documentation for any changes that are not self-evident
* if applicable, confirm that the UI still runs as expected
//-->
